### PR TITLE
golangci-lint: update rules to match core

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,11 @@ linters:
     - misspell
     - rowserrcheck
     - errorlint
+    - unconvert
+    - sqlclosecheck
+    - noctx
+    - whitespace
+    - depguard
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
@@ -26,7 +31,7 @@ linters-settings:
       # - G404
   govet:
     # report about shadowed variables
-    check-shadowing: false
+    check-shadowing: true
   errorlint:
     # Allow formatting of errors without %w
     errorf: false
@@ -40,9 +45,10 @@ linters-settings:
       - name: error-return
       - name: error-strings
       - name: error-naming
+      - name: exported
       - name: if-return
       - name: increment-decrement
-      # - name: var-naming
+      - name: var-naming
       - name: var-declaration
       - name: package-comments
       - name: range
@@ -61,20 +67,51 @@ linters-settings:
       - name: struct-tag
       # - name: string-format
       - name: string-of-int
-      # - name: range-val-address
+      - name: range-val-address
       - name: range-val-in-closure
       - name: modifies-value-receiver
       - name: modifies-parameter
       - name: identical-branches
       - name: get-return
       # - name: flag-parameter
-      # - name: early-return
+      - name: early-return
       - name: defer
       - name: constant-logical-expr
       # - name: confusing-naming
       # - name: confusing-results
       - name: bool-literal-in-expr
       - name: atomic
+  depguard:
+    rules:
+      main:
+        list-mode: lax
+        deny:
+          - pkg: "cosmossdk.io/errors"
+            desc: Use the standard library instead
+          - pkg: "github.com/ethereum/go-ethereum"
+            desc: This is a chain-agnostic repo
+          - pkg: "github.com/go-gorm/gorm"
+            desc: Use github.com/jmoiron/sqlx directly instead
+          - pkg: "github.com/gofrs/uuid"
+            desc: Use github.com/google/uuid instead
+          - pkg: "github.com/pkg/errors"
+            desc: Use the standard library instead, for example https://pkg.go.dev/errors#Join
+          - pkg: "github.com/satori/go.uuid"
+            desc: Use github.com/google/uuid instead
+          - pkg: "github.com/test-go/testify/assert"
+            desc: Use github.com/stretchr/testify/assert instead
+          - pkg: "github.com/test-go/testify/mock"
+            desc: Use github.com/stretchr/testify/mock instead
+          - pkg: "github.com/test-go/testify/require"
+            desc: Use github.com/stretchr/testify/require instead
+          - pkg: "go.uber.org/multierr"
+            desc: Use the standard library instead, for example https://pkg.go.dev/errors#Join
+          - pkg: "gopkg.in/guregu/null.v1"
+            desc: Use gopkg.in/guregu/null.v4 instead
+          - pkg: "gopkg.in/guregu/null.v2"
+            desc: Use gopkg.in/guregu/null.v4 instead
+          - pkg: "gopkg.in/guregu/null.v3"
+            desc: Use gopkg.in/guregu/null.v4 instead
 issues:
   exclude-rules:
     - path: test

