### PR TITLE
fix input types to avoid literals parsing issues

### DIFF
--- a/llo/stream_calculated.go
+++ b/llo/stream_calculated.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/big"
 	"regexp"
 	"strconv"
 	"sync"
@@ -462,12 +463,15 @@ func Round(x any, precision int) (decimal.Decimal, error) {
 }
 
 // Truncate truncates off digits from the number, without rounding.
-func Truncate(x any, precision int32) (decimal.Decimal, error) {
+func Truncate(x any, precision int) (decimal.Decimal, error) {
+	if precision > math.MaxInt32 {
+		return decimal.Decimal{}, fmt.Errorf("precision is too large")
+	}
 	n, err := toDecimal(x)
 	if err != nil {
 		return decimal.Decimal{}, err
 	}
-	return n.Truncate(precision), nil
+	return n.Truncate(int32(precision)), nil
 }
 
 // Duration parses a duration string into a time.Duration
@@ -496,6 +500,8 @@ func toDecimal(x any) (decimal.Decimal, error) {
 		return decimal.NewFromUint64(uint64(v)), nil
 	case uint64:
 		return decimal.NewFromUint64(v), nil
+	case *big.Int:
+		return decimal.NewFromBigInt(v, 0), nil
 	case decimal.Decimal:
 		return v, nil
 	case time.Duration:

--- a/llo/stream_calculated_test.go
+++ b/llo/stream_calculated_test.go
@@ -3,6 +3,7 @@ package llo
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"strconv"
 	"testing"
 
@@ -74,6 +75,11 @@ func TestToDecimal(t *testing.T) {
 			name:     "decimal.Decimal",
 			input:    decimal.NewFromFloat(123.45),
 			expected: decimal.NewFromFloat(123.45),
+		},
+		{
+			name:     "*big.Int",
+			input:    big.NewInt(123),
+			expected: decimal.NewFromBigInt(big.NewInt(123), 0),
 		},
 		{
 			name:        "unsupported type",
@@ -1018,7 +1024,7 @@ func TestRound(t *testing.T) {
 func TestTruncate(t *testing.T) {
 	tests := []struct {
 		name        string
-		precision   int32
+		precision   int
 		expected    string
 		expectError bool
 	}{


### PR DESCRIPTION
Use ints to avoid literal parsing issues.