### PR TITLE
llo/dev/v31: move blob broadcasting out of Observation

### DIFF
--- a/llo/dev/v31/blobcompress.go
+++ b/llo/dev/v31/blobcompress.go
@@ -1,0 +1,116 @@
+package llo
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+// Blob payload codec identifiers. The first byte of a blob payload names the
+// codec used for the remaining bytes, so a reader never has to guess and the
+// writer stays free to fall back to raw when compression does not pay off.
+const (
+	blobCodecRaw  byte = 0
+	blobCodecZstd byte = 1
+)
+
+// maxDecompressedBlobPayloadBytes bounds the size of a blob payload after
+// decompression. A blob is a stream-values-only observation proto, so the same
+// bound the v30 observation codec uses applies here: it is generously above any
+// honest payload while keeping a malicious peer from turning a small blob into
+// a huge allocation (zstd bomb).
+const maxDecompressedBlobPayloadBytes = protocol.MaxDecompressedObservationLength
+
+// zstd Encoder/Decoder are safe for concurrent use via EncodeAll/DecodeAll and
+// are expensive to build, so a single pair is shared process-wide. Built lazily
+// so a construction failure surfaces at the call site rather than in init.
+var (
+	blobZstd     blobCompressor
+	blobZstdOnce sync.Once
+	blobZstdErr  error
+)
+
+type blobCompressor struct {
+	encoder *zstd.Encoder
+	decoder *zstd.Decoder
+}
+
+func getBlobCompressor() (blobCompressor, error) {
+	blobZstdOnce.Do(func() {
+		encoder, err := zstd.NewWriter(nil)
+		if err != nil {
+			blobZstdErr = fmt.Errorf("new zstd encoder: %w", err)
+			return
+		}
+		// WithDecoderMaxMemory bounds the decompressed size to a safe limit.
+		decoder, err := zstd.NewReader(nil,
+			zstd.WithDecoderConcurrency(0),
+			zstd.WithDecoderMaxMemory(maxDecompressedBlobPayloadBytes),
+		)
+		if err != nil {
+			blobZstdErr = fmt.Errorf("new zstd decoder: %w", err)
+			return
+		}
+		blobZstd = blobCompressor{encoder: encoder, decoder: decoder}
+	})
+	return blobZstd, blobZstdErr
+}
+
+// encodeBlobPayload frames raw proto bytes for broadcast, compressing them when
+// that actually shrinks the payload. The codec choice is made here and recorded
+// in the leading byte; readers never re-derive it, so nodes are free to disagree
+// on whether compression paid off without affecting the decoded result.
+func encodeBlobPayload(raw []byte) ([]byte, error) {
+	if len(raw) > maxDecompressedBlobPayloadBytes {
+		// Refuse to emit a blob every peer would reject on decompression;
+		// fail loudly here instead.
+		return nil, fmt.Errorf("blob payload too large: %d > %d bytes", len(raw), maxDecompressedBlobPayloadBytes)
+	}
+	c, err := getBlobCompressor()
+	if err != nil {
+		return nil, err
+	}
+	compressed := c.encoder.EncodeAll(raw, []byte{blobCodecZstd})
+	if len(compressed) < len(raw)+1 {
+		return compressed, nil
+	}
+	out := make([]byte, 0, len(raw)+1)
+	out = append(out, blobCodecRaw)
+	return append(out, raw...), nil
+}
+
+// decodeBlobPayload reverses encodeBlobPayload. The payload is untrusted: the
+// decompressed size is bounded both by the decoder and by an explicit check.
+func decodeBlobPayload(payload []byte) ([]byte, error) {
+	if len(payload) == 0 {
+		return nil, fmt.Errorf("empty blob payload")
+	}
+	codec, body := payload[0], payload[1:]
+	switch codec {
+	case blobCodecRaw:
+		if len(body) > maxDecompressedBlobPayloadBytes {
+			return nil, fmt.Errorf("blob payload too large: %d > %d bytes", len(body), maxDecompressedBlobPayloadBytes)
+		}
+		return body, nil
+	case blobCodecZstd:
+		c, err := getBlobCompressor()
+		if err != nil {
+			return nil, err
+		}
+		out, err := c.decoder.DecodeAll(body, nil)
+		if err != nil {
+			return nil, fmt.Errorf("decompress blob payload: %w", err)
+		}
+		// DecodeAll already enforces the limit above, but keep an explicit
+		// check so the bound survives any change to the decoder options.
+		if len(out) > maxDecompressedBlobPayloadBytes {
+			return nil, fmt.Errorf("decompressed blob payload too large: %d > %d bytes", len(out), maxDecompressedBlobPayloadBytes)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unknown blob payload codec %d", codec)
+	}
+}

--- a/llo/dev/v31/blobcompress_test.go
+++ b/llo/dev/v31/blobcompress_test.go
@@ -1,0 +1,99 @@
+package llo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+func Test_BlobPayload_RoundTrip(t *testing.T) {
+	t.Run("compressible payload uses zstd", func(t *testing.T) {
+		raw := []byte(strings.Repeat("stream-values-are-repetitive", 200))
+		framed, err := encodeBlobPayload(raw)
+		require.NoError(t, err)
+		require.Equal(t, blobCodecZstd, framed[0])
+		assert.Less(t, len(framed), len(raw))
+
+		got, err := decodeBlobPayload(framed)
+		require.NoError(t, err)
+		assert.Equal(t, raw, got)
+	})
+
+	t.Run("incompressible payload falls back to raw", func(t *testing.T) {
+		// zstd cannot shrink a short high-entropy payload, so the encoder must
+		// not pay the framing overhead of compressing it.
+		raw := []byte{0x9f, 0x1c, 0x00, 0xd3, 0x7a}
+		framed, err := encodeBlobPayload(raw)
+		require.NoError(t, err)
+		require.Equal(t, blobCodecRaw, framed[0])
+		assert.Equal(t, len(raw)+1, len(framed))
+
+		got, err := decodeBlobPayload(framed)
+		require.NoError(t, err)
+		assert.Equal(t, raw, got)
+	})
+
+	t.Run("empty payload", func(t *testing.T) {
+		framed, err := encodeBlobPayload(nil)
+		require.NoError(t, err)
+		got, err := decodeBlobPayload(framed)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}
+
+func Test_BlobPayload_MarshalStreamValuesRoundTrip(t *testing.T) {
+	sv := make(protocol.StreamValues, 500)
+	for i := uint32(0); i < 500; i++ {
+		sv[i] = protocol.ToDecimal(decimal.NewFromInt(int64(i)))
+	}
+	payload, err := marshalStreamValues(sv)
+	require.NoError(t, err)
+	require.Equal(t, blobCodecZstd, payload[0])
+
+	raw, err := decodeBlobPayload(payload)
+	require.NoError(t, err)
+	chunk := &protocol.LLOObservationProto{}
+	require.NoError(t, proto.Unmarshal(raw, chunk))
+	assert.Len(t, chunk.StreamValues, 500)
+}
+
+func Test_decodeBlobPayload_Errors(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		_, err := decodeBlobPayload(nil)
+		require.ErrorContains(t, err, "empty blob payload")
+	})
+
+	t.Run("unknown codec", func(t *testing.T) {
+		_, err := decodeBlobPayload([]byte{0x7f, 0x01, 0x02})
+		require.ErrorContains(t, err, "unknown blob payload codec 127")
+	})
+
+	t.Run("corrupt zstd body", func(t *testing.T) {
+		_, err := decodeBlobPayload([]byte{blobCodecZstd, 0xde, 0xad, 0xbe, 0xef})
+		require.ErrorContains(t, err, "decompress blob payload")
+	})
+
+	t.Run("zstd bomb is rejected without allocating", func(t *testing.T) {
+		enc, err := zstd.NewWriter(nil)
+		require.NoError(t, err)
+		bomb := enc.EncodeAll(make([]byte, maxDecompressedBlobPayloadBytes+1), []byte{blobCodecZstd})
+		require.Less(t, len(bomb), 1<<20, "bomb should be tiny on the wire")
+
+		_, err = decodeBlobPayload(bomb)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "blob payload")
+	})
+}
+
+func Test_encodeBlobPayload_RejectsOversized(t *testing.T) {
+	_, err := encodeBlobPayload(make([]byte, maxDecompressedBlobPayloadBytes+1))
+	require.ErrorContains(t, err, "blob payload too large")
+}

--- a/llo/dev/v31/blobpump.go
+++ b/llo/dev/v31/blobpump.go
@@ -299,7 +299,9 @@ func (p *blobPump) observe(in pumpInput) (*blobSnapshot, error) {
 }
 
 // marshalStreamValues serializes stream values into the stream-values-only