--- a/mercury/fees.go
+++ b/mercury/fees.go
@@ -8,12 +8,12 @@ import (
 
 // PriceScalingFactor indicates the multiplier applied to token prices that we expect from data source
 // e.g. for a 1e8 multiplier, a LINK/USD value of 7.42 will be derived from a data source value of 742000000
-var PRICE_SCALING_FACTOR = decimal.NewFromInt(1e18) //nolint:revive
+var PriceScalingFactor = decimal.NewFromInt(1e18) //nolint:revive
 
 // FeeScalingFactor indicates the multiplier applied to fees.
 // e.g. for a 1e18 multiplier, a LINK fee of 7.42 will be represented as 7.42e18
 // This is what will be baked into the report for use on-chain.
-var FEE_SCALING_FACTOR = decimal.NewFromInt(1e18)
+var FeeScalingFactor = decimal.NewFromInt(1e18)
 
 // CalculateFee outputs a fee in wei according to the formula: baseUSDFee * scaleFactor / tokenPriceInUSD
 func CalculateFee(tokenPriceInUSD *big.Int, baseUSDFee decimal.Decimal) *big.Int {
@@ -23,7 +23,7 @@ func CalculateFee(tokenPriceInUSD *big.Int, baseUSDFee decimal.Decimal) *big.Int
 	}
 
 	// scale baseFee in USD
-	baseFeeScaled := baseUSDFee.Mul(PRICE_SCALING_FACTOR)
+	baseFeeScaled := baseUSDFee.Mul(PriceScalingFactor)
 
 	tokenPrice := decimal.NewFromBigInt(tokenPriceInUSD, 0)
 
@@ -31,7 +31,7 @@ func CalculateFee(tokenPriceInUSD *big.Int, baseUSDFee decimal.Decimal) *big.Int
 	fee := baseFeeScaled.Div(tokenPrice)
 
 	// scale fee to the expected format
-	fee = fee.Mul(FEE_SCALING_FACTOR)
+	fee = fee.Mul(FeeScalingFactor)
 
 	// convert to big.Int
 	return fee.BigInt()

--- a/mercury/onchain_config.go
+++ b/mercury/onchain_config.go
@@ -1,9 +1,8 @@
 package mercury
 
 import (
+	"fmt"
 	"math/big"
-
-	pkgerrors "github.com/pkg/errors"
 
 	"github.com/smartcontractkit/libocr/bigbigendian"
 
@@ -29,7 +28,7 @@ type StandardOnchainConfigCodec struct{}
 
 func (StandardOnchainConfigCodec) Decode(b []byte) (mercury.OnchainConfig, error) {
 	if len(b) != onchainConfigEncodedLength {
-		return mercury.OnchainConfig{}, pkgerrors.Errorf("unexpected length of OnchainConfig, expected %v, got %v", onchainConfigEncodedLength, len(b))
+		return mercury.OnchainConfig{}, fmt.Errorf("unexpected length of OnchainConfig, expected %v, got %v", onchainConfigEncodedLength, len(b))
 	}
 
 	v, err := bigbigendian.DeserializeSigned(32, b[:32])
@@ -37,7 +36,7 @@ func (StandardOnchainConfigCodec) Decode(b []byte) (mercury.OnchainConfig, error
 		return mercury.OnchainConfig{}, err
 	}
 	if v.Cmp(onchainConfigVersionBig) != 0 {
-		return mercury.OnchainConfig{}, pkgerrors.Errorf("unexpected version of OnchainConfig, expected %v, got %v", onchainConfigVersion, v)
+		return mercury.OnchainConfig{}, fmt.Errorf("unexpected version of OnchainConfig, expected %v, got %v", onchainConfigVersion, v)
 	}
 
 	min, err := bigbigendian.DeserializeSigned(32, b[32:64])
@@ -50,7 +49,7 @@ func (StandardOnchainConfigCodec) Decode(b []byte) (mercury.OnchainConfig, error
 	}
 
 	if !(min.Cmp(max) <= 0) {
-		return mercury.OnchainConfig{}, pkgerrors.Errorf("OnchainConfig min (%v) should not be greater than max(%v)", min, max)
+		return mercury.OnchainConfig{}, fmt.Errorf("OnchainConfig min (%v) should not be greater than max(%v)", min, max)
 	}
 
 	return mercury.OnchainConfig{Min: min, Max: max}, nil

--- a/mercury/onchain_config_test.go
+++ b/mercury/onchain_config_test.go
@@ -15,7 +15,7 @@ func FuzzDecodeOnchainConfig(f *testing.F) {
 	}
 
 	f.Add([]byte{})
-	f.Add([]byte(valid))
+	f.Add(valid)
 	f.Fuzz(func(t *testing.T, encoded []byte) {
 		decoded, err := StandardOnchainConfigCodec{}.Decode(encoded)
 		if err != nil {

--- a/mercury/v1/aggregate_functions.go
+++ b/mercury/v1/aggregate_functions.go
@@ -76,7 +76,6 @@ func GetConsensusLatestBlock(paos []PAO, f int) (hash []byte, num int64, ts uint
 			})
 
 			return usableBlocks[0].HashBytes(), usableBlocks[0].Num, usableBlocks[0].Ts, nil
-
 		}
 		// this grouping does not have any identical blocks with at least f+1 in agreement, try next block number down
 	}

--- a/mercury/v1/mercury_test.go
+++ b/mercury/v1/mercury_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	crand "crypto/rand"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -12,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -443,7 +443,6 @@ func Test_Plugin_Observation(t *testing.T) {
 		assert.True(t, p.CurrentBlockValid)
 		assert.True(t, p.MaxFinalizedBlockNumberValid)
 	})
-
 }
 
 func newAttributedObservation(t *testing.T, p *MercuryObservationProto) types.AttributedObservation {

--- a/mercury/v1/validation.go
+++ b/mercury/v1/validation.go
@@ -3,8 +3,6 @@ package v1
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	v1 "github.com/smartcontractkit/chainlink-common/pkg/types/mercury/v1"
 
 	"github.com/smartcontractkit/chainlink-data-streams/mercury"
@@ -23,7 +21,7 @@ func ValidateCurrentBlock(rf v1.ReportFields) error {
 	}
 	// NOTE: hardcoded ethereum hash
 	if len(rf.CurrentBlockHash) != mercury.EvmHashLen {
-		return errors.Errorf("invalid length for hash; expected %d (got: %d)", mercury.EvmHashLen, len(rf.CurrentBlockHash))
+		return fmt.Errorf("invalid length for hash; expected %d (got: %d)", mercury.EvmHashLen, len(rf.CurrentBlockHash))
 	}
 
 	return nil

--- a/mercury/v2/mercury_test.go
+++ b/mercury/v2/mercury_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"errors"
 	"math"
 	"math/big"
 	"math/rand"
@@ -9,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -272,7 +272,6 @@ func Test_Plugin_Report(t *testing.T) {
 				BenchmarkPrice:     big.NewInt(345),
 			}, *codec.builtReportFields)
 		})
