### PR TITLE
llo: make uncompressed observations backward compatible for transition

### DIFF
--- a/llo/llo_offchain_config.pb.go
+++ b/llo/llo_offchain_config.pb.go
@@ -25,6 +25,7 @@ type LLOOffchainConfigProto struct {
 	state                               protoimpl.MessageState `protogen:"open.v1"`
 	ProtocolVersion                     uint32                 `protobuf:"varint,1,opt,name=protocolVersion,proto3" json:"protocolVersion,omitempty"`
 	DefaultMinReportIntervalNanoseconds uint64                 `protobuf:"varint,2,opt,name=defaultMinReportIntervalNanoseconds,proto3" json:"defaultMinReportIntervalNanoseconds,omitempty"`
+	EnableObservationCompression        bool                   `protobuf:"varint,3,opt,name=enableObservationCompression,proto3" json:"enableObservationCompression,omitempty"`
 	unknownFields                       protoimpl.UnknownFields
 	sizeCache                           protoimpl.SizeCache
 }
@@ -73,14 +74,22 @@ func (x *LLOOffchainConfigProto) GetDefaultMinReportIntervalNanoseconds() uint64
 	return 0
 }
 
+func (x *LLOOffchainConfigProto) GetEnableObservationCompression() bool {
+	if x != nil {
+		return x.EnableObservationCompression
+	}
+	return false
+}
+
 var File_llo_offchain_config_proto protoreflect.FileDescriptor
 
 const file_llo_offchain_config_proto_rawDesc = "" +
 	"\n" +
-	"\x19llo_offchain_config.proto\x12\x02v1\"\x94\x01\n" +
+	"\x19llo_offchain_config.proto\x12\x02v1\"\xd8\x01\n" +
 	"\x16LLOOffchainConfigProto\x12(\n" +
 	"\x0fprotocolVersion\x18\x01 \x01(\rR\x0fprotocolVersion\x12P\n" +