-// proto that is carried by a blob. Returns nil when nothing was observed.
+// proto that is carried by a blob, framed by encodeBlobPayload (which
+// compresses it when that shrinks the payload). Returns nil when nothing was
+// observed.
 func marshalStreamValues(sv protocol.StreamValues) ([]byte, error) {
 	pb, err := streamValuesToProto(sv)
 	if err != nil {
@@ -308,9 +310,9 @@ func marshalStreamValues(sv protocol.StreamValues) ([]byte, error) {
 	if len(pb) == 0 {
 		return nil, nil
 	}
-	payload, err := proto.Marshal(&protocol.LLOObservationProto{StreamValues: pb})
+	raw, err := proto.Marshal(&protocol.LLOObservationProto{StreamValues: pb})
 	if err != nil {
 		return nil, fmt.Errorf("marshal stream values: %w", err)
 	}
-	return payload, nil
+	return encodeBlobPayload(raw)
 }

--- a/llo/dev/v31/blobpump.go
+++ b/llo/dev/v31/blobpump.go
@@ -1,0 +1,299 @@
+package llo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/datasource"
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"google.golang.org/protobuf/proto"
+)
+
+// Defaults for the blob pump. See PluginFactoryParams for the overrides.
+const (
+	// DefaultBlobLifetimeRounds is how many sequence numbers past the one a
+	// pump cycle started for a broadcast blob is hinted to live. It must exceed
+	// 1: a snapshot gathered for seqNr N is normally consumed at N+1, and the
+	// blob is fetched by the other oracles during that later round.
+	DefaultBlobLifetimeRounds = 3
+	// DefaultBlobObservationDurationMultiplier scales MaxDurationObservation
+	// into the pump's per-cycle budget. The pump runs off the OCR critical
+	// path, so it can afford to wait longer than a synchronous observation.
+	DefaultBlobObservationDurationMultiplier = 2
+	// DefaultBlobSnapshotAgeMultiplier scales MaxDurationObservation into the
+	// wall-clock age at which a parked snapshot is discarded. Generous on
+	// purpose: ordinary jitter should reuse the previous snapshot rather than
+	// discard it, since blob expiry already bounds staleness in rounds.
+	DefaultBlobSnapshotAgeMultiplier = 5
+)
+
+// pumpInput is the round context the pump needs, published by Observation.
+type pumpInput struct {
+	streams        []llotypes.StreamID
+	seqNr          uint64
+	lifeCycleStage llotypes.LifeCycleStage
+}
+
+// blobSnapshot is one completed pump cycle: stream values already serialized,
+// broadcast as a blob, and reduced to the marshaled handle that goes on the
+// wire.
+type blobSnapshot struct {
+	handleBytes []byte
+	observedAt  time.Time
+	// forSeqNr is the sequence number known when the cycle started.
+	forSeqNr uint64
+	// expiresAt is the blob expiration hint; the snapshot must not be used at
+	// or beyond this sequence number.
+	expiresAt uint64
+	// streamCount is the number of streams the cycle observed (for logging).
+	streamCount int
+}
+
+// blobPump gathers stream observations off the OCR critical path and broadcasts
+// them as blobs, parking the resulting handle for Observation to pick up.
+//
+// Cadence is consumption-driven: a cycle is kicked whenever Observation takes
+// (or discards) a snapshot, so the pump rate tracks the round rate without
+// needing to know deltaRound, and no blob is broadcast that no round asked for.
+// Cycles are serial, so there is never more than one DataSource.Observe in
+// flight. There is deliberately no idle watchdog: a snapshot's usability is
+// bounded by sequence number, so refreshing while no rounds are running would
+// produce snapshots that are already too old to use.
+type blobPump struct {
+	bbf                ocr3_1types.BlobBroadcastFetcher
+	ds                 DataSource
+	lggr               logger.Logger
+	configDigest       ocrtypes.ConfigDigest
+	verboseLogging     bool
+	observationTimeout time.Duration
+	maxSnapshotAge     time.Duration
+	blobLifetimeRounds uint64
+
+	trigger chan struct{}
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+
+	inFlight atomic.Bool
+	misses   atomic.Uint64
+	cycles   atomic.Uint64
+
+	mu    sync.Mutex
+	input pumpInput
+	ready *blobSnapshot
+}
+
+func newBlobPump(
+	bbf ocr3_1types.BlobBroadcastFetcher,
+	ds DataSource,
+	lggr logger.Logger,
+	configDigest ocrtypes.ConfigDigest,
+	verboseLogging bool,
+	observationTimeout time.Duration,
+	maxSnapshotAge time.Duration,
+	blobLifetimeRounds uint64,
+) *blobPump {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &blobPump{
+		bbf:                bbf,
+		ds:                 ds,
+		lggr:               logger.Sugared(lggr).Named("BlobPump"),
+		configDigest:       configDigest,
+		verboseLogging:     verboseLogging,
+		observationTimeout: observationTimeout,
+		maxSnapshotAge:     maxSnapshotAge,
+		blobLifetimeRounds: blobLifetimeRounds,
+		trigger:            make(chan struct{}, 1),
+		ctx:                ctx,
+		cancel:             cancel,
+	}
+}
+
+// enabled reports whether the pump can actually produce snapshots. Both
+// dependencies come from the host: a nil BlobBroadcastFetcher (as passed by
+// harnesses that run the plugin without blob transport) or a nil DataSource
+// leaves the pump inert rather than panicking in the loop goroutine.
+func (p *blobPump) enabled() bool { return p.bbf != nil && p.ds != nil }
+
+// Start launches the pump loop. Safe to call once. A pump with no broadcaster or
+// no data source starts no goroutine.
+func (p *blobPump) Start() {
+	if !p.enabled() {
+		p.lggr.Warnw("Blob pump disabled; observations will carry no stream values", "hasBroadcaster", p.bbf != nil, "hasDataSource", p.ds != nil)
+		return
+	}
+	p.wg.Add(1)
+	go p.run()
+}
+
+// Close stops the pump and waits for any in-flight cycle to unwind.
+func (p *blobPump) Close() {
+	p.cancel()
+	p.wg.Wait()
+}
+
+// SetInput publishes the round context for subsequent cycles. Cheap; called
+// from Observation before Take.
+func (p *blobPump) SetInput(in pumpInput) {
+	p.mu.Lock()
+	p.input = in
+	p.mu.Unlock()
+}
+
+// Take returns the parked snapshot if it is still usable at seqNr, and always
+// kicks the next cycle: kicking on a discard as well as on a hit is what stops
+// a single unusable snapshot from stalling the pump forever. The second return
+// value is the reason a snapshot was not returned, for logging.
+func (p *blobPump) Take(seqNr uint64) (*blobSnapshot, string) {
+	if !p.enabled() {
+		p.misses.Add(1)
+		return nil, "blob pump disabled"
+	}
+
+	p.mu.Lock()
+	snap := p.ready
+	p.ready = nil
+	p.mu.Unlock()
+
+	defer p.kick()
+
+	switch {
+	case snap == nil:
+		p.misses.Add(1)
+		if p.inFlight.Load() {
+			return nil, "cycle in flight"
+		}
+		return nil, "no snapshot parked"
+	case seqNr >= snap.expiresAt:
+		p.misses.Add(1)
+		return nil, fmt.Sprintf("blob expired (forSeqNr=%d expiresAt=%d)", snap.forSeqNr, snap.expiresAt)
+	case p.maxSnapshotAge > 0 && time.Since(snap.observedAt) > p.maxSnapshotAge:
+		p.misses.Add(1)
+		return nil, fmt.Sprintf("snapshot too old (age=%s max=%s)", time.Since(snap.observedAt), p.maxSnapshotAge)
+	default:
+		return snap, ""
+	}
+}
+
+// Misses reports how many rounds found no usable snapshot.
+func (p *blobPump) Misses() uint64 { return p.misses.Load() }
+
+// Cycles reports how many snapshots the pump has successfully parked.
+func (p *blobPump) Cycles() uint64 { return p.cycles.Load() }
+
+func (p *blobPump) kick() {
+	select {
+	case p.trigger <- struct{}{}:
+	default:
+	}
+}
+
+func (p *blobPump) run() {
+	defer p.wg.Done()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-p.trigger:
+		}
+		p.cycle()
+	}
+}
+
+// cycle runs one observation and parks the result. A failed cycle parks nothing:
+// the round that finds no snapshot emits an observation without stream values.
+func (p *blobPump) cycle() {
+	p.mu.Lock()
+	in := p.input
+	p.mu.Unlock()
+
+	if !p.enabled() || in.seqNr == 0 || len(in.streams) == 0 || in.lifeCycleStage == protocol.LifeCycleStageRetired {
+		return
+	}
+
+	p.inFlight.Store(true)
+	defer p.inFlight.Store(false)
+
+	snap, err := p.observe(in)
+	if err != nil {
+		p.lggr.Warnw("Blob pump cycle failed; round will observe no stream values", "err", err, "seqNr", in.seqNr, "streams", len(in.streams))
+		return
+	}
+
+	p.cycles.Add(1)
+	p.mu.Lock()
+	p.ready = snap
+	p.mu.Unlock()
+
+	if p.verboseLogging {
+		p.lggr.Debugw("Blob pump parked snapshot", "seqNr", in.seqNr, "expiresAt", snap.expiresAt, "streams", snap.streamCount, "handleBytes", len(snap.handleBytes))
+	}
+}
+
+func (p *blobPump) observe(in pumpInput) (*blobSnapshot, error) {
+	sv := make(protocol.StreamValues, len(in.streams))
+	for _, sid := range in.streams {
+		sv[sid] = nil
+	}
+
+	ctx, cancel := context.WithTimeout(p.ctx, p.observationTimeout)
+	defer cancel()
+
+	observedAt := time.Now()
+	opts := datasource.NewDSOpts(p.verboseLogging, in.seqNr, p.configDigest, observedAt, in.lifeCycleStage)
+	if err := p.ds.Observe(ctx, sv, opts); err != nil {
+		return nil, fmt.Errorf("DataSource.Observe error: %w", err)
+	}
+
+	payload, err := marshalStreamValues(sv)
+	if err != nil {
+		return nil, err
+	}
+	if len(payload) == 0 {
+		return nil, fmt.Errorf("no stream values observed for %d streams", len(in.streams))
+	}
+
+	expiresAt := in.seqNr + p.blobLifetimeRounds
+	handle, err := p.bbf.BroadcastBlob(ctx, payload, ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: expiresAt})
+	if err != nil {
+		return nil, fmt.Errorf("BroadcastBlob error: %w", err)
+	}
+	handleBytes, err := handle.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("marshal blob handle: %w", err)
+	}
+
+	return &blobSnapshot{
+		handleBytes: handleBytes,
+		observedAt:  observedAt,
+		forSeqNr:    in.seqNr,
+		expiresAt:   expiresAt,
+		streamCount: len(sv),
+	}, nil
+}
+
+// marshalStreamValues serializes stream values into the stream-values-only
+// proto that is carried by a blob. Returns nil when nothing was observed.
+func marshalStreamValues(sv protocol.StreamValues) ([]byte, error) {
+	pb, err := streamValuesToProto(sv)
+	if err != nil {
+		return nil, err
+	}
+	if len(pb) == 0 {
+		return nil, nil
+	}
+	payload, err := proto.Marshal(&protocol.LLOObservationProto{StreamValues: pb})
+	if err != nil {
+		return nil, fmt.Errorf("marshal stream values: %w", err)
+	}
+	return payload, nil
+}

--- a/llo/dev/v31/blobpump.go
+++ b/llo/dev/v31/blobpump.go
@@ -34,7 +34,24 @@ const (
 	// purpose: ordinary jitter should reuse the previous snapshot rather than
 	// discard it, since blob expiry already bounds staleness in rounds.
 	DefaultBlobSnapshotAgeMultiplier = 5
+	// MaxBlobLifetimeRounds bounds BlobLifetimeRounds. The pump broadcasts
+	// roughly one blob per round, so the unexpired-blob budget declared to
+	// libocr grows with the lifetime; this keeps that budget sane.
+	MaxBlobLifetimeRounds = 64
+	// BlobReapingMarginRounds is added to blobLifetimeRounds when deriving the
+	// per-oracle unexpired-blob budget, covering blobs that are expired but not
+	// yet reaped (reaping is asynchronous, on the order of tens of seconds).
+	BlobReapingMarginRounds = 16
+	// MinPerOracleUnexpiredBlobCount is the floor for the derived budget.
+	MinPerOracleUnexpiredBlobCount = 32
 )
