### PR TITLE
chore: github action version bumps

### DIFF
--- a/.github/workflows/pull-request-master.yml
+++ b/.github/workflows/pull-request-master.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-sonarqube
-        uses: smartcontractkit/.github/actions/ci-sonarqube@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-sonarqube@0.3.1
+        uses: smartcontractkit/.github/actions/ci-sonarqube@5b1046c28343660ecb84844c6fa95a66d1cdb52e # ci-sonarqube@0.3.2
         with:
           # grafana inputs
           metrics-job-name: ci-sonarqube

--- a/.github/workflows/pull-request-master.yml
+++ b/.github/workflows/pull-request-master.yml
@@ -86,7 +86,7 @@ jobs:
       actions: read
     steps:
       - name: ci-test
-        uses: smartcontractkit/.github/actions/ci-test-go@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-test-go@0.1.1
+        uses: smartcontractkit/.github/actions/ci-test-go@f8efc6bb91480713ddd64eaabd63d4b97ae6f088 # ci-test-go@0.1.4
         with:
           # grafana inputs
           metrics-job-name: ci-test

--- a/.github/workflows/pull-request-master.yml
+++ b/.github/workflows/pull-request-master.yml
@@ -21,7 +21,7 @@ jobs:
       lint_args_packages: ${{ steps.set-matrix-packages.outputs.lint_args_packages }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0
       - name: Set matrix packages

--- a/.github/workflows/pull-request-master.yml
+++ b/.github/workflows/pull-request-master.yml
@@ -48,7 +48,7 @@ jobs:
       actions: read
     steps:
       - name: ci-lint
-        uses: smartcontractkit/.github/actions/ci-lint-go@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-lint-go@0.1.1
+        uses: smartcontractkit/.github/actions/ci-lint-go@7ac9af09dda8c553593d2153a975b43b6958fa9f # ci-lint-go@0.2.2
         with:
           # grafana inputs
           metrics-job-name: ci-lint

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-sonarqube
-        uses: smartcontractkit/.github/actions/ci-sonarqube@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-sonarqube@0.3.1
+        uses: smartcontractkit/.github/actions/ci-sonarqube@5b1046c28343660ecb84844c6fa95a66d1cdb52e # ci-sonarqube@0.3.2
         with:
           # grafana inputs
           metrics-job-name: ci-sonarqube

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -66,7 +66,7 @@ jobs:
       actions: read
     steps:
       - name: ci-test
-        uses: smartcontractkit/.github/actions/ci-test-go@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-test-go@0.1.1
+        uses: smartcontractkit/.github/actions/ci-test-go@f8efc6bb91480713ddd64eaabd63d4b97ae6f088 # ci-test-go@0.1.4
         with:
           # grafana inputs
           metrics-job-name: ci-test

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -115,7 +115,7 @@ jobs:
     steps:
       - name: cd-release
         id: cd-release
-        uses: smartcontractkit/.github/actions/cicd-changesets@c5b65fcfe12a5a14b60b03605748af0b0c6cfbea # cicd-changesets@0.2.0
+        uses: smartcontractkit/.github/actions/cicd-changesets@6da79c7b9f14bec077df2c1ad40d53823b409d9c # cicd-changesets@0.3.3
         with:
           # general inputs
           git-user: app-token-issuer-foundations[bot]

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -16,7 +16,7 @@ jobs:
       lint_args_packages: ${{ steps.set-matrix-packages.outputs.lint_args_packages }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Set matrix packages
         id: set-matrix-packages
         shell: bash

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -40,7 +40,7 @@ jobs:
       actions: read
     steps:
       - name: ci-lint
-        uses: smartcontractkit/.github/actions/ci-lint-go@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-lint-go@0.1.1
+        uses: smartcontractkit/.github/actions/ci-lint-go@7ac9af09dda8c553593d2153a975b43b6958fa9f # ci-lint-go@0.2.2
         with:
           # grafana inputs
           metrics-job-name: ci-lint


### PR DESCRIPTION
## What

Updating Github Action references in all workflows.

## Why

Github Actions node16 deprecation. See [blog post (github.blog)](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
> Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). As a result we have started the deprecation process of Node16 for GitHub Actions. We plan to migrate all actions to run on Node20 by Spring 2024.
> Following on from our [warning in workflows using Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) we will start enforcing the use of Node20 rather than Node16 on the 13th of May.

## Notes

RE-2531


Outdated Dependency Paths:

```
Workflow:pull-request-master ---> Job:ci-lint ---> smartcontractkit/.github/actions/ci-lint-go@6b08487b176ef7cad086526d0b54ddff6691c044 ---> cardinalby/export-env-action@04460b5708ae685cda6419c29deb8903ca2db74a ---> node16
Workflow:pull-request-master ---> Job:ci-lint ---> smartcontractkit/.github/actions/ci-lint-go@6b08487b176ef7cad086526d0b54ddff6691c044 ---> golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc ---> node16
Workflow:pull-request-master ---> Job:ci-lint ---> smartcontractkit/.github/actions/ci-lint-go@6b08487b176ef7cad086526d0b54ddff6691c044 ---> actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 ---> node16
Workflow:pull-request-master ---> Job:ci-sonarqube ---> smartcontractkit/.github/actions/ci-sonarqube@6b08487b176ef7cad086526d0b54ddff6691c044 ---> actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a ---> node16
``` 