-	"#defaultMinReportIntervalNanoseconds\x18\x02 \x01(\x04R#defaultMinReportIntervalNanosecondsB\aZ\x05.;llob\x06proto3"
+	"#defaultMinReportIntervalNanoseconds\x18\x02 \x01(\x04R#defaultMinReportIntervalNanoseconds\x12B\n" +
+	"\x1cenableObservationCompression\x18\x03 \x01(\bR\x1cenableObservationCompressionB\aZ\x05.;llob\x06proto3"
 
 var (
 	file_llo_offchain_config_proto_rawDescOnce sync.Once

--- a/llo/llo_offchain_config.proto
+++ b/llo/llo_offchain_config.proto
@@ -6,4 +6,5 @@ option go_package = ".;llo";
 message LLOOffchainConfigProto {
     uint32 protocolVersion = 1;
     uint64 defaultMinReportIntervalNanoseconds = 2;
+    bool enableObservationCompression = 3;
 }

--- a/llo/observation_compress.go
+++ b/llo/observation_compress.go
@@ -2,16 +2,14 @@ package llo
 
 import (
 	"github.com/klauspost/compress/zstd"
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
-type Compressor struct {
-	logger  logger.Logger
+type compressor struct {
 	encoder *zstd.Encoder
 	decoder *zstd.Decoder
 }
 
-func NewCompressor(lggr logger.Logger) (*Compressor, error) {
+func newCompressor() (*compressor, error) {
 	encoder, err := zstd.NewWriter(nil)
 	if err != nil {
 		return nil, err
@@ -20,19 +18,14 @@ func NewCompressor(lggr logger.Logger) (*Compressor, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Compressor{logger.Sugared(lggr).Named("Compressor"), encoder, decoder}, nil
+	return &compressor{encoder, decoder}, nil
 }
 
-func (c *Compressor) CompressObservation(b []byte) ([]byte, error) {
+func (c *compressor) CompressObservation(b []byte) ([]byte, error) {
 	compressed := c.encoder.EncodeAll(b, nil)
-	c.logger.Debugw("compressed observation", "compressed_size", len(compressed), "uncompressed_size", len(b))
 	return compressed, nil
 }
 
-func (c *Compressor) DecompressObservation(b []byte) ([]byte, error) {
-	uncompressed, err := c.decoder.DecodeAll(b, nil)
-	if err != nil {
-		return nil, err
-	}
-	return uncompressed, nil
+func (c *compressor) DecompressObservation(b []byte) ([]byte, error) {
+	return c.decoder.DecodeAll(b, nil)
 }

--- a/llo/offchain_config.go
+++ b/llo/offchain_config.go
@@ -18,6 +18,8 @@ type OffchainConfig struct {
 	// produced quickly, you are still limited by OCR3's DeltaRound and
 	// DeltaGrace params, as well as networking latency.
 	DefaultMinReportIntervalNanoseconds uint64
+	// EnableObservationCompression enables observation compression.
+	EnableObservationCompression bool
 }
 
 func DecodeOffchainConfig(b []byte) (o OffchainConfig, err error) {
@@ -40,6 +42,7 @@ func DecodeOffchainConfig(b []byte) (o OffchainConfig, err error) {
 	}
 	o.ProtocolVersion = pbuf.ProtocolVersion
 	o.DefaultMinReportIntervalNanoseconds = pbuf.DefaultMinReportIntervalNanoseconds
+	o.EnableObservationCompression = pbuf.EnableObservationCompression
 	return
 }
 
@@ -47,6 +50,7 @@ func (c OffchainConfig) Encode() ([]byte, error) {
 	pbuf := &LLOOffchainConfigProto{
 		ProtocolVersion:                     c.ProtocolVersion,
 		DefaultMinReportIntervalNanoseconds: c.DefaultMinReportIntervalNanoseconds,
+		EnableObservationCompression:        c.EnableObservationCompression,
 	}
 	return proto.Marshal(pbuf)
 }

--- a/llo/offchain_config_test.go
+++ b/llo/offchain_config_test.go
@@ -53,6 +53,7 @@ func Test_OffchainConfig(t *testing.T) {
 			cfg := OffchainConfig{
 				ProtocolVersion:                     1,
 				DefaultMinReportIntervalNanoseconds: 1000,
+				EnableObservationCompression:        true,
 			}
 
 			b, err := cfg.Encode()

--- a/llo/plugin.go
+++ b/llo/plugin.go
@@ -256,7 +256,7 @@ func (f *PluginFactory) NewReportingPlugin(ctx context.Context, cfg ocr3types.Re
 
 	l.Infow("llo.NewReportingPlugin", "onchainConfig", onchainConfig, "offchainConfig", offchainConfig)
 
-	obsCodec, err := NewProtoObservationCodec(l)
+	obsCodec, err := NewProtoObservationCodec(l, offchainConfig.EnableObservationCompression)
 	if err != nil {
 		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("NewReportingPlugin failed to create observation codec: %w", err)
 	}

--- a/llo/plugin_observation_test.go
+++ b/llo/plugin_observation_test.go
@@ -67,7 +67,7 @@ func testObservation(t *testing.T, outcomeCodec OutcomeCodec) {
 		err: nil,
 	}
 
-	obsCodec, err := NewProtoObservationCodec(logger.Nop())
+	obsCodec, err := NewProtoObservationCodec(logger.Nop(), true)
 	require.NoError(t, err)
 
 	p := &Plugin{

--- a/llo/plugin_outcome_test.go
+++ b/llo/plugin_outcome_test.go
@@ -29,7 +29,7 @@ func Test_Outcome(t *testing.T) {
 func testOutcome(t *testing.T, outcomeCodec OutcomeCodec) {
 	ctx := tests.Context(t)
 
-	obsCodec, err := NewProtoObservationCodec(logger.Nop())
+	obsCodec, err := NewProtoObservationCodec(logger.Nop(), true)
 	require.NoError(t, err)
 	p := &Plugin{
 		Config:           Config{true},

--- a/llo/plugin_test.go
+++ b/llo/plugin_test.go
@@ -46,7 +46,7 @@ func (m *mockDataSource) Observe(ctx context.Context, streamValues StreamValues,
 }
 
 func Test_ValidateObservation(t *testing.T) {
-	obsCodec, err := NewProtoObservationCodec(logger.Nop())
+	obsCodec, err := NewProtoObservationCodec(logger.Nop(), true)
 	require.NoError(t, err)
 
 	p := &Plugin{


### PR DESCRIPTION
Minimises changes and avoid complex transition scenarios with new observation formats or offchain config changes.