+
+// perOracleUnexpiredBlobCount derives the per-oracle unexpired-blob budget from
+// the configured blob lifetime: one blob per round, plus a reaping margin.
+func perOracleUnexpiredBlobCount(blobLifetimeRounds uint64) int {
+	n := int(blobLifetimeRounds) + BlobReapingMarginRounds
+	return max(n, MinPerOracleUnexpiredBlobCount)
+}
 
 // pumpInput is the round context the pump needs, published by Observation.
 type pumpInput struct {

--- a/llo/dev/v31/blobpump_test.go
+++ b/llo/dev/v31/blobpump_test.go
@@ -1,0 +1,253 @@
+package llo
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/dev/v31/llotest"
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+func testPump(t *testing.T, ds DataSource, bbf ocr3_1types.BlobBroadcastFetcher, maxAge time.Duration) *blobPump {
+	t.Helper()
+	p := newBlobPump(bbf, ds, logger.Test(t), ocrtypes.ConfigDigest{1}, true, tests.WaitTimeout(t), maxAge, DefaultBlobLifetimeRounds)
+	p.Start()
+	t.Cleanup(p.Close)
+	return p
+}
+
+func pumpInputFor(seqNr uint64) pumpInput {
+	return pumpInput{streams: []llotypes.StreamID{100}, seqNr: seqNr, lifeCycleStage: protocol.LifeCycleStageProduction}
+}
+
+func mockDS() *mockDataSource {
+	return &mockDataSource{vals: protocol.StreamValues{100: protocol.ToDecimal(decimal.NewFromInt(7))}}
+}
+
+// Test_blobPump_TakeKicksNextCycle covers the cadence contract: the first Take
+// finds nothing and kicks a cycle, and the snapshot it produces is served to the
+// next Take.
+func Test_blobPump_TakeKicksNextCycle(t *testing.T) {
+	ds := mockDS()
+	bc := newFakeBroadcaster()
+	p := testPump(t, ds, bc, time.Minute)
+
+	p.SetInput(pumpInputFor(2))
+	snap, reason := p.Take(2)
+	require.Nil(t, snap)
+	require.NotEmpty(t, reason)
+
+	require.Eventually(t, func() bool { return p.Cycles() >= 1 }, tests.WaitTimeout(t), 10*time.Millisecond)
+
+	p.SetInput(pumpInputFor(3))
+	snap, reason = p.Take(3)
+	require.NotNil(t, snap, "reason: %s", reason)
+	require.Equal(t, uint64(2), snap.forSeqNr)
+	require.Equal(t, uint64(2+DefaultBlobLifetimeRounds), snap.expiresAt)
+	require.NotEmpty(t, snap.handleBytes)
+	require.Equal(t, uint64(1), p.Misses())
+
+	// The blob was hinted to expire at forSeqNr + lifetime. Assert on the first
+	// broadcast: later cycles re-broadcast an identical payload, which is
+	// content-addressed to the same handle, so only the ordered hint log
+	// distinguishes them.
+	hints := bc.Hints()
+	require.NotEmpty(t, hints)
+	require.Equal(t, ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: snap.expiresAt}, hints[0])
+
+	// The snapshot's handle fetches back the payload the pump broadcast.
+	var handle ocr3_1types.BlobHandle
+	require.NoError(t, handle.UnmarshalBinary(snap.handleBytes))
+	payload, err := bc.FetchBlob(tests.Context(t), handle)
+	require.NoError(t, err)
+	require.NotEmpty(t, payload)
+
+	// Taking a snapshot also kicks, so the pump keeps running.
+	require.Eventually(t, func() bool { return p.Cycles() >= 2 }, tests.WaitTimeout(t), 10*time.Millisecond)
+}
+
+// Test_blobPump_TakeIsSingleUse guards against two rounds referencing the same
+// blob handle.
+func Test_blobPump_TakeIsSingleUse(t *testing.T) {
+	p := testPump(t, mockDS(), newFakeBroadcaster(), time.Minute)
+	p.SetInput(pumpInputFor(2))
+	require.Eventually(t, func() bool {
+		_, _ = p.Take(2)
+		return p.Cycles() >= 1
+	}, tests.WaitTimeout(t), 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		snap, _ := p.Take(2)
+		return snap != nil
+	}, tests.WaitTimeout(t), 10*time.Millisecond)
+
+	// The pump may have parked a fresh snapshot by now, so assert on the parked
+	// slot directly rather than on a second Take.
+	p.mu.Lock()
+	p.ready = nil
+	p.mu.Unlock()
+	snap, reason := p.Take(2)
+	require.Nil(t, snap)
+	require.NotEmpty(t, reason)
+}
+
+func Test_blobPump_RejectsStaleSnapshots(t *testing.T) {
+	t.Run("expired by sequence number", func(t *testing.T) {
+		p := testPump(t, mockDS(), newFakeBroadcaster(), time.Minute)
+		p.mu.Lock()
+		p.ready = &blobSnapshot{handleBytes: []byte{1}, observedAt: time.Now(), forSeqNr: 2, expiresAt: 5}
+		p.mu.Unlock()
+
+		snap, reason := p.Take(5)
+		require.Nil(t, snap)
+		require.Contains(t, reason, "blob expired")
+		require.Equal(t, uint64(1), p.Misses())
+	})
+
+	t.Run("expired by wall clock", func(t *testing.T) {
+		p := testPump(t, mockDS(), newFakeBroadcaster(), time.Nanosecond)
+		p.mu.Lock()
+		p.ready = &blobSnapshot{handleBytes: []byte{1}, observedAt: time.Now().Add(-time.Hour), forSeqNr: 2, expiresAt: 100}
+		p.mu.Unlock()
+
+		snap, reason := p.Take(3)
+		require.Nil(t, snap)
+		require.Contains(t, reason, "too old")
+	})
+
+	t.Run("age check disabled", func(t *testing.T) {
+		p := testPump(t, mockDS(), newFakeBroadcaster(), 0)
+		p.mu.Lock()
+		p.ready = &blobSnapshot{handleBytes: []byte{1}, observedAt: time.Now().Add(-time.Hour), forSeqNr: 2, expiresAt: 100}
+		p.mu.Unlock()
+
+		snap, _ := p.Take(3)
+		require.NotNil(t, snap, "with the age check disabled only blob expiry bounds staleness")
+	})
+}
+
+// Test_blobPump_ParksNothingOnFailure covers both failure modes: a data-source
+// error and a broadcast error. Neither may park a snapshot, since stream values
+// are only ever disseminated by blob.
+func Test_blobPump_ParksNothingOnFailure(t *testing.T) {
+	t.Run("data source error", func(t *testing.T) {
+		ds := mockDS()
+		ds.err = errors.New("bridge down")
+		p := testPump(t, ds, newFakeBroadcaster(), time.Minute)
+		p.SetInput(pumpInputFor(2))
+		_, _ = p.Take(2)
+
+		require.Eventually(t, func() bool { return ds.observeCount() >= 1 }, tests.WaitTimeout(t), 10*time.Millisecond)
+		require.Zero(t, p.Cycles())
+		snap, _ := p.Take(3)
+		require.Nil(t, snap)
+	})
+
+	t.Run("broadcast error", func(t *testing.T) {
+		bc := func() *llotest.BlobBroadcastFetcher {
+			bc := newFakeBroadcaster()
+			bc.SetBroadcastError(errors.New("broadcast unavailable"))
+			return bc
+		}()
+		p := testPump(t, mockDS(), bc, time.Minute)
+		p.SetInput(pumpInputFor(2))
+		_, _ = p.Take(2)
+
+		require.Eventually(t, func() bool { return bc.Broadcasts() >= 1 }, tests.WaitTimeout(t), 10*time.Millisecond)
+		require.Zero(t, p.Cycles())
+		snap, _ := p.Take(3)
+		require.Nil(t, snap)
+	})
+}
+
+// Test_blobPump_SkipsIdleInput asserts the pump does not observe (or spend blob
+// budget) when there is nothing to observe.
+func Test_blobPump_SkipsIdleInput(t *testing.T) {
+	for name, in := range map[string]pumpInput{
+		"no input yet": {},
+		"no streams":   {seqNr: 2, lifeCycleStage: protocol.LifeCycleStageProduction},
+		"retired":      {streams: []llotypes.StreamID{100}, seqNr: 2, lifeCycleStage: protocol.LifeCycleStageRetired},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ds := mockDS()
+			bc := newFakeBroadcaster()
+			p := testPump(t, ds, bc, time.Minute)
+			p.SetInput(in)
+			for i := 0; i < 3; i++ {
+				_, _ = p.Take(2)
+			}
+			// Give the loop a chance to run the kicked cycles.
+			require.Never(t, func() bool { return ds.observeCount() > 0 || bc.Broadcasts() > 0 }, 100*time.Millisecond, 10*time.Millisecond)
+			require.Zero(t, p.Cycles())
+		})
+	}
+}
+
+// Test_blobPump_SingleFlight asserts cycles are serial: however many kicks
+// arrive, only one DataSource.Observe runs at a time.
+func Test_blobPump_SingleFlight(t *testing.T) {
+	release := make(chan struct{})
+	ds := &blockingDataSource{release: release}
+	p := testPump(t, ds, newFakeBroadcaster(), time.Minute)
+	p.SetInput(pumpInputFor(2))
+
+	for i := 0; i < 10; i++ {
+		_, _ = p.Take(2)
+	}
+	require.Eventually(t, func() bool { return ds.started() >= 1 }, tests.WaitTimeout(t), 10*time.Millisecond)
+	require.Never(t, func() bool { return ds.concurrent() > 1 }, 100*time.Millisecond, 10*time.Millisecond)
+	close(release)
+}
+
+func Test_observableStreams(t *testing.T) {
+	state := &kvState{channelDefinitions: llotypes.ChannelDefinitions{
+		1: {ReportFormat: llotypes.ReportFormatJSON, Streams: []llotypes.Stream{
+			{StreamID: 100, Aggregator: llotypes.AggregatorMedian},
+			{StreamID: 101, Aggregator: llotypes.AggregatorCalculated},
+		}},
+		// Duplicate stream across channels must be listed once.
+		2: {ReportFormat: llotypes.ReportFormatJSON, Streams: []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}}},
+		3: {ReportFormat: llotypes.ReportFormatJSON, Tombstone: true, Streams: []llotypes.Stream{{StreamID: 102, Aggregator: llotypes.AggregatorMedian}}},
+	}}
+	require.ElementsMatch(t, []llotypes.StreamID{100}, observableStreams(state))
+	require.Empty(t, observableStreams(&kvState{}))
+}
+
+// Test_blobPump_DisabledIsInert covers hosts that run the plugin without blob
+// transport (a nil BlobBroadcastFetcher, as some harnesses pass): the pump must
+// stay inert instead of dereferencing the nil dependency in its loop goroutine.
+func Test_blobPump_DisabledIsInert(t *testing.T) {
+	t.Run("nil broadcaster", func(t *testing.T) {
+		ds := mockDS()
+		p := testPump(t, ds, nil, time.Minute)
+		p.SetInput(pumpInputFor(2))
+		for i := 0; i < 3; i++ {
+			snap, reason := p.Take(2)
+			require.Nil(t, snap)
+			require.Equal(t, "blob pump disabled", reason)
+		}
+		require.Never(t, func() bool { return ds.observeCount() > 0 }, 100*time.Millisecond, 10*time.Millisecond)
+		require.Zero(t, p.Cycles())
+	})
+
+	t.Run("nil data source", func(t *testing.T) {
+		bc := newFakeBroadcaster()
+		p := testPump(t, nil, bc, time.Minute)
+		p.SetInput(pumpInputFor(2))
+		snap, reason := p.Take(2)
+		require.Nil(t, snap)
+		require.Equal(t, "blob pump disabled", reason)
+		require.Zero(t, bc.Broadcasts())
+	})
+}

