### PR TITLE
Don't pass Outcome or Report by pointer

### DIFF
--- a/llo/plugin_outcome.go
+++ b/llo/plugin_outcome.go
@@ -297,7 +297,7 @@ func (p *Plugin) outcome(outctx ocr3types.OutcomeContext, query types.Query, aos
 	if p.Config.VerboseLogging {
 		p.Logger.Debugw("Generated outcome", "outcome", outcome, "stage", "Outcome", "seqNr", outctx.SeqNr)
 	}
-	p.captureOutcomeTelemetry(&outcome, &outctx)
+	p.captureOutcomeTelemetry(outcome, outctx)
 	return p.OutcomeCodec.Encode(outcome)
 }
 
@@ -518,7 +518,7 @@ func medianTimestamp(timestampsNanoseconds []uint64) uint64 {
 	return timestampsNanoseconds[len(timestampsNanoseconds)/2]
 }
 
-func (p *Plugin) captureOutcomeTelemetry(outcome *Outcome, outctx *ocr3types.OutcomeContext) {
+func (p *Plugin) captureOutcomeTelemetry(outcome Outcome, outctx ocr3types.OutcomeContext) {
 	if p.OutcomeTelemetryCh != nil {
 		ot, err := makeOutcomeTelemetry(outcome, p.ConfigDigest, outctx.SeqNr, p.DonID)
 		if err != nil {
@@ -533,7 +533,7 @@ func (p *Plugin) captureOutcomeTelemetry(outcome *Outcome, outctx *ocr3types.Out
 	}
 }
 
-func makeOutcomeTelemetry(outcome *Outcome, configDigest types.ConfigDigest, seqNr uint64, donID uint32) (*LLOOutcomeTelemetry, error) {
+func makeOutcomeTelemetry(outcome Outcome, configDigest types.ConfigDigest, seqNr uint64, donID uint32) (*LLOOutcomeTelemetry, error) {
 	ot := &LLOOutcomeTelemetry{
 		LifeCycleStage:                  string(outcome.LifeCycleStage),
 		ObservationTimestampNanoseconds: outcome.ObservationTimestampNanoseconds,

--- a/llo/plugin_reports.go
+++ b/llo/plugin_reports.go
@@ -100,11 +100,11 @@ func (p *Plugin) encodeReport(r Report, cd llotypes.ChannelDefinition) (types.Re
 	if !exists {
 		return nil, fmt.Errorf("codec missing for ReportFormat=%q", cd.ReportFormat)
 	}
-	p.captureReportTelemetry(&r, cd)
+	p.captureReportTelemetry(r, cd)
 	return codec.Encode(r, cd)
 }
 
-func (p *Plugin) captureReportTelemetry(r *Report, cd llotypes.ChannelDefinition) {
+func (p *Plugin) captureReportTelemetry(r Report, cd llotypes.ChannelDefinition) {
 	if p.ReportTelemetryCh != nil {
 		rt, err := makeReportTelemetry(r, cd, p.DonID)
 		if err != nil {
@@ -119,7 +119,7 @@ func (p *Plugin) captureReportTelemetry(r *Report, cd llotypes.ChannelDefinition
 	}
 }
 
-func makeReportTelemetry(r *Report, cd llotypes.ChannelDefinition, donID uint32) (*LLOReportTelemetry, error) {
+func makeReportTelemetry(r Report, cd llotypes.ChannelDefinition, donID uint32) (*LLOReportTelemetry, error) {
 	streams := make([]*LLOStreamDefinition, len(cd.Streams))
 	for i, s := range cd.Streams {
 		streams[i] = &LLOStreamDefinition{


### PR DESCRIPTION
Minimize possibility of leaking memory