-
 	})
 
 	t.Run("when previous report is present", func(t *testing.T) {
@@ -304,7 +303,6 @@ func Test_Plugin_Report(t *testing.T) {
 				ExpiresAt:          ts + 1,
 				BenchmarkPrice:     big.NewInt(345),
 			}, *codec.builtReportFields)
-
 		})
 		t.Run("errors if cannot extract timestamp from previous report", func(t *testing.T) {
 			codec.err = errors.New("something exploded trying to extract timestamp")

--- a/mercury/v3/mercury_test.go
+++ b/mercury/v3/mercury_test.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"context"
+	"errors"
 	"math"
 	"math/big"
 	"math/rand"
@@ -9,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -289,7 +289,6 @@ func Test_Plugin_Report(t *testing.T) {
 				Ask:                big.NewInt(350),
 			}, *codec.builtReportFields)
 		})
-
 	})
 
 	t.Run("when previous report is present", func(t *testing.T) {
@@ -323,7 +322,6 @@ func Test_Plugin_Report(t *testing.T) {
 				Bid:                big.NewInt(340),
 				Ask:                big.NewInt(350),
 			}, *codec.builtReportFields)
-
 		})
 		t.Run("errors if cannot extract timestamp from previous report", func(t *testing.T) {
 			codec.err = errors.New("something exploded trying to extract timestamp")

--- a/mercury/validation.go
+++ b/mercury/validation.go
@@ -3,8 +3,6 @@ package mercury
 import (
 	"fmt"
 	"math/big"
-
-	pkgerrors "github.com/pkg/errors"
 )
 
 // NOTE: hardcoded for now, this may need to change if we support block range on chains other than eth
@@ -16,7 +14,7 @@ func ValidateBetween(name string, answer *big.Int, min, max *big.Int) error {
 		return fmt.Errorf("%s: got nil value", name)
 	}
 	if !(min.Cmp(answer) <= 0 && answer.Cmp(max) <= 0) {
-		return pkgerrors.Errorf("%s (Value: %s) is outside of allowable range (Min: %s, Max: %s)", name, answer, min, max)
+		return fmt.Errorf("%s (Value: %s) is outside of allowable range (Min: %s, Max: %s)", name, answer, min, max)
 	}
 
 	return nil
@@ -24,7 +22,7 @@ func ValidateBetween(name string, answer *big.Int, min, max *big.Int) error {
 
 func ValidateValidFromTimestamp(observationTimestamp uint32, validFromTimestamp uint32) error {
 	if observationTimestamp < validFromTimestamp {
-		return pkgerrors.Errorf("observationTimestamp (Value: %d) must be >= validFromTimestamp (Value: %d)", observationTimestamp, validFromTimestamp)
+		return fmt.Errorf("observationTimestamp (Value: %d) must be >= validFromTimestamp (Value: %d)", observationTimestamp, validFromTimestamp)
 	}
 
 	return nil
@@ -32,7 +30,7 @@ func ValidateValidFromTimestamp(observationTimestamp uint32, validFromTimestamp 
 
 func ValidateExpiresAt(observationTimestamp uint32, expiresAt uint32) error {
 	if observationTimestamp > expiresAt {
-		return pkgerrors.Errorf("expiresAt (Value: %d) must be ahead of observation timestamp (Value: %d)", expiresAt, observationTimestamp)
+		return fmt.Errorf("expiresAt (Value: %d) must be ahead of observation timestamp (Value: %d)", expiresAt, observationTimestamp)
 	}
 
 	return nil


### PR DESCRIPTION
There are only five outstanding problems. Four of them are exported names, so I only fixed the other one.