--- a/llo/dev/v31/doc.go
+++ b/llo/dev/v31/doc.go
@@ -81,6 +81,10 @@
 // Stream values are always disseminated as a blob, never inline: an observation
 // carries only votes, the retirement report, its timestamp, and the handle of a
 // blob holding the round's stream values. See observation.go for the framing.
+// The blob payload itself is framed by blobcompress.go: a leading codec byte
+// followed by the stream-values proto, zstd-compressed whenever that shrinks
+// it. The codec is chosen by the writer and read from the byte, so nodes need
+// not agree on whether compression paid off.
 //
 // Gathering those values is off the OCR critical path. blobpump.go runs
 // DataSource.Observe in a background loop, serializes the result, broadcasts it,

--- a/llo/dev/v31/doc.go
+++ b/llo/dev/v31/doc.go
@@ -76,11 +76,29 @@
 // definition changes within the round that agrees them. Lifecycle changes are
 // NOT deferred: retirement stops reporting in the round it is agreed.
 //
-// # Blobs
+// # Blobs and the blob pump
 //
-// Observations carry per-stream values. When the serialized stream-value
-// payload is large it is disseminated as a blob and referenced by handle in the
-// observation, rather than sent inline. See observation.go.
+// Stream values are always disseminated as a blob, never inline: an observation
+// carries only votes, the retirement report, its timestamp, and the handle of a
+// blob holding the round's stream values. See observation.go for the framing.
+//
+// Gathering those values is off the OCR critical path. blobpump.go runs
+// DataSource.Observe in a background loop, serializes the result, broadcasts it,
+// and parks the marshaled handle; Observation publishes the round context
+// (stream set, seqNr, lifecycle stage) and picks up whatever is parked. Cadence
+// is consumption-driven: a cycle is kicked whenever Observation takes or
+// discards a snapshot, so the pump rate tracks the round rate without knowing
+// deltaRound, and cycles are serial so only one Observe is ever in flight.
+//
+// A snapshot is therefore gathered one round before it is used, and its
+// usability is bounded by the blob expiration hint (forSeqNr +
+// BlobLifetimeRounds) plus a generous wall-clock age check. A round that finds
+// nothing usable — cold start, a failed cycle, or a stale snapshot — emits an
+// observation with no stream values. That is not a halt: quorum counts
+// observations, not values. The cost lands in aggregation, which needs >F values
+// per stream, so streams miss the round only if more than F nodes miss together.
+// The pump counts misses and cycles (Misses / Cycles) so correlated misses show
+// up as more than an unexplained report gap.
 //
 // # Parity status (vs v30)
 //
@@ -116,8 +134,13 @@
 // logic (state transition, aggregation, reportability, backfill, calculated
 // streams) is ported from v30; the transport differs (KV state + blobs).
 //
-// Missing: Blob success path isn't unit-tested: ocr3_1types.BlobHandle has no exported constructor,
-// it's in an internal package, so a test can't fabricate a handle.
-// Tests cover the offload decision + inline fallback;
-// the full broadcast→fetch→merge round-trip needs libocr-provided doubles or an integration test.
+// Blob test coverage: ocr3_1types.BlobHandle has no exported constructor (it
+// lives in an internal package), but a handle can be UnmarshalBinary'd from a
+// syntactically valid encoding. The llotest subpackage exports an in-memory,
+// content-addressed BlobBroadcastFetcher built that way, so the
+// broadcast→fetch→merge round trip is unit-tested; only the real libocr
+// certification of a blob is out of reach without an integration test. Hosts
+// that run this plugin outside libocr (benchmarks, simulation harnesses) must
+// pass llotest.NewBlobBroadcastFetcher() rather than a nil fetcher: with a nil
+// fetcher the pump stays inert and no observation ever carries stream values.
 package llo

