### PR TITLE
[CRE-491] Move mercury config to chainlink-data-streams

### DIFF
--- a/llo/transmitter/de/config.go
+++ b/llo/transmitter/de/config.go
@@ -1,0 +1,58 @@
+package de
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+)
+
+type MercuryTransmitterProtocol string
+
+const (
+	MercuryTransmitterProtocolWSRPC MercuryTransmitterProtocol = "wsrpc"
+	MercuryTransmitterProtocolGRPC  MercuryTransmitterProtocol = "grpc"
+)
+
+func (m MercuryTransmitterProtocol) String() string {
+	return string(m)
+}
+
+func (m *MercuryTransmitterProtocol) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "wsrpc":
+		*m = MercuryTransmitterProtocolWSRPC
+	case "grpc":
+		*m = MercuryTransmitterProtocolGRPC
+	default:
+		return fmt.Errorf("unknown mercury transmitter protocol: %s", text)
+	}
+	return nil
+}
+
+type MercuryCache interface {
+	LatestReportTTL() time.Duration
+	MaxStaleAge() time.Duration
+	LatestReportDeadline() time.Duration
+}
+
+type MercuryTLS interface {
+	CertFile() string
+}
+
+type MercuryTransmitter interface {
+	Protocol() MercuryTransmitterProtocol
+	TransmitQueueMaxSize() uint32
+	TransmitTimeout() time.Duration
+	TransmitConcurrency() uint32
+	ReaperFrequency() time.Duration
+	ReaperMaxAge() time.Duration
+}
+
+type Mercury interface {
+	Credentials(credName string) *types.MercuryCredentials
+	Cache() MercuryCache
+	TLS() MercuryTLS
+	Transmitter() MercuryTransmitter
+	VerboseLogging() bool
+}

--- a/llo/transmitter/de/transmitter.go
+++ b/llo/transmitter/de/transmitter.go
@@ -58,29 +58,6 @@ var (
 	)
 )
 
-type MercuryTransmitterProtocol string
-
-const (
-	MercuryTransmitterProtocolWSRPC MercuryTransmitterProtocol = "wsrpc"
-	MercuryTransmitterProtocolGRPC  MercuryTransmitterProtocol = "grpc"
-)
-
-func (m MercuryTransmitterProtocol) String() string {
-	return string(m)
-}
-
-func (m *MercuryTransmitterProtocol) UnmarshalText(text []byte) error {
-	switch string(text) {
-	case "wsrpc":
-		*m = MercuryTransmitterProtocolWSRPC
-	case "grpc":
-		*m = MercuryTransmitterProtocolGRPC
-	default:
-		return fmt.Errorf("unknown mercury transmitter protocol: %s", text)
-	}
-	return nil
-}
-
 type Transmission struct {
 	ServerURL    string
 	ConfigDigest types.ConfigDigest


### PR DESCRIPTION
Also, moved `MercuryTransmitterProtocol` to the newly created config file.

Supports https://github.com/smartcontractkit/chainlink/pull/22594