--- a/llo/dev/v31/factory.go
+++ b/llo/dev/v31/factory.go
@@ -78,6 +78,9 @@ func (f *PluginFactory) NewReportingPlugin(ctx context.Context, cfg ocr3types.Re
 	if blobLifetimeRounds <= 1 {
 		blobLifetimeRounds = DefaultBlobLifetimeRounds
 	}
+	if blobLifetimeRounds > MaxBlobLifetimeRounds {
+		return nil, nil, fmt.Errorf("BlobLifetimeRounds (%d) exceeds MaxBlobLifetimeRounds (%d)", blobLifetimeRounds, MaxBlobLifetimeRounds)
+	}
 	blobObservationTimeout := f.MaxDurationBlobObservation
 	if blobObservationTimeout <= 0 {
 		blobObservationTimeout = DefaultBlobObservationDurationMultiplier * cfg.MaxDurationObservation
@@ -118,6 +121,7 @@ func (f *PluginFactory) NewReportingPlugin(ctx context.Context, cfg ocr3types.Re
 	p.pump = newBlobPump(bbf, f.DataSource, l, cfg.ConfigDigest, f.Config.VerboseLogging, blobObservationTimeout, maxSnapshotAge, blobLifetimeRounds)
 	p.pump.Start()
 
+	unexpiredBlobCount := perOracleUnexpiredBlobCount(blobLifetimeRounds)
 	info := ocr3_1types.ReportingPluginInfo1{
 		Name: "LLO-3.1",
 		Limits: ocr3_1types.ReportingPluginLimits{
@@ -131,10 +135,12 @@ func (f *PluginFactory) NewReportingPlugin(ctx context.Context, cfg ocr3types.Re
 			MaxKeyValueModifiedKeysPlusValuesBytes: ocr3_1types.MaxMaxKeyValueModifiedKeysPlusValuesBytes,
 
 			MaxBlobPayloadBytes: ocr3_1types.MaxMaxBlobPayloadBytes,
-			// Blobs live for blobLifetimeRounds sequence numbers; set loosely to
-			// account for asynchronous reaping (see the libocr docs).
-			MaxPerOracleUnexpiredBlobCount:                  32,
-			MaxPerOracleUnexpiredBlobCumulativePayloadBytes: 32 * ocr3_1types.MaxMaxBlobPayloadBytes,
+			// Blobs live for blobLifetimeRounds sequence numbers and the pump
+			// broadcasts about one per round, so both budgets are derived from
+			// the configured lifetime plus a margin for asynchronous reaping
+			// (see the libocr docs).
+			MaxPerOracleUnexpiredBlobCount:                  unexpiredBlobCount,
+			MaxPerOracleUnexpiredBlobCumulativePayloadBytes: unexpiredBlobCount * ocr3_1types.MaxMaxBlobPayloadBytes,
 		},
 	}
 	if err := info.Validate(); err != nil {

--- a/llo/dev/v31/factory.go
+++ b/llo/dev/v31/factory.go
@@ -3,6 +3,7 @@ package llo
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
@@ -13,15 +14,11 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 )
 
-// DefaultBlobThreshold is the default serialized stream-value payload size in
-// bytes above which an observation offloads its stream values to a blob.
-const DefaultBlobThreshold = 128 * 1024
-
 var _ ocr3_1types.ReportingPluginFactory[llotypes.ReportInfo] = &PluginFactory{}
 
 // PluginFactoryParams bundles the dependencies needed to construct the v31
 // reporting plugin. It mirrors the v30 params, minus the outcome codec (state
-// lives in the KeyValueState), and adds BlobThreshold.
+// lives in the KeyValueState), and adds the blob pump knobs.
 type PluginFactoryParams struct {
 	Config
 	protocol.PredecessorRetirementReportCache
@@ -38,9 +35,19 @@ type PluginFactoryParams struct {
 	ReportTelemetryCh chan<- *protocol.LLOReportTelemetry
 	// DonID is optional and used only for telemetry and logging.
 	DonID uint32
-	// BlobThreshold overrides DefaultBlobThreshold if non-zero. A negative value
-	// disables blob offloading.
-	BlobThreshold int
+	// BlobLifetimeRounds overrides DefaultBlobLifetimeRounds if non-zero. Must
+	// be >1, since a snapshot gathered for one sequence number is consumed by a
+	// later one.
+	BlobLifetimeRounds uint64
+	// MaxDurationBlobObservation overrides the pump's per-cycle observation
+	// budget (default: DefaultBlobObservationDurationMultiplier *
+	// cfg.MaxDurationObservation).
+	MaxDurationBlobObservation time.Duration
+	// MaxBlobSnapshotAge overrides the wall-clock age at which a parked snapshot
+	// is discarded (default: DefaultBlobSnapshotAgeMultiplier *
+	// cfg.MaxDurationObservation). A negative value disables the age check,
+	// leaving blob expiry as the only staleness bound.
+	MaxBlobSnapshotAge time.Duration
 }
 
 func NewPluginFactory(p PluginFactoryParams) *PluginFactory {
@@ -51,7 +58,7 @@ type PluginFactory struct {
 	PluginFactoryParams
 }
 
-func (f *PluginFactory) NewReportingPlugin(ctx context.Context, cfg ocr3types.ReportingPluginConfig, _ ocr3_1types.BlobBroadcastFetcher) (ocr3_1types.ReportingPlugin[llotypes.ReportInfo], ocr3_1types.ReportingPluginInfo, error) {
+func (f *PluginFactory) NewReportingPlugin(ctx context.Context, cfg ocr3types.ReportingPluginConfig, bbf ocr3_1types.BlobBroadcastFetcher) (ocr3_1types.ReportingPlugin[llotypes.ReportInfo], ocr3_1types.ReportingPluginInfo, error) {
 	onchainConfig, err := f.OnchainConfigCodec.Decode(cfg.OnchainConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("NewReportingPlugin failed to decode onchain config; got: 0x%x (len: %d); %w", cfg.OnchainConfig, len(cfg.OnchainConfig), err)
@@ -67,12 +74,20 @@ func (f *PluginFactory) NewReportingPlugin(ctx context.Context, cfg ocr3types.Re
 	// Initialize the memory ballast
 	protocol.InitMemoryBallast()
 
-	blobThreshold := f.BlobThreshold
+	blobLifetimeRounds := f.BlobLifetimeRounds
+	if blobLifetimeRounds <= 1 {
+		blobLifetimeRounds = DefaultBlobLifetimeRounds
+	}
+	blobObservationTimeout := f.MaxDurationBlobObservation
+	if blobObservationTimeout <= 0 {
+		blobObservationTimeout = DefaultBlobObservationDurationMultiplier * cfg.MaxDurationObservation
+	}
+	maxSnapshotAge := f.MaxBlobSnapshotAge
 	switch {
-	case blobThreshold == 0:
-		blobThreshold = DefaultBlobThreshold
-	case blobThreshold < 0:
-		blobThreshold = 0 // disabled
+	case maxSnapshotAge == 0:
+		maxSnapshotAge = DefaultBlobSnapshotAgeMultiplier * cfg.MaxDurationObservation
+	case maxSnapshotAge < 0:
+		maxSnapshotAge = 0 // disabled; blob expiry still bounds staleness
 	}
 
 	p := &Plugin{
@@ -91,15 +106,17 @@ func (f *PluginFactory) NewReportingPlugin(ctx context.Context, cfg ocr3types.Re
 		DonID:                               f.DonID,
 		OutcomeTelemetryCh:                  f.OutcomeTelemetryCh,
 		ReportTelemetryCh:                   f.ReportTelemetryCh,
-		MaxDurationObservation:              cfg.MaxDurationObservation,
 		ProtocolVersion:                     offchainConfig.ProtocolVersion,
 		DefaultMinReportIntervalNanoseconds: offchainConfig.DefaultMinReportIntervalNanoseconds,
-		BlobThreshold:                       blobThreshold,
 	}
 
 	// Definitions and the opts decoded from them are cached together, as one
 	// immutable generation per c/seqnr, so a round can never mix the two.
 	p.ChannelCache = protocol.NewChannelCache()
+
+	// Setup the blobpump
+	p.pump = newBlobPump(bbf, f.DataSource, l, cfg.ConfigDigest, f.Config.VerboseLogging, blobObservationTimeout, maxSnapshotAge, blobLifetimeRounds)
+	p.pump.Start()
 
 	info := ocr3_1types.ReportingPluginInfo1{
 		Name: "LLO-3.1",
@@ -114,7 +131,7 @@ func (f *PluginFactory) NewReportingPlugin(ctx context.Context, cfg ocr3types.Re
 			MaxKeyValueModifiedKeysPlusValuesBytes: ocr3_1types.MaxMaxKeyValueModifiedKeysPlusValuesBytes,
 
 			MaxBlobPayloadBytes: ocr3_1types.MaxMaxBlobPayloadBytes,
-			// Blobs expire after a couple of sequence numbers; set loosely to
+			// Blobs live for blobLifetimeRounds sequence numbers; set loosely to
 			// account for asynchronous reaping (see the libocr docs).
 			MaxPerOracleUnexpiredBlobCount:                  32,
 			MaxPerOracleUnexpiredBlobCumulativePayloadBytes: 32 * ocr3_1types.MaxMaxBlobPayloadBytes,

--- a/llo/dev/v31/flow_test.go
+++ b/llo/dev/v31/flow_test.go
@@ -2,7 +2,9 @@ package llo
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
@@ -30,9 +32,13 @@ func (m *mockChannelDefinitionCache) Ready() error                   { return ni
 func (m *mockChannelDefinitionCache) HealthReport() map[string]error { return nil }
 func (m *mockChannelDefinitionCache) Name() string                   { return "mockChannelDefinitionCache" }
 
+// mockDataSource is observed from the blob pump goroutine, so its bookkeeping is
+// mutex-guarded.
 type mockDataSource struct {
-	vals       protocol.StreamValues
-	optsProbed bool
+	mu    sync.Mutex
+	vals  protocol.StreamValues
+	calls int
+	err   error
 }
 
 func (m *mockDataSource) Observe(ctx context.Context, sv protocol.StreamValues, opts DSOpts) error {
@@ -41,11 +47,64 @@ func (m *mockDataSource) Observe(ctx context.Context, sv protocol.StreamValues, 
 	_ = opts.SeqNr()
 	_ = opts.ConfigDigest()
 	_ = opts.ObservationTimestamp()
-	m.optsProbed = true
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	if m.err != nil {
+		return m.err
+	}
 	for k, v := range m.vals {
 		sv[k] = v
 	}
 	return nil
+}
+
+func (m *mockDataSource) observeCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+// blockingDataSource blocks in Observe until released, so tests can observe
+// how many cycles the pump runs concurrently.
+type blockingDataSource struct {
+	release  chan struct{}
+	mu       sync.Mutex
+	inFlight int
+	maxSeen  int
+	starts   int
+}
+
+func (m *blockingDataSource) Observe(ctx context.Context, sv protocol.StreamValues, opts DSOpts) error {
+	m.mu.Lock()
+	m.starts++
+	m.inFlight++
+	if m.inFlight > m.maxSeen {
+		m.maxSeen = m.inFlight
+	}
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		m.inFlight--
+		m.mu.Unlock()
+	}()
+	select {
+	case <-m.release:
+	case <-ctx.Done():
+	}
+	return nil
+}
+
+func (m *blockingDataSource) started() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.starts
+}
+
+func (m *blockingDataSource) concurrent() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.maxSeen
 }
 
 type mockShouldRetireCache struct{ retire bool }
@@ -103,18 +162,20 @@ func Test_Factory_NewReportingPlugin(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, 4, pl.N)
 	require.Equal(t, 1, pl.F)
-	require.Equal(t, DefaultBlobThreshold, pl.BlobThreshold)
 	require.NotNil(t, pl.ChannelCache)
+	require.NotNil(t, pl.pump)
+	require.Equal(t, uint64(DefaultBlobLifetimeRounds), pl.pump.blobLifetimeRounds)
 	require.NoError(t, pl.Close())
 }
 
 func Test_Observation_And_Validate_Flow(t *testing.T) {
 	ctx := tests.Context(t)
 	ds := &mockDataSource{vals: protocol.StreamValues{100: protocol.ToDecimal(decimal.NewFromInt(5))}}
+	bc := newFakeBroadcaster()
 	p := testPlugin(t)
 	p.ChannelDefinitionCache = &mockChannelDefinitionCache{defs: llotypes.ChannelDefinitions{1: jsonChannel()}}
-	p.DataSource = ds
 	p.ShouldRetireCache = &mockShouldRetireCache{}
+	attachPump(t, p, ds, bc)
 	kv := newMemKV()
 
 	// Query is empty; misc callbacks return their fixed values.
@@ -122,7 +183,6 @@ func Test_Observation_And_Validate_Flow(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, q)
 	require.NoError(t, p.Committed(ctx, 2, kv))
-	require.NoError(t, p.Close())
 	acc, err := p.ShouldAcceptAttestedReport(ctx, 2, ocr3types.ReportWithInfo[llotypes.ReportInfo]{})
 	require.NoError(t, err)
 	require.True(t, acc)
@@ -136,18 +196,34 @@ func Test_Observation_And_Validate_Flow(t *testing.T) {
 	_, err = p.StateTransition(ctx, 2, ocrtypes.AttributedQuery{}, addChannelRound(t, 1000, 1, jsonChannel()), kv, nil)
 	require.NoError(t, err)
 
-	// Observation at seqNr=3: channel 1 is now in KV, so DataSource is consulted.
-	obsBytes, err := p.Observation(ctx, 3, ocrtypes.AttributedQuery{}, kv, nil)
+	// Observation at seqNr=3: channel 1 is now in KV, so the pump is fed. The
+	// first round finds nothing parked yet (the pump runs off the critical path)
+	// and returns an observation with votes only; it kicks a cycle whose snapshot
+	// the next round picks up.
+	first, err := p.Observation(ctx, 3, ocrtypes.AttributedQuery{}, kv, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+	decodedFirst, err := decodeObservation(ctx, first, bc)
+	require.NoError(t, err)
+	require.Empty(t, decodedFirst.StreamValues)
+
+	require.Eventually(t, func() bool { return p.pump.Cycles() >= 1 }, tests.WaitTimeout(t), 10*time.Millisecond)
+	require.Positive(t, ds.observeCount(), "DataSource.Observe should have been called by the pump")
+	require.Positive(t, bc.Broadcasts(), "stream values must be disseminated as a blob")
+
+	obsBytes, err := p.Observation(ctx, 4, ocrtypes.AttributedQuery{}, kv, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, obsBytes)
-	require.True(t, ds.optsProbed, "DataSource.Observe should have been called")
+	decoded, err := decodeObservation(ctx, obsBytes, bc)
+	require.NoError(t, err)
+	require.Contains(t, decoded.StreamValues, llotypes.StreamID(100))
 
 	// Quorum + validation of the produced observation.
 	aos := []ocrtypes.AttributedObservation{ao(0, obsBytes), ao(1, obsBytes), ao(2, obsBytes)}
-	reached, err := p.ObservationQuorum(ctx, 3, ocrtypes.AttributedQuery{}, aos, kv, nil)
+	reached, err := p.ObservationQuorum(ctx, 4, ocrtypes.AttributedQuery{}, aos, kv, nil)
 	require.NoError(t, err)
 	require.True(t, reached)
-	require.NoError(t, p.ValidateObservation(ctx, 3, ocrtypes.AttributedQuery{}, ao(0, obsBytes), kv, nil))
+	require.NoError(t, p.ValidateObservation(ctx, 4, ocrtypes.AttributedQuery{}, ao(0, obsBytes), kv, bc))
 
 	// seqNr==1 observation must be empty.
 	require.Error(t, p.ValidateObservation(ctx, 1, ocrtypes.AttributedQuery{}, ao(0, []byte{1}), kv, nil))

--- a/llo/dev/v31/llotest/blob.go
+++ b/llo/dev/v31/llotest/blob.go
@@ -1,0 +1,190 @@
+// Package llotest provides test doubles for hosts that run the LLO OCR3.1
+// reporting plugin outside of libocr (benchmarks, simulation harnesses,
+// integration tests).
+//
+// The plugin disseminates stream values exclusively through blobs, so a host
+// that passes a nil ocr3_1types.BlobBroadcastFetcher to
+// PluginFactory.NewReportingPlugin gets a plugin whose observations never carry
+// stream values (the blob pump detects the nil and stays inert rather than
+// panicking). Such hosts should pass BlobBroadcastFetcher from this package
+// instead.
+package llotest
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+)
+
+// blobHandleVariantLightCertifiedBlob is the BlobHandle sum-type variant byte
+// for a LightCertifiedBlob.
+const blobHandleVariantLightCertifiedBlob = 0x01
+
+// BlobBroadcastFetcher is an in-memory, content-addressed
+// ocr3_1types.BlobBroadcastFetcher. Broadcast payloads are stored keyed by the
+// handle they are addressed with, so any number of blobs may be in flight and
+// each handle fetches back exactly its own payload.
+//
+// A real BlobHandle cannot be constructed outside libocr (the concrete type
+// lives in an internal package), but one can be unmarshaled from a
+// syntactically valid encoding, which is what this type does: a
+// LightCertifiedBlob handle whose chunk-digests root is the SHA-256 of the
+// payload. Handles are therefore distinct per payload and stable across
+// re-broadcasts of identical payloads. There is no certification, no chunking
+// and no expiry: expiration hints are recorded for assertions but never acted
+// on.
+//
+// It is safe for concurrent use, which matters because the plugin broadcasts
+// from its blob pump goroutine and fetches from the round goroutines. A single
+// instance may be shared by every oracle in a simulated DON, which models a
+// network where every broadcast blob is fetchable by every peer.
+type BlobBroadcastFetcher struct {
+	mu         sync.Mutex
+	blobs      map[string][]byte
+	hints      map[string]ocr3_1types.BlobExpirationHint
+	hintLog    []ocr3_1types.BlobExpirationHint
+	broadcasts int
+	broadcastB int
+	fetches    int
+	err        error
+}
+
+var _ ocr3_1types.BlobBroadcastFetcher = &BlobBroadcastFetcher{}
+
+// NewBlobBroadcastFetcher returns an empty in-memory broadcaster/fetcher.
+func NewBlobBroadcastFetcher() *BlobBroadcastFetcher {
+	return &BlobBroadcastFetcher{
+		blobs: map[string][]byte{},
+		hints: map[string]ocr3_1types.BlobExpirationHint{},
+	}
+}
+
+// SetBroadcastError makes every subsequent BroadcastBlob fail with err (nil
+// clears it), for exercising the plugin's broadcast-failure path: a round whose
+// blob could not be broadcast carries no stream values.
+func (b *BlobBroadcastFetcher) SetBroadcastError(err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.err = err
+}
+
+// BroadcastBlob stores the payload and returns a handle addressing it.
+func (b *BlobBroadcastFetcher) BroadcastBlob(_ context.Context, payload []byte, hint ocr3_1types.BlobExpirationHint) (ocr3_1types.BlobHandle, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.broadcasts++
+	if b.err != nil {
+		return ocr3_1types.BlobHandle{}, b.err
+	}
+
+	handle, encoded, err := handleFor(payload)
+	if err != nil {
+		return ocr3_1types.BlobHandle{}, err
+	}
+	b.blobs[string(encoded)] = append([]byte(nil), payload...)
+	b.hints[string(encoded)] = hint
+	b.hintLog = append(b.hintLog, hint)
+	b.broadcastB += len(payload)
+	return handle, nil
+}
+
+// FetchBlob returns the payload the handle addresses.
+func (b *BlobBroadcastFetcher) FetchBlob(_ context.Context, handle ocr3_1types.BlobHandle) ([]byte, error) {
+	encoded, err := handle.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("marshal blob handle: %w", err)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.fetches++
+	payload, ok := b.blobs[string(encoded)]
+	if !ok {
+		return nil, errors.New("llotest: no blob was broadcast for this handle")
+	}
+	return append([]byte(nil), payload...), nil
+}
+
+// Broadcasts reports how many times BroadcastBlob was called, including failed
+// calls.
+func (b *BlobBroadcastFetcher) Broadcasts() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.broadcasts
+}
+
+// BroadcastBytes reports the total payload bytes of successful broadcasts. It
+// lets a benchmark account for the bytes that left the observation when stream
+// values moved into a blob.
+func (b *BlobBroadcastFetcher) BroadcastBytes() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.broadcastB
+}
+
+// Fetches reports how many times FetchBlob was called.
+func (b *BlobBroadcastFetcher) Fetches() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.fetches
+}
+
+// Blobs reports how many distinct payloads are stored.
+func (b *BlobBroadcastFetcher) Blobs() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.blobs)
+}
+
+// Hints returns the expiration hints of all successful broadcasts, in call
+// order. Unlike ExpirationHint it distinguishes repeat broadcasts of an
+// identical payload, which are content-addressed to the same handle.
+func (b *BlobBroadcastFetcher) Hints() []ocr3_1types.BlobExpirationHint {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]ocr3_1types.BlobExpirationHint(nil), b.hintLog...)
+}
+
+// ExpirationHint returns the hint the payload was most recently broadcast with,
+// or nil if the payload was never broadcast.
+func (b *BlobBroadcastFetcher) ExpirationHint(payload []byte) ocr3_1types.BlobExpirationHint {
+	_, encoded, err := handleFor(payload)
+	if err != nil {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.hints[string(encoded)]
+}
+
+// NewBlobHandle returns a syntactically valid BlobHandle addressing payload,
+// for tests that need a handle without a broadcaster (e.g. to build an
+// observation referencing an unfetchable blob).
+func NewBlobHandle(payload []byte) (ocr3_1types.BlobHandle, error) {
+	handle, _, err := handleFor(payload)
+	return handle, err
+}
+
+// handleFor builds the handle addressing payload, plus its wire encoding.
+//
+// The encoding is the minimum a LightCertifiedBlob accepts: the sum-type
+// variant byte, then a protobuf carrying only chunk_digests_root (field 1, a
+// 32-byte value) set to the SHA-256 of the payload.
+func handleFor(payload []byte) (ocr3_1types.BlobHandle, []byte, error) {
+	digest := sha256.Sum256(payload)
+	encoded := make([]byte, 0, 3+sha256.Size)
+	encoded = append(encoded, blobHandleVariantLightCertifiedBlob)
+	encoded = append(encoded, 0x0A, sha256.Size) // proto field 1, wire type 2 (bytes), length 32
+	encoded = append(encoded, digest[:]...)
+
+	var handle ocr3_1types.BlobHandle
+	if err := handle.UnmarshalBinary(encoded); err != nil {
+		return ocr3_1types.BlobHandle{}, nil, fmt.Errorf("llotest: build blob handle: %w", err)
+	}
+	return handle, encoded, nil
+}

--- a/llo/dev/v31/llotest/blob_test.go
+++ b/llo/dev/v31/llotest/blob_test.go
@@ -1,0 +1,71 @@
+package llotest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+)
+
+func Test_BlobBroadcastFetcher_RoundTrip(t *testing.T) {
+	ctx := tests.Context(t)
+	b := NewBlobBroadcastFetcher()
+
+	h1, err := b.BroadcastBlob(ctx, []byte("first"), ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: 5})
+	require.NoError(t, err)
+	h2, err := b.BroadcastBlob(ctx, []byte("second"), ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: 6})
+	require.NoError(t, err)
+
+	// Handles are content-addressed, so concurrently-live blobs stay distinct.
+	e1, err := h1.MarshalBinary()
+	require.NoError(t, err)
+	e2, err := h2.MarshalBinary()
+	require.NoError(t, err)
+	require.NotEqual(t, e1, e2)
+
+	got1, err := b.FetchBlob(ctx, h1)
+	require.NoError(t, err)
+	require.Equal(t, []byte("first"), got1)
+	got2, err := b.FetchBlob(ctx, h2)
+	require.NoError(t, err)
+	require.Equal(t, []byte("second"), got2)
+
+	require.Equal(t, 2, b.Broadcasts())
+	require.Equal(t, 2, b.Fetches())
+	require.Equal(t, 2, b.Blobs())
+	require.Equal(t, len("first")+len("second"), b.BroadcastBytes())
+	require.Equal(t, ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: 6}, b.ExpirationHint([]byte("second")))
+	require.Equal(t, []ocr3_1types.BlobExpirationHint{
+		ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: 5},
+		ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: 6},
+	}, b.Hints())
+}
+
+func Test_BlobBroadcastFetcher_UnknownHandle(t *testing.T) {
+	ctx := tests.Context(t)
+	handle, err := NewBlobHandle([]byte("never broadcast"))
+	require.NoError(t, err)
+
+	_, err = NewBlobBroadcastFetcher().FetchBlob(ctx, handle)
+	require.ErrorContains(t, err, "no blob was broadcast")
+}
+
+func Test_BlobBroadcastFetcher_BroadcastError(t *testing.T) {
+	ctx := tests.Context(t)
+	b := NewBlobBroadcastFetcher()
+	b.SetBroadcastError(errors.New("broadcast unavailable"))
+
+	_, err := b.BroadcastBlob(ctx, []byte("payload"), ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: 5})
+	require.ErrorContains(t, err, "broadcast unavailable")
+	require.Equal(t, 1, b.Broadcasts())
+	require.Zero(t, b.Blobs())
+
+	b.SetBroadcastError(nil)
+	_, err = b.BroadcastBlob(ctx, []byte("payload"), ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: 5})
+	require.NoError(t, err)
+	require.Equal(t, 1, b.Blobs())
+}

--- a/llo/dev/v31/observation.go
+++ b/llo/dev/v31/observation.go
@@ -35,11 +35,11 @@ const observationWireVersion byte = 1
 // crafted handle count in decodeObservation.
 const maxObservationBlobHandles = 64
 
-// encodeObservation serializes an Observation. When the serialized stream-value
-// payload exceeds blobThreshold, the stream values are broadcast as a blob and
-// referenced by handle instead of being sent inline. A threshold of 0 disables
-// blob offloading. A nil broadcaster also disables offloading (values inline).
-func encodeObservation(ctx context.Context, obs Observation, seqNr uint64, blobThreshold int, bbf ocr3_1types.BlobBroadcaster) (ocrtypes.Observation, error) {
+// encodeObservation serializes an Observation into the v31 wire frame. Stream
+// values are never carried inline: they are broadcast as a blob by the blob pump
+// and referenced here by the marshaled handle(s) it produced. An observation
+// with no handles simply carries no stream values.
+func encodeObservation(obs Observation, handles [][]byte) (ocrtypes.Observation, error) {
 	main := &protocol.LLOObservationProto{
 		AttestedPredecessorRetirement: obs.AttestedPredecessorRetirement,
 		ShouldRetire:                  obs.ShouldRetire,
@@ -52,36 +52,6 @@ func encodeObservation(ctx context.Context, obs Observation, seqNr uint64, blobT
 		main.UpdateChannelDefinitions = make(map[uint32]*protocol.LLOChannelDefinitionProto, len(obs.UpdateChannelDefinitions))
 		for id, cd := range obs.UpdateChannelDefinitions {
 			main.UpdateChannelDefinitions[id] = protocol.ChannelDefinitionToProto(cd)
-		}
-	}
-
-	streamValues, err := streamValuesToProto(obs.StreamValues)
-	if err != nil {
-		return nil, err
-	}
-
-	// Decide whether to offload stream values to a blob.
-	var handles [][]byte
-	if len(streamValues) > 0 {
-		svOnly := &protocol.LLOObservationProto{StreamValues: streamValues}
-		svBytes, err := proto.Marshal(svOnly)
-		if err != nil {
-			return nil, fmt.Errorf("marshal stream values: %w", err)
-		}
-		if blobThreshold > 0 && bbf != nil && len(svBytes) > blobThreshold {
-			handle, berr := bbf.BroadcastBlob(ctx, svBytes, ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: seqNr + 1})
-			if berr != nil {
-				// Blob broadcast failure must not fail Observation; fall back to inline.
-				main.StreamValues = streamValues
-			} else {
-				hb, herr := handle.MarshalBinary()
-				if herr != nil {
-					return nil, fmt.Errorf("marshal blob handle: %w", herr)
-				}
-				handles = append(handles, hb)
-			}
-		} else {
-			main.StreamValues = streamValues
 		}
 	}
 

--- a/llo/dev/v31/observation.go
+++ b/llo/dev/v31/observation.go
@@ -146,8 +146,15 @@ func decodeObservation(ctx context.Context, raw ocrtypes.Observation, bf ocr3_1t
 		if ferr != nil {
 			return Observation{}, &blobFetchError{fmt.Errorf("fetch blob: %w", ferr)}
 		}
+		// Framing/codec faults are deterministic across oracles (every one sees
+		// the same bytes), so they stay plain errors and drop this observation
+		// alone, unlike the fetch failure above.
+		raw, err := decodeBlobPayload(payload)
+		if err != nil {
+			return Observation{}, err
+		}
 		chunk := &protocol.LLOObservationProto{}
-		if err := proto.Unmarshal(payload, chunk); err != nil {
+		if err := proto.Unmarshal(raw, chunk); err != nil {
 			return Observation{}, fmt.Errorf("unmarshal blob payload: %w", err)
 		}
 		if obs.StreamValues == nil {

--- a/llo/dev/v31/plugin.go
+++ b/llo/dev/v31/plugin.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 
-	"github.com/smartcontractkit/chainlink-data-streams/llo/datasource"
 	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
@@ -55,15 +54,13 @@ type Plugin struct {
 	OutcomeTelemetryCh chan<- *protocol.LLOOutcomeTelemetry
 	ReportTelemetryCh  chan<- *protocol.LLOReportTelemetry
 
-	MaxDurationObservation time.Duration
+	// pump gathers stream observations and broadcasts them as blobs off the OCR
+	// critical path. Observation only picks up the handle it parked.
+	pump *blobPump
 
 	// From offchain config
 	ProtocolVersion                     uint32
 	DefaultMinReportIntervalNanoseconds uint64
-
-	// BlobThreshold is the serialized stream-value payload size (bytes) above
-	// which observations offload stream values to a blob. 0 disables offloading.
-	BlobThreshold int
 }
 
 // Query is empty: LLO oracles do not coordinate on what to observe.
@@ -71,10 +68,12 @@ func (p *Plugin) Query(ctx context.Context, seqNr uint64, _ ocr3_1types.KeyValue
 	return nil, nil
 }
 
-// Observation reads current state from the KeyValueState, gathers stream
-// observations, votes on channel changes, and returns a (possibly blob-backed)
-// serialized observation.
-func (p *Plugin) Observation(ctx context.Context, seqNr uint64, _ ocrtypes.AttributedQuery, kvReader ocr3_1types.KeyValueStateReader, bbf ocr3_1types.BlobBroadcastFetcher) (ocrtypes.Observation, error) {
+// Observation reads current state from the KeyValueState, votes on channel
+// changes, and returns a serialized observation referencing the blob of stream
+// values most recently gathered by the blob pump.
+// The per-round BlobBroadcastFetcher is unused: broadcasting happens in the blob
+// pump, which holds the identical fetcher handed to the factory.
+func (p *Plugin) Observation(_ context.Context, seqNr uint64, _ ocrtypes.AttributedQuery, kvReader ocr3_1types.KeyValueStateReader, _ ocr3_1types.BlobBroadcastFetcher) (ocrtypes.Observation, error) {
 	if seqNr < 1 {
 		return nil, fmt.Errorf("got invalid seqnr=%d, must be >=1", seqNr)
 	} else if seqNr == 1 {
@@ -88,6 +87,7 @@ func (p *Plugin) Observation(ctx context.Context, seqNr uint64, _ ocrtypes.Attri
 	}
 
 	var obs Observation
+	var streams []llotypes.StreamID
 
 	if state.lifeCycleStage == protocol.LifeCycleStageRetired {
 		p.Logger.Debugw("Node is retired, will generate empty observation", "stage", "Observation", "seqNr", seqNr)
@@ -110,26 +110,26 @@ func (p *Plugin) Observation(ctx context.Context, seqNr uint64, _ ocrtypes.Attri
 
 		p.voteOnChannels(&obs, state, seqNr)
 
-		if len(state.channelDefinitions) > 0 {
-			obs.StreamValues = make(protocol.StreamValues)
-			for _, cd := range state.channelDefinitions {
-				if cd.Tombstone {
-					continue
-				}
-				for _, strm := range cd.Streams {
-					if strm.Aggregator == llotypes.AggregatorCalculated {
-						continue
-					}
-					obs.StreamValues[strm.StreamID] = nil
-				}
-			}
+		streams = observableStreams(state)
+	}
 
-			observationCtx, cancel := context.WithTimeout(ctx, p.MaxDurationObservation)
-			defer cancel()
-			opts := datasource.NewDSOpts(p.Config.VerboseLogging, seqNr, p.ConfigDigest, time.Now(), state.lifeCycleStage)
-			if err = p.DataSource.Observe(observationCtx, obs.StreamValues, opts); err != nil {
-				return nil, fmt.Errorf("DataSource.Observe error: %w", err)
-			}
+	// Stream values are gathered asynchronously by the blob pump and are always
+	// carried by a blob, never inline. Publish this round's context, then pick up
+	// whatever the pump has ready; a round that finds nothing usable emits an
+	// observation carrying only votes and its timestamp. Missing values cost the
+	// affected streams that round's aggregate (which needs >F values), not the
+	// round itself.
+	var handles [][]byte
+	// A nil pump means stream values were never wired up (or the plugin was built
+	// without the factory); rounds that observe no streams have nothing for the
+	// pump to gather, so neither publishes input nor consumes a snapshot.
+	if p.pump != nil && len(streams) > 0 {
+		p.pump.SetInput(pumpInput{streams: streams, seqNr: seqNr, lifeCycleStage: state.lifeCycleStage})
+
+		if snap, reason := p.pump.Take(seqNr); snap != nil {
+			handles = append(handles, snap.handleBytes)
+		} else {
+			p.Logger.Debugw("No usable stream-value snapshot for this round", "stage", "Observation", "seqNr", seqNr, "reason", reason, "misses", p.pump.Misses(), "cycles", p.pump.Cycles())
 		}
 	}
 
@@ -139,7 +139,34 @@ func (p *Plugin) Observation(ctx context.Context, seqNr uint64, _ ocrtypes.Attri
 	}
 	obs.UnixTimestampNanoseconds = uint64(obsTSNanos)
 
-	return encodeObservation(ctx, obs, seqNr, p.BlobThreshold, bbf)
+	return encodeObservation(obs, handles)
+}
+
+// observableStreams lists the streams a round should observe: every stream of
+// every live channel, minus calculated streams (which are derived in
+// StateTransition rather than observed).
+func observableStreams(state *kvState) []llotypes.StreamID {
+	if len(state.channelDefinitions) == 0 {
+		return nil
+	}
+	seen := make(map[llotypes.StreamID]struct{})
+	streams := make([]llotypes.StreamID, 0, len(state.channelDefinitions))
+	for _, cd := range state.channelDefinitions {
+		if cd.Tombstone {
+			continue
+		}
+		for _, strm := range cd.Streams {
+			if strm.Aggregator == llotypes.AggregatorCalculated {
+				continue
+			}
+			if _, dup := seen[strm.StreamID]; dup {
+				continue
+			}
+			seen[strm.StreamID] = struct{}{}
+			streams = append(streams, strm.StreamID)
+		}
+	}
+	return streams
 }
 
 // voteOnChannels populates obs.RemoveChannelIDs / obs.UpdateChannelDefinitions
@@ -256,5 +283,8 @@ func (p *Plugin) ShouldTransmitAcceptedReport(context.Context, uint64, ocr3types
 }
 
 func (p *Plugin) Close() error {
+	if p.pump != nil {
+		p.pump.Close()
+	}
 	return nil
 }

--- a/llo/dev/v31/plugin_test.go
+++ b/llo/dev/v31/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,7 @@ import (
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
+	"github.com/smartcontractkit/chainlink-data-streams/llo/dev/v31/llotest"
 	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
 	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol/calculated"
 	"github.com/smartcontractkit/chainlink-data-streams/llo/reportcodec"
@@ -93,6 +95,11 @@ func (b *errBroadcaster) FetchBlob(context.Context, ocr3_1types.BlobHandle) ([]b
 
 var _ ocr3_1types.BlobBroadcastFetcher = &errBroadcaster{}
 
+// The blob-carrying paths use the exported in-memory double from llotest, which
+// is also what non-libocr hosts (benchmarks, simulation harnesses) should pass
+// to NewReportingPlugin in place of a nil BlobBroadcastFetcher.
+func newFakeBroadcaster() *llotest.BlobBroadcastFetcher { return llotest.NewBlobBroadcastFetcher() }
+
 // --- helpers ---
 
 func testPlugin(t *testing.T) *Plugin {
@@ -109,20 +116,57 @@ func testPlugin(t *testing.T) *Plugin {
 	}
 }
 
+// attachPump wires a plugin to a data source and broadcaster through a blob pump
+// with test-friendly timings, and stops it at the end of the test.
+func attachPump(t *testing.T, p *Plugin, ds DataSource, bbf ocr3_1types.BlobBroadcastFetcher) *blobPump {
+	t.Helper()
+	p.DataSource = ds
+	p.pump = newBlobPump(bbf, ds, logger.Test(t), p.ConfigDigest, true, tests.WaitTimeout(t), time.Minute, DefaultBlobLifetimeRounds)
+	p.pump.Start()
+	t.Cleanup(func() { require.NoError(t, p.Close()) })
+	return p.pump
+}
+
 func ao(observer int, obsBytes []byte) ocrtypes.AttributedObservation {
 	return ocrtypes.AttributedObservation{Observer: commontypes.OracleID(observer), Observation: obsBytes}
 }
 
+// mustEncodeObs encodes an observation for use as a StateTransition fixture.
+// The production encoder never emits stream values inline (they always travel in
+// a blob), but the decoder still accepts inline values, so tests build fixtures
+// that way to avoid a fetcher on every StateTransition call.
 func mustEncodeObs(t *testing.T, obs Observation) []byte {
 	t.Helper()
-	b, err := encodeObservation(context.Background(), obs, 2, 0, nil)
+	b, err := encodeObservation(obs, nil)
 	require.NoError(t, err)
-	return b
+	if len(obs.StreamValues) == 0 {
+		return b
+	}
+	sv, err := streamValuesToProto(obs.StreamValues)
+	require.NoError(t, err)
+	main := &protocol.LLOObservationProto{
+		AttestedPredecessorRetirement: obs.AttestedPredecessorRetirement,
+		ShouldRetire:                  obs.ShouldRetire,
+		UnixTimestampNanoseconds:      obs.UnixTimestampNanoseconds,
+		StreamValues:                  sv,
+	}
+	for id := range obs.RemoveChannelIDs {
+		main.RemoveChannelIDs = append(main.RemoveChannelIDs, id)
+	}
+	if len(obs.UpdateChannelDefinitions) > 0 {
+		main.UpdateChannelDefinitions = make(map[uint32]*protocol.LLOChannelDefinitionProto, len(obs.UpdateChannelDefinitions))
+		for id, cd := range obs.UpdateChannelDefinitions {
+			main.UpdateChannelDefinitions[id] = protocol.ChannelDefinitionToProto(cd)
+		}
+	}
+	mainBytes, err := proto.Marshal(main)
+	require.NoError(t, err)
+	return frameObservation(nil, mainBytes)
 }
 
 // --- tests ---
 
-func Test_Observation_InlineRoundTrip(t *testing.T) {
+func Test_Observation_WireRoundTrip(t *testing.T) {
 	ctx := tests.Context(t)
 	obs := Observation{
 		ShouldRetire:             true,
@@ -131,11 +175,8 @@ func Test_Observation_InlineRoundTrip(t *testing.T) {
 		UpdateChannelDefinitions: llotypes.ChannelDefinitions{
 			1: {ReportFormat: llotypes.ReportFormatJSON, Streams: []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}}},
 		},
-		StreamValues: protocol.StreamValues{
-			100: protocol.ToDecimal(decimal.NewFromInt(42)),
-		},
 	}
-	enc, err := encodeObservation(ctx, obs, 2, 0, nil)
+	enc, err := encodeObservation(obs, nil)
 	require.NoError(t, err)
 
 	got, err := decodeObservation(ctx, enc, nil)
@@ -145,8 +186,57 @@ func Test_Observation_InlineRoundTrip(t *testing.T) {
 	assert.Equal(t, obs.UnixTimestampNanoseconds, got.UnixTimestampNanoseconds)
 	assert.Equal(t, obs.RemoveChannelIDs, got.RemoveChannelIDs)
 	require.Contains(t, got.UpdateChannelDefinitions, llotypes.ChannelID(1))
-	require.Contains(t, got.StreamValues, llotypes.StreamID(100))
-	assert.True(t, equalStreamValue(obs.StreamValues[100], got.StreamValues[100]))
+	require.Empty(t, got.StreamValues)
+}
+
+// Test_Observation_StreamValuesNeverInline pins the invariant that stream values
+// are only ever disseminated by blob: an encoded observation carries no inline
+// stream values even when the Observation struct holds some.
+func Test_Observation_StreamValuesNeverInline(t *testing.T) {
+	ctx := tests.Context(t)
+	obs := Observation{
+		UnixTimestampNanoseconds: 1,
+		StreamValues:             protocol.StreamValues{100: protocol.ToDecimal(decimal.NewFromInt(42))},
+	}
+	enc, err := encodeObservation(obs, nil)
+	require.NoError(t, err)
+
+	got, err := decodeObservation(ctx, enc, nil)
+	require.NoError(t, err)
+	require.Empty(t, got.StreamValues, "stream values must travel in a blob, never inline")
+}
+
+// Test_Observation_BlobRoundTrip covers the blob path end to end: the pump's
+// serialized payload is broadcast, referenced by handle, and recovered by the
+// decoder through the fetcher.
+func Test_Observation_BlobRoundTrip(t *testing.T) {
+	ctx := tests.Context(t)
+	sv := protocol.StreamValues{}
+	for i := 0; i < 500; i++ {
+		sv[llotypes.StreamID(i)] = protocol.ToDecimal(decimal.NewFromInt(int64(i)))
+	}
+	payload, err := marshalStreamValues(sv)
+	require.NoError(t, err)
+
+	bc := newFakeBroadcaster()
+	handle, err := bc.BroadcastBlob(ctx, payload, ocr3_1types.BlobExpirationHintSequenceNumber{SeqNr: 5})
+	require.NoError(t, err)
+	handleBytes, err := handle.MarshalBinary()
+	require.NoError(t, err)
+
+	enc, err := encodeObservation(Observation{UnixTimestampNanoseconds: 1}, [][]byte{handleBytes})
+	require.NoError(t, err)
+
+	got, err := decodeObservation(ctx, enc, bc)
+	require.NoError(t, err)
+	require.Len(t, got.StreamValues, len(sv))
+	require.True(t, equalStreamValue(sv[100], got.StreamValues[100]))
+
+	// Without a fetcher the reference is unusable, and that must be classified
+	// as a node-local blob-fetch failure rather than a malformed observation.
+	_, err = decodeObservation(ctx, enc, nil)
+	var bfErr *blobFetchError
+	require.ErrorAs(t, err, &bfErr)
 }
 
 func Test_StateTransition_Bootstrap(t *testing.T) {
@@ -299,27 +389,6 @@ func Test_StateTransition_Determinism_ShuffledObservations(t *testing.T) {
 
 	require.Equal(t, precA, precB, "precursor must be identical regardless of observation order")
 	require.Equal(t, kvA.m, kvB.m, "KV write-set must be identical regardless of observation order")
-}
-
-func Test_Observation_BlobOffloadFallback(t *testing.T) {
-	ctx := tests.Context(t)
-
-	// Build an observation whose serialized stream values exceed a tiny threshold.
-	sv := protocol.StreamValues{}
-	for i := 0; i < 500; i++ {
-		sv[llotypes.StreamID(i)] = protocol.ToDecimal(decimal.NewFromInt(int64(i)))
-	}
-	obs := Observation{UnixTimestampNanoseconds: 1, StreamValues: sv}
-
-	bc := &errBroadcaster{}
-	enc, err := encodeObservation(ctx, obs, 2, 16, bc) // 16-byte threshold forces an offload attempt
-	require.NoError(t, err)
-	require.True(t, bc.broadcastCalled, "expected a blob broadcast attempt for a large observation")
-
-	// Broadcast failed, so values must have fallen back to inline and decode without a fetcher.
-	got, err := decodeObservation(ctx, enc, nil)
-	require.NoError(t, err)
-	require.Len(t, got.StreamValues, len(sv))
 }
 
 func Test_decodeObservation_RejectsHugeHandleCount(t *testing.T) {
@@ -674,17 +743,19 @@ func Test_HistoryBackfill(t *testing.T) {
 	require.Equal(t, llotypes.ReportFormatJSON, reports[0].ReportWithInfo.Info.ReportFormat)
 }
 
-// validBlobHandleBytes returns the wire encoding of a syntactically-valid (but
-// meaningless) BlobHandle: the sum-type variant byte 0x01 (LightCertifiedBlob)
-// followed by a protobuf carrying only chunk_digests_root (field 1) = 32 bytes,
-// which is the minimum LightCertifiedBlob.UnmarshalBinary accepts. It lets a
-// test build an observation that *references* a blob (so decodeObservation
-// reaches the fetch path); the handle can never be fetched because there is no
-// real blob behind it. A real handle cannot be constructed outside libocr.
+// validBlobHandleBytes returns the wire encoding of a syntactically valid handle
+// for a blob nobody broadcast. It lets a test build an observation that
+// *references* a blob (so decodeObservation reaches the fetch path) while the
+// fetch is guaranteed to fail.
 func validBlobHandleBytes() []byte {
-	b := []byte{0x01}         // BlobHandle sum-type variant: LightCertifiedBlob
-	b = append(b, 0x0A, 0x20) // proto field 1 (bytes), length 32 (== sha256.Size)
-	b = append(b, make([]byte, 32)...)
+	handle, err := llotest.NewBlobHandle([]byte("never broadcast"))
+	if err != nil {
+		panic(err)
+	}
+	b, err := handle.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
 	return b
 }
 


### PR DESCRIPTION
Stream values are now gathered by a background blob pump with the BlobBroadcastFetcher provided to the factory. Each cycle observes the streams and seqNr known at the time, serializes the values, broadcasts them, and parks the marshaled handle for the next observation. Observation keeps only the cheap synchronous work (KV load, retirement, channel votes), publishes the round context, and picks up the handles prepared by the pump.

Cadence is consumption driven, a cycle is kicked whenever Observation takes or discards a snapshot, so the pump rate tracks the round rate without the plugin needing to know OCR round cadence, and no blob is broadcasted unnecessarily. Pump cycles are serial so only one is ever in flight. There is no idle watchdog, snapshot usability is bounded by sequence number, so refreshing while no rounds run would only produce snapshots already too old to use.

Stream values are now carried exclusively by blobs and never inline.

A round that finds nothing usable (cold start, failed cycle, stale snapshot) emits an observation carrying only votes and its timestamp.

Adds llo/dev/v31/llotest, exporting an in-memory, content-addressed BlobBroadcastFetcher that makes the broadcast/fetch/merge round trip testable.