### PR TITLE
[DS-3869] stateful calculated streams

### DIFF
--- a/llo/dev/v31/backfill.go
+++ b/llo/dev/v31/backfill.go
@@ -16,12 +16,12 @@ import (
 // watermark and strictly before obsTsNanos. This mirrors the v30
 // SelectBackfillCandidate but operates on plain fields (shared by precursor and
 // kvState) and returns a bool instead of an UnreportableChannelError.
-func selectBackfillCandidate(defs llotypes.ChannelDefinitions, validAfter map[llotypes.ChannelID]uint64, obsTsNanos uint64, backfillCID llotypes.ChannelID) (tsNanos uint64, rawTS uint64, opts protocol.HistoryBackfillOpts, ok bool) {
+func selectBackfillCandidate(defs llotypes.ChannelDefinitions, validAfter map[llotypes.ChannelID]uint64, obsTsNanos uint64, backfillCID llotypes.ChannelID, optsCache *protocol.OptsCache) (tsNanos uint64, rawTS uint64, opts protocol.HistoryBackfillOpts, ok bool) {
 	cd, exists := defs[backfillCID]
 	if !exists || cd.ReportFormat != llotypes.ReportFormatHistoryBackfill {
 		return 0, 0, protocol.HistoryBackfillOpts{}, false
 	}
-	o, err := protocol.ParseHistoryBackfillOpts(cd.Opts)
+	o, err := protocol.GetHistoryBackfillOpts(optsCache, cd, backfillCID)
 	if err != nil {
 		return 0, 0, protocol.HistoryBackfillOpts{}, false
 	}
@@ -41,7 +41,12 @@ func selectBackfillCandidate(defs llotypes.ChannelDefinitions, validAfter map[ll
 	var bestRaw, bestNanos uint64
 	found := false
 	for rawKey := range o.Observations {
-		tsN := protocol.ObservationTimestampKeyToNanoseconds(rawKey, res)
+		tsN, ok := protocol.ObservationTimestampKeyToNanoseconds(rawKey, res)
+		if !ok {
+			// Not expressible in nanoseconds; scaling it would wrap into a
+			// timestamp that looks like a valid past one.
+			continue
+		}
 		if tsN >= obsTsNanos || tsN <= watermark {
 			continue
 		}

--- a/llo/dev/v31/doc.go
+++ b/llo/dev/v31/doc.go
@@ -127,7 +127,82 @@
 // aggregates that are not otherwise persisted.
 //
 // Calculated streams (EVMABIEncodeUnpackedExpr channels) are supported via the
-// expression engine in calculated.go, run at the end of StateTransition.
+// expression engine in calculated.go, run at the end of StateTransition. A
+// channel whose expressions did not produce every calculated stream its opts
+// declare is not reportable, regardless of DisableNilStreamValues: the codec
+// would have nothing to encode, so the report is skipped, and counting the
+// channel as reported would advance validAfter over a round that emitted
+// nothing.
+//
+// # Stream history
+//
+// Expressions can read a window of a stream's past agreed values with
+// History(s<streamID>, <depth>) (see llo/protocol/calculated). Windows are
+// persisted per (streamID, aggregator) pair — the aggregator is part of the
+// identity because the same stream may be aggregated differently by different
+// channels, and interleaving those series would be silently wrong:
+//
+//	hh/<streamID BE uint32><aggregator BE uint32>              -> LLOStreamHistoryHeaderProto
+//	hc/<streamID BE uint32><aggregator BE uint32><slot BE u32> -> LLOStreamHistoryChunkProto
+//	hidx                                                       -> sorted (streamID, aggregator) pairs
+//	hv                                                         -> history layout version
+//
+// A window is a ring of chunks rather than one value: a slot holds
+// MaxHistoryChunkRecords records, and a round rewrites only the newest one.
+// Sealed chunks are immutable for as long as they are retained and eviction is a
+// delete, so a pair's per-round write cost is a function of the chunk size, not
+// of its depth — about 2 KiB rather than 60 KiB for a full quote window at
+// maximum depth. Reads cost depth/chunkSize point reads instead of one, and only
+// the chunks covering what was asked for are read.
+//
+// The header alone says which chunks are retained, how full each is and when
+// each starts, so a round decides whether there is enough depth, which chunks to
+// read, whether a value may be appended and which chunk falls out without
+// opening a chunk at all. A pair still warming up therefore costs one read.
+//
+// The ring is a fixed slot space rather than an unbounded sequence because the
+// in-round reader has no range scan: if a header cannot be decoded there is no
+// way to discover which chunk keys exist, and a bounded space makes recovery a
+// blind delete of every slot. A chunk left by an earlier lap carries a sequence
+// the header no longer retains, which is how slot reuse stays safe.
+//
+// hidx exists for the same no-range-scan reason: it is what lets windows for
+// pairs no channel references any more be found and deleted. hv records the
+// layout; a mismatch drops every stored window and re-warms, which is the whole
+// migration story while v31 is under llo/dev.
+//
+// Per round, in StateTransition:
+//
+//   - computeHistoryRequirements derives the depth each pair needs (the deepest
+//     any live channel's expressions ask for) from the channel definitions and
+//     their opts. Both are replicated and expression analysis is a pure function
+//     of the expression string, so every oracle computes the same depths — they
+//     become persisted state. Pairs beyond MaxHistoryPairs are denied history
+//     entirely, in (streamID, aggregator) order; channels reading them do not
+//     report, rather than silently evaluating over a shorter window. The pair cap
+//     is the only admission rule: per-round cost no longer depends on depth, so
+//     MaxHistoryPairs of them fit the byte budget by construction.
+//   - aggregate appends each required pair's agreed value, timestamped with the
+//     value's own observation time for timestamped aggregates and the round's
+//     consensus observation timestamp otherwise. An append only takes effect if
+//     it is strictly newer than the newest stored record, which is what stops a
+//     carried-forward t/ value from being counted once per round until it
+//     refreshes. A pair with no aggregate this round contributes nothing: a gap
+//     is honest, a repeated value is not.
+//   - ProcessCalculatedStreams reads through the same store. An expression whose
+//     window is still shallower than requested is not evaluated and writes no
+//     aggregate, so the channel is not reportable and validAfter does not
+//     advance. This is the warmup gate, and it means adding a History call to a
+//     live channel stops it reporting for as many rounds as the depth requested.
+//   - flushKV writes each modified window's header and newest chunk, deletes the
+//     chunks that fell out and the pairs no live channel requires, and rewrites
+//     hidx at most once.
+//
+// Each of a pair's keys is read at most once and written at most once per round
+// however many channels or expressions reference it, which is what keeps history
+// inside the per-round key-value budget. A window that cannot be decoded — bad
+// header, missing chunk, or one that does not match the header — is discarded
+// whole and re-warmed rather than failing the round.
 //
 // History-backfill channels are supported: backfill.go selects the next
 // observation to emit (advancing a per-channel watermark stored in validAfter),

--- a/llo/dev/v31/doc.go
+++ b/llo/dev/v31/doc.go
@@ -118,8 +118,7 @@
 //
 // DisableNilStreamValues (a channel with any nil stream aggregate is
 // unreportable; for expression channels the expected calculated streams are
-// taken from the channel's opts rather than from the definition, since the
-// definition only lists them once evaluation succeeded), cross-round
+// taken from the channel's opts, which is where they are declared), cross-round
 // timestamped-aggregate carry-forward (in the r/agg record, newer-wins
 // monotonicity), and best-effort outcome/report telemetry are also implemented.
 // Reportability is persisted per channel each round (also in r/agg) so the next
@@ -127,12 +126,27 @@
 // aggregates that are not otherwise persisted.
 //
 // Calculated streams (EVMABIEncodeUnpackedExpr channels) are supported via the
-// expression engine in calculated.go, run at the end of StateTransition. A
-// channel whose expressions did not produce every calculated stream its opts
-// declare is not reportable, regardless of DisableNilStreamValues: the codec
-// would have nothing to encode, so the report is skipped, and counting the
-// channel as reported would advance validAfter over a round that emitted
-// nothing.
+// expression engine in llo/protocol/calculated, run at the end of
+// StateTransition. A channel whose expressions did not produce every calculated
+// stream its opts declare is not reportable, regardless of
+// DisableNilStreamValues: the codec would have nothing to encode, so the report
+// is skipped, and counting the channel as reported would advance validAfter over
+// a round that emitted nothing.
+//
+// Evaluation writes stream aggregates and nothing else. It does not touch the
+// channel definitions, so a persisted definition is exactly what was voted on
+// and no derived state reaches the replicated key-value store. Which streams a
+// channel reports — its observed streams followed by one calculated stream per
+// declared expression, in declaration order — is derived on demand by
+// protocol.EffectiveStreams, which is a pure function of the definition and its
+// opts and therefore identical on every oracle. Report assembly must go through
+// it rather than reading cd.Streams, since the trailing calculated values are
+// what ReportCodecEVMABIEncodeUnpackedExpr encodes as its payload.
+//
+// v3.0 instead appends the calculated streams to the definitions it commits in
+// its outcome (calculated.ProcessCalculatedStreamsWithDefinitionAppend), which
+// EffectiveStreams drops any such inline entries before appending the declared
+// ones, so it reads definitions written by either version identically.
 //
 // # Stream history
 //

--- a/llo/dev/v31/history.go
+++ b/llo/dev/v31/history.go
@@ -49,6 +49,11 @@ type historyStore struct {
 	// re-warmed from empty; this is kept for telemetry and to force the bad
 	// bytes to be overwritten.
 	corrupt map[histKey]bool
+	// reclaimed lists the pairs whose stored history was deleted this round,
+	// either as orphans or by a layout reset. Telemetry only: per-pair gauges
+	// are keyed by stream and aggregator, so a pair that goes away has to be
+	// deleted from them or it reports its final value forever.
+	reclaimed []histKey
 	// oversized counts agreed values dropped for exceeding the per-record size
 	// cap, each of which leaves a gap in a series. Telemetry only.
 	oversized int
@@ -94,16 +99,31 @@ func newHistoryStore(r ocr3_1types.KeyValueStateReader, lggr logger.Logger) (*hi
 		layoutReset: version != historyLayoutVersion,
 	}
 
+	for _, k := range keys {
+		s.index[k] = true
+	}
+
 	if s.layoutReset {
 		if len(keys) > 0 {
 			lggr.Infow("Stream history layout changed; dropping stored windows and re-warming",
 				"storedVersion", version, "version", historyLayoutVersion, "pairs", len(keys))
 		}
 		s.abandoned = len(keys)
-		return s, nil
-	}
-	for _, k := range keys {
-		s.index[k] = true
+		// Every indexed pair is installed as an already-reset window, without
+		// reading its header. Two things depend on this:
+		//
+		//   - a pair required this round re-warms from empty. Reading the header
+		//     instead would adopt whatever the old layout stored whenever those
+		//     bytes still happen to decode, which is exactly what a version bump
+		//     exists to prevent. A layout change is a reset and a re-warm, not a
+		//     dual-read shim.
+		//   - a pair not required this round is still in the index, so the
+		//     orphan pass finds it and deletes its keys. Dropping the index here
+		//     would strand them: the rewritten index would not name them, so no
+		//     later round could find them either.
+		for _, k := range keys {
+			s.windows[k] = protocol.ResetRingWindow()
+		}
 	}
 	return s, nil
 }
@@ -332,6 +352,7 @@ func (s *historyStore) Flush(w ocr3_1types.KeyValueStateReadWriter) error {
 			return err
 		}
 		delete(s.index, k)
+		s.reclaimed = append(s.reclaimed, k)
 		indexChanged = true
 	}
 

--- a/llo/dev/v31/history.go
+++ b/llo/dev/v31/history.go
@@ -1,0 +1,430 @@
+package llo
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol/calculated"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+)
+
+// historyStore satisfies the read side of the shared expression engine.
+var _ calculated.HistoryReader = (*historyStore)(nil)
+
+// historyStore is the per-round working set of stream history windows. It is
+// created fresh in each StateTransition and discarded at the end of it; nothing
+// carries across rounds except what Flush persists.
+//
+// It is the only thing in the plugin that touches history keys, and it holds
+// two guarantees the design depends on:
+//
+//   - each key is read at most once and written at most once per round, however
+//     many channels or expressions reference the pair. Ten channels sharing
+//     History(s101, 300) cause one set of reads and one set of writes.
+//   - a round reads only what it needs. Windows are chunked (see
+//     protocol.RingWindow), so appending touches the newest chunk, reading n
+//     records touches the chunks covering them, and a pair that is still warming
+//     up costs a single header read — the shortfall is decided from the header
+//     without opening a chunk at all.
+type historyStore struct {
+	r    ocr3_1types.KeyValueStateReader
+	lggr logger.Logger
+
+	// windows memoizes the working copy of each pair touched this round,
+	// including negative results: a pair present here has already been read.
+	windows map[histKey]*protocol.RingWindow
+	// required is the depth admitted for each pair this round. Kept separately
+	// from the windows so that discarding a corrupt one does not lose it.
+	required map[histKey]uint32
+	// index is the persisted set of pairs that have a stored window, used to
+	// find orphans without a range scan.
+	index map[histKey]bool
+	// corrupt records pairs whose stored window failed to decode. They are
+	// re-warmed from empty; this is kept for telemetry and to force the bad
+	// bytes to be overwritten.
+	corrupt map[histKey]bool
+	// oversized counts agreed values dropped for exceeding the per-record size
+	// cap, each of which leaves a gap in a series. Telemetry only.
+	oversized int
+	// written records the bytes each pair's keys took this round, which is what
+	// the per-round byte budget is actually spent on. Telemetry only.
+	written map[histKey]int
+	// chunkWrites counts chunk values written this round. Telemetry only.
+	chunkWrites int
+
+	// layoutReset is set when the stored layout version is not the current one.
+	// The stored windows are abandoned rather than read, and Flush records the
+	// current version even if there was nothing else to write.
+	layoutReset bool
+	// abandoned is how many indexed pairs the layout reset threw away. Non-zero
+	// means the stored index is stale and must be rewritten even if this round
+	// warms nothing.
+	abandoned int
+}
+
+// newHistoryStore loads the history index and returns a store for this round.
+//
+// If the stored layout version is not the current one, the index is treated as
+// empty and every window re-warms from scratch: v31 is under llo/dev, so a
+// layout change is a reset and a re-warm, not a dual-read shim.
+func newHistoryStore(r ocr3_1types.KeyValueStateReader, lggr logger.Logger) (*historyStore, error) {
+	keys, err := readHistoryIndex(r)
+	if err != nil {
+		return nil, fmt.Errorf("read history index: %w", err)
+	}
+	version, err := readHistoryLayoutVersion(r)
+	if err != nil {
+		return nil, fmt.Errorf("read history layout version: %w", err)
+	}
+
+	s := &historyStore{
+		r:           r,
+		lggr:        lggr,
+		windows:     make(map[histKey]*protocol.RingWindow, len(keys)),
+		required:    map[histKey]uint32{},
+		index:       make(map[histKey]bool, len(keys)),
+		corrupt:     map[histKey]bool{},
+		written:     map[histKey]int{},
+		layoutReset: version != historyLayoutVersion,
+	}
+
+	if s.layoutReset {
+		if len(keys) > 0 {
+			lggr.Infow("Stream history layout changed; dropping stored windows and re-warming",
+				"storedVersion", version, "version", historyLayoutVersion, "pairs", len(keys))
+		}
+		s.abandoned = len(keys)
+		return s, nil
+	}
+	for _, k := range keys {
+		s.index[k] = true
+	}
+	return s, nil
+}
+
+// window returns the working copy for a pair, reading its header on first use.
+//
+// A header that fails to decode is replaced with a reset window, which deletes
+// the pair's whole slot space on flush. Corruption must not fail the round:
+// libocr requires malformed stored entries to be handled gracefully, and the
+// cost of discarding is a warmup, not a halt.
+func (s *historyStore) window(k histKey) (*protocol.RingWindow, error) {
+	if w, ok := s.windows[k]; ok {
+		return w, nil
+	}
+
+	header, err := readHistoryHeader(s.r, k.streamID, k.aggregator)
+	if err != nil {
+		if !errors.Is(err, protocol.ErrCorruptStreamHistory) {
+			// A genuine read failure, not bad data. Failing the round is right:
+			// every oracle will retry, and continuing would silently drop
+			// history that is actually there.
+			return nil, err
+		}
+		return s.reset(k, err), nil
+	}
+
+	w := protocol.NewRingWindow(header)
+	s.windows[k] = w
+	return w, nil
+}
+
+// reset discards a pair's stored window and returns an empty one whose write set
+// deletes every slot of the ring.
+//
+// Blind deletion of the whole slot space is why the layout uses a fixed ring:
+// the header is the only thing that says which chunks exist, so when it cannot
+// be trusted there is nothing else to consult. The admitted depth is reapplied
+// so the pair starts warming again immediately.
+func (s *historyStore) reset(k histKey, cause error) *protocol.RingWindow {
+	s.lggr.Errorw("Discarding corrupt stream history; re-warming from empty",
+		"err", cause, "streamID", k.streamID, "aggregator", k.aggregator)
+	s.corrupt[k] = true
+
+	w := protocol.ResetRingWindow()
+	if n := s.required[k]; n > 0 {
+		if _, err := w.SetRequiredCount(n); err != nil {
+			// Only possible above the cap, which admission already rejects.
+			s.lggr.Errorw("Failed to reapply history requirement after reset",
+				"err", err, "streamID", k.streamID, "aggregator", k.aggregator, "requiredCount", n)
+		}
+	}
+	s.windows[k] = w
+	return w
+}
+
+// provide reads the named chunks into the window. A chunk that is missing or
+// does not match the header means the window as a whole cannot be trusted, so it
+// is discarded and re-warmed; the returned window is then the empty replacement.
+func (s *historyStore) provide(k histKey, w *protocol.RingWindow, sequences []uint64) (*protocol.RingWindow, error) {
+	for _, sequence := range sequences {
+		if w.Loaded(sequence) {
+			// Already in hand, and possibly appended to since: the stored bytes
+			// are stale until this round's write set is flushed, so re-reading
+			// them would look like a header/chunk mismatch. This is also what
+			// makes the one-read-per-key-per-round guarantee hold when a pair is
+			// both appended to and read in the same round.
+			continue
+		}
+		slot := protocol.HistoryChunkSlot(sequence)
+		chunk, err := readHistoryChunk(s.r, k.streamID, k.aggregator, slot)
+		switch {
+		case err != nil && !errors.Is(err, protocol.ErrCorruptStreamHistory):
+			return nil, err
+		case err != nil:
+			return s.reset(k, err), nil
+		case chunk == nil:
+			return s.reset(k, fmt.Errorf("%w: chunk %d (slot %d) is missing",
+				protocol.ErrCorruptStreamHistory, sequence, slot)), nil
+		}
+		if err := w.Provide(chunk); err != nil {
+			return s.reset(k, err), nil
+		}
+	}
+	return w, nil
+}
+
+// Load returns the working copy for a pair, reading no chunks. The window is
+// empty, never nil, when nothing is stored.
+//
+// It is enough for anything that only asks how deep a window is; reading records
+// out of it additionally needs the chunks covering them (see Series).
+func (s *historyStore) Load(sid llotypes.StreamID, agg llotypes.Aggregator) (*protocol.RingWindow, error) {
+	return s.window(histKey{streamID: sid, aggregator: agg})
+}
+
+// Series implements calculated.HistoryReader, projecting the newest count
+// records onto one field.
+//
+// Chunk memoization is what satisfies the interface's one-read-per-pair
+// requirement: however many expressions ask for this pair, at whatever depths
+// and fields, each underlying key is read once. Depths that overlap share the
+// chunks they have in common, and an unsatisfiable depth reads nothing.
+func (s *historyStore) Series(sid llotypes.StreamID, agg llotypes.Aggregator, count uint32, field calculated.Field) (calculated.Series, error) {
+	k := histKey{streamID: sid, aggregator: agg}
+	w, err := s.window(k)
+	if err != nil {
+		return calculated.Series{}, err
+	}
+
+	sequences, err := w.ReadPlan(count)
+	if err != nil {
+		// Not deep enough yet: warming up, or a depth increase, or state that
+		// was discarded as corrupt. Decided from the header alone, so this costs
+		// no chunk reads. The caller must not evaluate.
+		return calculated.Series{}, err
+	}
+
+	if w, err = s.provide(k, w, sequences); err != nil {
+		return calculated.Series{}, err
+	}
+	records, err := w.Newest(count)
+	if err != nil {
+		if errors.Is(err, protocol.ErrCorruptStreamHistory) {
+			s.reset(k, err)
+		}
+		return calculated.Series{}, err
+	}
+	return calculated.SeriesFromRecords(records, field)
+}
+
+// SetRequired sets a pair's window capacity for this round. A capacity of zero
+// means no channel needs the pair any more, and Flush deletes it.
+//
+// Capacity changes never rewrite a chunk: growing touches only the header, and
+// shrinking evicts whole chunks, which is deletes.
+func (s *historyStore) SetRequired(sid llotypes.StreamID, agg llotypes.Aggregator, n uint32) error {
+	k := histKey{streamID: sid, aggregator: agg}
+	s.required[k] = n
+
+	w, err := s.window(k)
+	if err != nil {
+		return err
+	}
+	if _, err := w.SetRequiredCount(n); err != nil {
+		return fmt.Errorf("set required count for stream %d aggregator %d: %w", sid, agg, err)
+	}
+	return nil
+}
+
+// Append records this round's agreed value for a pair, reporting whether it was
+// stored. See protocol.RingWindow.Append for the strictly-newer rule; a rejected
+// append is normal and not an error.
+func (s *historyStore) Append(sid llotypes.StreamID, agg llotypes.Aggregator, observedAtNanoseconds uint64, sv protocol.StreamValue) (bool, error) {
+	k := histKey{streamID: sid, aggregator: agg}
+	w, err := s.window(k)
+	if err != nil {
+		return false, err
+	}
+	// Appending needs the newest chunk when it still has room; a sealed or
+	// absent one starts a fresh chunk and reads nothing.
+	if w, err = s.provide(k, w, w.AppendPlan()); err != nil {
+		return false, err
+	}
+
+	appended, err := w.Append(observedAtNanoseconds, sv)
+	if err != nil {
+		return false, fmt.Errorf("append history for stream %d aggregator %d: %w", sid, agg, err)
+	}
+	return appended, nil
+}
+
+// Flush persists modified windows, deletes pairs no live channel requires, and
+// rewrites the index if the stored set changed.
+//
+// Pairs are visited in sorted order and each pair's writes precede its deletes,
+// so every oracle issues the same operations in the same sequence. Per pair a
+// round writes at most one header and one chunk — the newest, the only one that
+// is ever rewritten — plus a delete for each chunk that fell out.
+func (s *historyStore) Flush(w ocr3_1types.KeyValueStateReadWriter) error {
+	// A layout reset abandons whatever the previous layout stored: if the stale
+	// index listed anything, it must be rewritten from the windows this round
+	// actually warmed.
+	indexChanged := s.abandoned > 0
+
+	for _, k := range s.sortedWindowKeys() {
+		win := s.windows[k]
+		if win.RequiredCount() == 0 {
+			continue // handled by the orphan pass below
+		}
+		set := win.WriteSet()
+		if set.Empty() {
+			continue
+		}
+
+		if set.Header != nil {
+			n, err := writeHistoryHeader(w, k.streamID, k.aggregator, set.Header)
+			if err != nil {
+				return err
+			}
+			s.written[k] += n
+		}
+		if set.Chunk != nil {
+			n, err := writeHistoryChunk(w, k.streamID, k.aggregator, set.Chunk)
+			if err != nil {
+				return err
+			}
+			s.written[k] += n
+			s.chunkWrites++
+		}
+		for _, slot := range set.DeletedSlots {
+			if err := deleteHistoryChunk(w, k.streamID, k.aggregator, slot); err != nil {
+				return fmt.Errorf("delete history chunk for stream %d aggregator %d slot %d: %w", k.streamID, k.aggregator, slot, err)
+			}
+		}
+
+		if !s.index[k] {
+			s.index[k] = true
+			indexChanged = true
+		}
+	}
+
+	// A stored pair with no capacity is dead state: either its channels were
+	// removed, or their expressions no longer reference it.
+	for _, k := range s.orphans() {
+		if err := s.deleteWindow(w, k); err != nil {
+			return err
+		}
+		delete(s.index, k)
+		indexChanged = true
+	}
+
+	if indexChanged {
+		if err := writeHistoryIndex(w, s.indexKeys()); err != nil {
+			return fmt.Errorf("write history index: %w", err)
+		}
+	}
+
+	// Record the layout only once this round has actually stored something in
+	// it. A DON that has never used history writes no history keys at all, and
+	// stamping a version onto an otherwise untouched state would be the only
+	// exception to that.
+	if s.layoutReset && (indexChanged || len(s.index) > 0) {
+		if err := writeHistoryLayoutVersion(w); err != nil {
+			return fmt.Errorf("write history layout version: %w", err)
+		}
+		s.layoutReset = false
+	}
+	return nil
+}
+
+// deleteWindow removes every key belonging to a pair.
+//
+// The chunks to delete come from the window's write set, which after a teardown
+// or a reset lists exactly the slots it held. A pair that was never loaded this
+// round has no such list, so its whole slot space is deleted — bounded, and the
+// same recovery a corrupt header gets.
+func (s *historyStore) deleteWindow(w ocr3_1types.KeyValueStateReadWriter, k histKey) error {
+	if err := deleteHistoryHeader(w, k.streamID, k.aggregator); err != nil {
+		return fmt.Errorf("delete history header for stream %d aggregator %d: %w", k.streamID, k.aggregator, err)
+	}
+
+	slots := allHistoryChunkSlots()
+	if win, ok := s.windows[k]; ok {
+		slots = win.WriteSet().DeletedSlots
+	}
+	for _, slot := range slots {
+		if err := deleteHistoryChunk(w, k.streamID, k.aggregator, slot); err != nil {
+			return fmt.Errorf("delete history chunk for stream %d aggregator %d slot %d: %w", k.streamID, k.aggregator, slot, err)
+		}
+	}
+	return nil
+}
+
+func allHistoryChunkSlots() []uint32 {
+	slots := make([]uint32, 0, protocol.MaxHistoryChunkSlots)
+	for slot := range uint32(protocol.MaxHistoryChunkSlots) {
+		slots = append(slots, slot)
+	}
+	return slots
+}
+
+// sortedWindowKeys returns the pairs touched this round, in sorted order.
+func (s *historyStore) sortedWindowKeys() []histKey {
+	keys := make([]histKey, 0, len(s.windows))
+	for k := range s.windows {
+		keys = append(keys, k)
+	}
+	sortHistKeys(keys)
+	return keys
+}
+
+// indexKeys returns the stored pairs in sorted order.
+func (s *historyStore) indexKeys() []histKey {
+	keys := make([]histKey, 0, len(s.index))
+	for k := range s.index {
+		keys = append(keys, k)
+	}
+	sortHistKeys(keys)
+	return keys
+}
+
+// orphans returns stored pairs that no live channel requires, in sorted order.
+// A pair is an orphan when it has a stored window but was never given a
+// non-zero capacity this round.
+func (s *historyStore) orphans() []histKey {
+	orphans := make([]histKey, 0)
+	for k := range s.index {
+		if w, ok := s.windows[k]; ok && w.RequiredCount() > 0 {
+			continue
+		}
+		orphans = append(orphans, k)
+	}
+	sortHistKeys(orphans)
+	return orphans
+}
+
+func sortHistKeys(keys []histKey) {
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].streamID != keys[j].streamID {
+			return keys[i].streamID < keys[j].streamID
+		}
+		return keys[i].aggregator < keys[j].aggregator
+	})
+}

--- a/llo/dev/v31/history_bench_test.go
+++ b/llo/dev/v31/history_bench_test.go
@@ -1,0 +1,209 @@
+package llo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+// Stream history benchmarks at the caps.
+//
+// The caps were set from measured sizes; these measure time, which nothing had
+// yet. The number to compare against is the round interval (on the order of a
+// second): history work happens inside StateTransition, so anything approaching
+// that is a problem regardless of how many bytes it writes.
+//
+// The kvBytes metric is reported alongside ns/op because the per-round byte
+// budget, not CPU, is what the design expects to bind first.
+
+const (
+	benchPairs  = protocol.MaxHistoryPairs
+	benchDepth  = protocol.MaxHistoryRecordsPerPair
+	benchAggreg = llotypes.AggregatorMedian
+)
+
+// benchQuote is the largest realistic record: one window serves _bid/_ask/
+// _benchmark, so quote streams are the case worth measuring.
+func benchQuote(i int) protocol.StreamValue {
+	return &protocol.Quote{
+		Bid:       decimal.New(int64(110000000000000000+i), -8),
+		Benchmark: decimal.New(int64(110000000000000001+i), -8),
+		Ask:       decimal.New(int64(110000000000000002+i), -8),
+	}
+}
+
+// benchState returns a store pre-populated with benchPairs full windows.
+func benchState(tb testing.TB, pairs, depth int) *memKV {
+	tb.Helper()
+	kv := newMemKV()
+
+	keys := make([]histKey, 0, pairs)
+	for p := range pairs {
+		key := histKey{streamID: llotypes.StreamID(p + 1), aggregator: benchAggreg}
+		keys = append(keys, key)
+
+		// Built in one pass rather than round by round: the window is kept in
+		// memory and each chunk is persisted as it seals, which is exactly what
+		// a run of rounds would have written.
+		w := protocol.NewRingWindow(nil)
+		_, err := w.SetRequiredCount(uint32(depth))
+		require.NoError(tb, err)
+
+		// Half a chunk past the required depth, so the benchmark measures a
+		// settled window with a half-full newest chunk rather than the boundary
+		// case where the next append happens to start a fresh, nearly empty one.
+		records := depth + protocol.MaxHistoryChunkRecords/2
+		for i := 1; i <= records; i++ {
+			appended, err := w.Append(uint64(i)*uint64(1_000_000_000), benchQuote(i))
+			require.NoError(tb, err)
+			require.True(tb, appended)
+
+			set := w.WriteSet()
+			if set.Chunk.Len() == protocol.MaxHistoryChunkRecords || i == records {
+				_, err := writeHistoryChunk(kv, key.streamID, key.aggregator, set.Chunk)
+				require.NoError(tb, err)
+			}
+			for _, slot := range set.DeletedSlots {
+				require.NoError(tb, deleteHistoryChunk(kv, key.streamID, key.aggregator, slot))
+			}
+		}
+		_, err = writeHistoryHeader(kv, key.streamID, key.aggregator, w.WriteSet().Header)
+		require.NoError(tb, err)
+	}
+	require.NoError(tb, writeHistoryIndex(kv, keys))
+	require.NoError(tb, writeHistoryLayoutVersion(kv))
+	return kv
+}
+
+func benchRequirements(pairs, depth int) historyRequirements {
+	depths := make(map[histKey]uint32, pairs)
+	for p := range pairs {
+		depths[histKey{streamID: llotypes.StreamID(p + 1), aggregator: benchAggreg}] = uint32(depth)
+	}
+	return historyRequirements{depths: depths}
+}
+
+// BenchmarkHistoryStore_LoadAll measures decoding every window once, which is
+// what a round costs before it has done any work.
+func BenchmarkHistoryStore_LoadAll(b *testing.B) {
+	kv := benchState(b, benchPairs, benchDepth)
+	lggr := logger.Test(b)
+
+	b.ResetTimer()
+	for range b.N {
+		store, err := newHistoryStore(kv, lggr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for p := range benchPairs {
+			if _, err := store.Load(llotypes.StreamID(p+1), benchAggreg); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+// BenchmarkHistoryStore_Round measures a full round's history work: load the
+// index, set requirements, append one value per pair, flush.
+func BenchmarkHistoryStore_Round(b *testing.B) {
+	for _, tc := range []struct{ pairs, depth int }{
+		{1, benchDepth},
+		{16, benchDepth},
+		{benchPairs, 300},
+		{benchPairs, benchDepth},
+	} {
+		b.Run(fmt.Sprintf("pairs=%d/depth=%d", tc.pairs, tc.depth), func(b *testing.B) {
+			base := benchState(b, tc.pairs, tc.depth)
+			requirements := benchRequirements(tc.pairs, tc.depth)
+			lggr := logger.Test(b)
+
+			var bytesWritten int
+			b.ResetTimer()
+			for n := range b.N {
+				// A fresh writer per iteration so the measured writes are one
+				// round's worth, not cumulative.
+				kv := &countingWriter{memKV: base}
+
+				store, err := newHistoryStore(kv, lggr)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := requirements.apply(store); err != nil {
+					b.Fatal(err)
+				}
+				ts := uint64(tc.depth+protocol.MaxHistoryChunkRecords/2+n+1) * uint64(1_000_000_000)
+				for p := range tc.pairs {
+					if _, err := store.Append(llotypes.StreamID(p+1), benchAggreg, ts, benchQuote(n)); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := store.Flush(kv); err != nil {
+					b.Fatal(err)
+				}
+				bytesWritten = kv.bytes
+			}
+			b.ReportMetric(float64(bytesWritten), "kvBytes/op")
+			b.ReportMetric(float64(bytesWritten)/1024, "kvKiB/op")
+		})
+	}
+}
+
+// BenchmarkComputeHistoryRequirements measures deriving the required depths from
+// the channel definitions, which happens once per round.
+func BenchmarkComputeHistoryRequirements(b *testing.B) {
+	for _, channels := range []int{1, 16, 128} {
+		b.Run(fmt.Sprintf("channels=%d", channels), func(b *testing.B) {
+			defs := llotypes.ChannelDefinitions{}
+			for c := range channels {
+				streamID := llotypes.StreamID(c + 1)
+				defs[llotypes.ChannelID(c+1)] = llotypes.ChannelDefinition{
+					ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+					Streams:      []llotypes.Stream{{StreamID: streamID, Aggregator: benchAggreg}},
+					Opts: []byte(fmt.Sprintf(
+						`{"abi":[{"type":"int256","expression":"Avg(History(s%d, 300))","expressionStreamID":%d}]}`,
+						streamID, 900+c)),
+				}
+			}
+			cache := protocol.NewOptsCache()
+			cache.ResetTo(defs)
+			lggr := logger.Test(b)
+
+			// Sanity check outside the timed loop, and a note on what it shows:
+			// at 128 channels each wanting a 300-deep window every pair is
+			// admitted. Under the single-blob layout only 109 were — a pair cost
+			// depth * MaxHistoryRecordBytes per round and the byte budget ran out
+			// first. Chunking made that cost independent of depth, so the pair
+			// cap is now the only thing that can deny a window.
+			admitted := len(computeHistoryRequirements(defs, cache, lggr).depths)
+			b.ReportMetric(float64(admitted), "admittedPairs")
+
+			b.ResetTimer()
+			for range b.N {
+				computeHistoryRequirements(defs, cache, lggr)
+			}
+		})
+	}
+}
+
+// countingWriter counts bytes written, so a round's byte cost can be reported
+// against the per-round budget. Reads fall through to the shared base state.
+type countingWriter struct {
+	*memKV
+	bytes int
+}
+
+func (w *countingWriter) Write(key, value []byte) error {
+	w.bytes += len(key) + len(value)
+	// Deliberately not persisted: the benchmark measures one round against a
+	// fixed starting state, and mutating it would make iterations diverge.
+	return nil
+}
+
+func (w *countingWriter) Delete([]byte) error { return nil }

--- a/llo/dev/v31/history_flow_test.go
+++ b/llo/dev/v31/history_flow_test.go
@@ -1,0 +1,298 @@
+package llo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+// historyExprChannel is an expression channel reading a window of stream 100.
+func historyExprChannel(expression string) llotypes.ChannelDefinition {
+	return llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+		Streams:      []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}},
+		Opts:         []byte(fmt.Sprintf(`{"abi":[{"type":"int256","expression":%q,"expressionStreamID":999}]}`, expression)),
+	}
+}
+
+// valueRound feeds 4 identical observations carrying a value for stream 100.
+func valueRound(t *testing.T, ts uint64, value int64) []ocrtypes.AttributedObservation {
+	t.Helper()
+	obs := Observation{
+		UnixTimestampNanoseconds: ts,
+		StreamValues:             protocol.StreamValues{100: protocol.ToDecimal(decimal.NewFromInt(value))},
+	}
+	aos := make([]ocrtypes.AttributedObservation, 0, 4)
+	for i := range 4 {
+		aos = append(aos, ao(i, mustEncodeObs(t, obs)))
+	}
+	return aos
+}
+
+// historyPlugin returns a plugin whose only channel reads stream history.
+func historyPlugin(t *testing.T, expression string) *Plugin {
+	t.Helper()
+	p := testPlugin(t)
+	p.ChannelDefinitionCache = &mockChannelDefinitionCache{defs: llotypes.ChannelDefinitions{1: historyExprChannel(expression)}}
+	return p
+}
+
+// bootstrapHistoryChannel brings up the plugin and installs the channel.
+func bootstrapHistoryChannel(t *testing.T, p *Plugin, kv *memKV, expression string) {
+	t.Helper()
+	ctx := tests.Context(t)
+	_, err := p.StateTransition(ctx, 1, ocrtypes.AttributedQuery{}, []ocrtypes.AttributedObservation{ao(0, nil), ao(1, nil), ao(2, nil)}, kv, nil)
+	require.NoError(t, err)
+	_, err = p.StateTransition(ctx, 2, ocrtypes.AttributedQuery{}, addChannelRound(t, 1_000, 1, historyExprChannel(expression)), kv, nil)
+	require.NoError(t, err)
+	require.Contains(t, storedChannelDefinitions(t, kv), llotypes.ChannelID(1))
+}
+
+// Test_History_Warmup is the central behaviour of the feature: a channel reading
+// a window of depth N produces nothing, and does not advance its coverage
+// watermark, until the window is N deep — then it reports on exactly that round.
+func Test_History_Warmup(t *testing.T) {
+	ctx := tests.Context(t)
+	const depth = 3
+
+	p := historyPlugin(t, fmt.Sprintf("Count(History(s100, %d))", depth))
+	kv := newMemKV()
+	bootstrapHistoryChannel(t, p, kv, fmt.Sprintf("Count(History(s100, %d))", depth))
+
+	key := histKey{streamID: 100, aggregator: llotypes.AggregatorMedian}
+	seqNr := uint64(3)
+
+	var validAfterWhileWarming uint64
+	for round := 1; round <= depth; round++ {
+		ts := uint64(round) * 10_000
+		_, err := p.StateTransition(ctx, seqNr, ocrtypes.AttributedQuery{}, valueRound(t, ts, int64(round)), kv, nil)
+		require.NoError(t, err)
+		seqNr++
+
+		stored := readHistory(t, kv, key.streamID, key.aggregator)
+		require.NotNil(t, stored, "round %d: a required pair must have a window", round)
+		assert.Equal(t, round, stored.Len(), "round %d: one record per round", round)
+		assert.Equal(t, uint32(depth), stored.RequiredCount())
+
+		validAfter := storedValidAfter(t, kv, 1)
+
+		if round < depth {
+			// Not deep enough: no value, so nothing to report.
+			require.False(t, reportedFlag(t, kv, 1), "round %d: must not be reportable while warming up", round)
+			if round == 1 {
+				validAfterWhileWarming = validAfter
+			} else {
+				assert.Equal(t, validAfterWhileWarming, validAfter,
+					"round %d: validAfter must not advance over rounds that emitted nothing", round)
+			}
+		} else {
+			// The window is now exactly deep enough.
+			require.True(t, reportedFlag(t, kv, 1), "round %d: must become reportable once the window is deep enough", round)
+		}
+	}
+}
+
+// Test_History_EvictsAtDepth checks the window stays bounded across many rounds
+// and keeps the newest values.
+func Test_History_EvictsAtDepth(t *testing.T) {
+	ctx := tests.Context(t)
+	const depth = 2
+	expression := fmt.Sprintf("Count(History(s100, %d))", depth)
+
+	p := historyPlugin(t, expression)
+	kv := newMemKV()
+	bootstrapHistoryChannel(t, p, kv, expression)
+
+	seqNr := uint64(3)
+	for round := 1; round <= 6; round++ {
+		_, err := p.StateTransition(ctx, seqNr, ocrtypes.AttributedQuery{}, valueRound(t, uint64(round)*10_000, int64(round)), kv, nil)
+		require.NoError(t, err)
+		seqNr++
+	}
+
+	stored := readHistory(t, kv, 100, llotypes.AggregatorMedian)
+	requireHistoryRetention(t, stored)
+	assert.Equal(t, uint64(6*10_000), stored.LastObservationTimestampNanoseconds())
+
+	// What the expression sees is the newest `depth` records, whatever the
+	// window retains around them.
+	window := readHistoryNewest(t, kv, 100, llotypes.AggregatorMedian, depth)
+	assert.Equal(t, []uint64{5 * 10_000, 6 * 10_000}, historyTimestamps(window))
+	newest, ok := window[depth-1].Value.(*protocol.Decimal)
+	require.True(t, ok)
+	assert.True(t, decimal.NewFromInt(6).Equal(newest.Decimal()))
+}
+
+// Test_History_NoDuplicateOnStalledTimestamp covers the rule that keeps a window
+// from double counting: if the round's observation timestamp does not advance,
+// nothing is appended.
+func Test_History_NoDuplicateOnStalledTimestamp(t *testing.T) {
+	ctx := tests.Context(t)
+	expression := "Count(History(s100, 5))"
+
+	p := historyPlugin(t, expression)
+	kv := newMemKV()
+	bootstrapHistoryChannel(t, p, kv, expression)
+
+	seqNr := uint64(3)
+	_, err := p.StateTransition(ctx, seqNr, ocrtypes.AttributedQuery{}, valueRound(t, 10_000, 1), kv, nil)
+	require.NoError(t, err)
+	seqNr++
+
+	stored := readHistory(t, kv, 100, llotypes.AggregatorMedian)
+	require.Equal(t, 1, stored.Len())
+
+	// Same observation timestamp, different value: must not be appended.
+	_, err = p.StateTransition(ctx, seqNr, ocrtypes.AttributedQuery{}, valueRound(t, 10_000, 99), kv, nil)
+	require.NoError(t, err)
+
+	stored = readHistory(t, kv, 100, llotypes.AggregatorMedian)
+	assert.Equal(t, 1, stored.Len(), "a non-advancing observation timestamp must not append")
+}
+
+// Test_History_ReclaimedOnChannelRemoval checks the window does not outlive the
+// channel that needed it.
+func Test_History_ReclaimedOnChannelRemoval(t *testing.T) {
+	ctx := tests.Context(t)
+	expression := "Count(History(s100, 3))"
+
+	p := historyPlugin(t, expression)
+	kv := newMemKV()
+	bootstrapHistoryChannel(t, p, kv, expression)
+
+	seqNr := uint64(3)
+	_, err := p.StateTransition(ctx, seqNr, ocrtypes.AttributedQuery{}, valueRound(t, 10_000, 1), kv, nil)
+	require.NoError(t, err)
+	seqNr++
+
+	require.NotEmpty(t, kv.m[string(historyHeaderKey(100, llotypes.AggregatorMedian))])
+	require.NotEmpty(t, kv.m[string(keyHistoryIndex)])
+
+	// Vote the channel away.
+	removeObs := Observation{UnixTimestampNanoseconds: 20_000, RemoveChannelIDs: map[llotypes.ChannelID]struct{}{1: {}}}
+	removeAOs := make([]ocrtypes.AttributedObservation, 0, 4)
+	for i := range 4 {
+		removeAOs = append(removeAOs, ao(i, mustEncodeObs(t, removeObs)))
+	}
+	p.ChannelDefinitionCache = &mockChannelDefinitionCache{defs: llotypes.ChannelDefinitions{}}
+	_, err = p.StateTransition(ctx, seqNr, ocrtypes.AttributedQuery{}, removeAOs, kv, nil)
+	require.NoError(t, err)
+	seqNr++
+
+	// The removal round still runs against the effective definitions, which
+	// include the channel being voted away, so its requirement — and therefore
+	// its window — survives this round. Reclaim happens on the next one, the
+	// same one-round lag the carry-forward aggregates have.
+	require.NotNil(t, readHistory(t, kv, 100, llotypes.AggregatorMedian),
+		"the removal round still evaluates the channel, so its window must survive it")
+
+	_, err = p.StateTransition(ctx, seqNr, ocrtypes.AttributedQuery{}, valueRound(t, 30_000, 2), kv, nil)
+	require.NoError(t, err)
+
+	stored := readHistory(t, kv, 100, llotypes.AggregatorMedian)
+	assert.Nil(t, stored, "history must not outlive the channel that required it")
+
+	idx, err := readHistoryIndex(kv)
+	require.NoError(t, err)
+	assert.Empty(t, idx)
+}
+
+// Test_History_DeterministicAcrossOracles is the property a divergence would
+// halt the DON over: two independent oracles processing identical rounds must
+// end with byte-identical state.
+func Test_History_DeterministicAcrossOracles(t *testing.T) {
+	ctx := tests.Context(t)
+	expression := "Count(History(s100, 3))"
+
+	run := func() map[string][]byte {
+		p := historyPlugin(t, expression)
+		kv := newMemKV()
+		bootstrapHistoryChannel(t, p, kv, expression)
+		seqNr := uint64(3)
+		for round := 1; round <= 5; round++ {
+			_, err := p.StateTransition(ctx, seqNr, ocrtypes.AttributedQuery{}, valueRound(t, uint64(round)*10_000, int64(round)), kv, nil)
+			require.NoError(t, err)
+			seqNr++
+		}
+		return kv.m
+	}
+
+	a, b := run(), run()
+	require.Equal(t, len(a), len(b))
+	for key, want := range a {
+		require.Equal(t, want, b[key], "key %q diverged", key)
+	}
+}
+
+// Test_History_UnavailableOnDeniedPair checks a pair denied by the caps yields no
+// value, so the channel does not report — rather than silently evaluating over a
+// shallower window.
+func Test_History_UnavailableOnDeniedPair(t *testing.T) {
+	t.Parallel()
+
+	// Requirements computed with the byte budget already exhausted by
+	// lower-numbered pairs.
+	required := map[histKey]uint32{}
+	for i := range protocol.MaxHistoryPairs + 1 {
+		required[histKey{streamID: llotypes.StreamID(i + 1), aggregator: llotypes.AggregatorMedian}] = 1
+	}
+	got := admitHistoryRequirements(required, logger.Test(t))
+	require.NotEmpty(t, got.denied)
+
+	denied := got.sortedDenied()[0]
+	assert.False(t, got.requires(denied.streamID, denied.aggregator),
+		"a denied pair must not be appended to")
+
+	// And the store never gets a capacity for it, so reads report insufficient
+	// history rather than an empty window.
+	kv := newCountingKV()
+	store := newTestHistoryStore(t, kv)
+	require.NoError(t, got.apply(store))
+	_, err := store.Series(denied.streamID, denied.aggregator, 1, 0)
+	require.ErrorIs(t, err, protocol.ErrInsufficientStreamHistory)
+}
+
+// reportedFlag reads the persisted reportability bit. The key is written only
+// when the decision changes, so an absent key means "not reportable".
+// storedChannelDefinitions decodes the c/defs record.
+func storedChannelDefinitions(t *testing.T, kv *memKV) llotypes.ChannelDefinitions {
+	t.Helper()
+	defs, err := readChannelState(kv)
+	require.NoError(t, err)
+	return defs
+}
+
+// storedHotState decodes the r/agg record.
+func storedHotState(t *testing.T, kv *memKV) *kvState {
+	t.Helper()
+	s := &kvState{
+		validAfterNanoseconds: map[llotypes.ChannelID]uint64{},
+		reportedLastRound:     map[llotypes.ChannelID]bool{},
+		carryForward:          map[llotypes.StreamID]map[llotypes.Aggregator]*protocol.TimestampedStreamValue{},
+	}
+	require.NoError(t, readHotState(kv, s))
+	return s
+}
+
+// storedValidAfter returns a channel's persisted coverage watermark.
+func storedValidAfter(t *testing.T, kv *memKV, cid llotypes.ChannelID) uint64 {
+	t.Helper()
+	return storedHotState(t, kv).validAfterNanoseconds[cid]
+}
+
+// reportedFlag returns the reportability decision the last round persisted.
+func reportedFlag(t *testing.T, kv *memKV, cid llotypes.ChannelID) bool {
+	t.Helper()
+	return storedHotState(t, kv).reportedLastRound[cid]
+}

--- a/llo/dev/v31/history_metrics.go
+++ b/llo/dev/v31/history_metrics.go
@@ -1,0 +1,214 @@
+package llo
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol/calculated"
+)
+
+// Stream history metrics.
+//
+// These are node-local observations with no effect on consensus: nothing reads
+// them back, and a node that fails to record one behaves identically. They exist
+// because the interesting history conditions are otherwise invisible — a channel
+// that is quietly not reporting looks the same as one with nothing to say.
+//
+// Cardinality is bounded by MaxHistoryPairs (128) times the aggregators in use,
+// which is why the per-pair gauges are labelled by stream and aggregator while
+// the fault counters are labelled by DON only.
+var (
+	// historyRecordsMetric is how deep each pair's window actually is. Compared
+	// against historyRequiredMetric it shows warmup progress.
+	historyRecordsMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "llo",
+		Subsystem: "history",
+		Name:      "records",
+		Help:      "Number of records currently stored in a stream history window.",
+	}, []string{"donID", "streamID", "aggregator"})
+
+	// historyRequiredMetric is the depth the live channels ask for.
+	historyRequiredMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "llo",
+		Subsystem: "history",
+		Name:      "required_records",
+		Help:      "Depth required of a stream history window by the deepest live channel referencing it.",
+	}, []string{"donID", "streamID", "aggregator"})
+
+	// historySatisfiedMetric is 1 once a window is deep enough to be read.
+	// Warmup is expected to end; this not reaching 1 is what to alert on.
+	historySatisfiedMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "llo",
+		Subsystem: "history",
+		Name:      "satisfied",
+		Help:      "1 when a stream history window holds at least the required number of records, 0 while warming up.",
+	}, []string{"donID", "streamID", "aggregator"})
+
+	// historyBytesMetric is what each pair actually wrote this round, which is
+	// the quantity the per-round byte budget is spent on. Under the chunked
+	// layout that is the newest chunk plus the header, not the whole window, so
+	// it should stay flat as a window deepens.
+	historyBytesMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "llo",
+		Subsystem: "history",
+		Name:      "bytes",
+		Help:      "Bytes written to the key-value state for a stream history window in the last round.",
+	}, []string{"donID", "streamID", "aggregator"})
+
+	// historyChunkWritesMetric counts chunk values written. Expect one per pair
+	// per round with an appended value; a sustained higher rate would mean
+	// sealed chunks are being rewritten, which the layout forbids.
+	historyChunkWritesMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "llo",
+		Subsystem: "history",
+		Name:      "chunk_writes_total",
+		Help:      "Stream history chunks written to the key-value state.",
+	}, []string{"donID"})
+
+	// historyPairsMetric is how many pairs hold history, against MaxHistoryPairs.
+	historyPairsMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "llo",
+		Subsystem: "history",
+		Name:      "pairs",
+		Help:      "Number of (stream, aggregator) pairs with stored history.",
+	}, []string{"donID"})
+
+	// historyDeniedMetric counts pairs refused history because a cap or the byte
+	// budget was reached. Any non-zero value means channels are not reporting.
+	historyDeniedMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "llo",
+		Subsystem: "history",
+		Name:      "denied_total",
+		Help:      "Pairs denied stream history because the pair cap or byte budget was exhausted. Channels reading them cannot report.",
+	}, []string{"donID"})
+
+	// historyCorruptMetric counts windows discarded as undecodable. Stored state
+	// is untrusted input, so this is handled rather than fatal, but it should
+	// never happen.
+	historyCorruptMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "llo",
+		Subsystem: "history",
+		Name:      "corrupt_total",
+		Help:      "Stream history windows discarded because they could not be decoded, and re-warmed from empty.",
+	}, []string{"donID"})
+
+	// historyOversizedRecordMetric counts values too large to store. The record
+	// is dropped, leaving a gap in the series.
+	historyOversizedRecordMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "llo",
+		Subsystem: "history",
+		Name:      "oversized_records_total",
+		Help:      "Agreed values dropped from stream history because they exceeded the per-record size cap, leaving a gap in the series.",
+	}, []string{"donID"})
+
+	// historyInsufficientMetric counts rounds a channel could not be evaluated
+	// because a window was still too shallow. Expected during warmup; sustained
+	// beyond it means the channel is not reporting.
+	historyInsufficientMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "llo",
+		Subsystem: "history",
+		Name:      "insufficient_total",
+		Help:      "Rounds in which a channel was not evaluated because a stream history window was shallower than requested.",
+	}, []string{"donID"})
+)
+
+// captureHistoryTelemetry records the round's history state.
+//
+// Called after Flush so the sizes reported are the ones actually written. Like
+// the rest of the telemetry in this package it is best-effort and side-effect
+// free with respect to the protocol.
+func (p *Plugin) captureHistoryTelemetry(history *historyStore, requirements historyRequirements) {
+	if history == nil {
+		return
+	}
+	donID := strconv.FormatUint(uint64(p.DonID), 10)
+
+	historyPairsMetric.WithLabelValues(donID).Set(float64(len(history.index)))
+	historyCorruptMetric.WithLabelValues(donID).Add(float64(len(history.corrupt)))
+	historyDeniedMetric.WithLabelValues(donID).Add(float64(len(requirements.denied)))
+	historyOversizedRecordMetric.WithLabelValues(donID).Add(float64(history.oversized))
+	historyChunkWritesMetric.WithLabelValues(donID).Add(float64(history.chunkWrites))
+
+	for _, key := range history.indexKeys() {
+		h, ok := history.windows[key]
+		if !ok {
+			continue // not touched this round, so nothing new to report
+		}
+		streamID := strconv.FormatUint(uint64(key.streamID), 10)
+		aggregator := strconv.FormatUint(uint64(key.aggregator), 10)
+
+		records, required := h.Len(), h.RequiredCount()
+		historyRecordsMetric.WithLabelValues(donID, streamID, aggregator).Set(float64(records))
+		historyRequiredMetric.WithLabelValues(donID, streamID, aggregator).Set(float64(required))
+
+		satisfied := 0.0
+		if required > 0 && uint32(records) >= required {
+			satisfied = 1
+		}
+		historySatisfiedMetric.WithLabelValues(donID, streamID, aggregator).Set(satisfied)
+		historyBytesMetric.WithLabelValues(donID, streamID, aggregator).Set(float64(history.written[key]))
+	}
+}
+
+// captureInsufficientHistory counts channels that could not be evaluated this
+// round because a window they read was shallower than they asked for.
+//
+// It is measured per channel and per reference rather than from the per-pair
+// gauges, because the stored depth is the maximum any channel wants: a channel
+// asking for less can be satisfied while the pair as a whole is not. Counting
+// from the gauges would over-report.
+func (p *Plugin) captureInsufficientHistory(defs llotypes.ChannelDefinitions, opts *protocol.OptsCache, history *historyStore) {
+	if history == nil {
+		return
+	}
+
+	var unsatisfied int
+	for cid, cd := range defs {
+		if cd.Tombstone || cd.ReportFormat != llotypes.ReportFormatEVMABIEncodeUnpackedExpr {
+			continue
+		}
+		aggByStream, err := calculated.AggregatorByStream(cd)
+		if err != nil {
+			continue // reported elsewhere; not a history condition
+		}
+		expressions, err := calculated.Expressions(opts, cd, cid)
+		if err != nil {
+			continue
+		}
+		if !channelHistorySatisfied(expressions, aggByStream, history) {
+			unsatisfied++
+		}
+	}
+	if unsatisfied > 0 {
+		historyInsufficientMetric.WithLabelValues(strconv.FormatUint(uint64(p.DonID), 10)).Add(float64(unsatisfied))
+	}
+}
+
+// channelHistorySatisfied reports whether every window a channel's expressions
+// read is deep enough to be evaluated.
+func channelHistorySatisfied(expressions []string, aggByStream map[llotypes.StreamID]llotypes.Aggregator, history *historyStore) bool {
+	for _, expression := range expressions {
+		refs, err := calculated.AnalyzeExpressionHistory(expression)
+		if err != nil {
+			continue // invalid expression, not a history condition
+		}
+		for _, ref := range refs {
+			aggregator, ok := aggByStream[ref.StreamID]
+			if !ok {
+				continue
+			}
+			// Reads through the memoized store, so this costs no extra state
+			// access.
+			h, err := history.Load(ref.StreamID, aggregator)
+			if err != nil || uint32(h.Len()) < ref.Count {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/llo/dev/v31/history_metrics.go
+++ b/llo/dev/v31/history_metrics.go
@@ -153,6 +153,21 @@ func (p *Plugin) captureHistoryTelemetry(history *historyStore, requirements his
 		historySatisfiedMetric.WithLabelValues(donID, streamID, aggregator).Set(satisfied)
 		historyBytesMetric.WithLabelValues(donID, streamID, aggregator).Set(float64(history.written[key]))
 	}
+
+	// Pairs whose history was reclaimed this round are deleted from the per-pair
+	// gauges. Prometheus keeps every label set it has ever seen, so leaving them
+	// behind does two things: the series report their final value forever, so an
+	// alert on an unsatisfied window fires for a pair that no longer exists; and
+	// cardinality grows with the number of distinct pairs ever configured, which
+	// MaxHistoryPairs does not bound because it caps live pairs only.
+	for _, key := range history.reclaimed {
+		streamID := strconv.FormatUint(uint64(key.streamID), 10)
+		aggregator := strconv.FormatUint(uint64(key.aggregator), 10)
+		historyRecordsMetric.DeleteLabelValues(donID, streamID, aggregator)
+		historyRequiredMetric.DeleteLabelValues(donID, streamID, aggregator)
+		historySatisfiedMetric.DeleteLabelValues(donID, streamID, aggregator)
+		historyBytesMetric.DeleteLabelValues(donID, streamID, aggregator)
+	}
 }
 
 // captureInsufficientHistory counts channels that could not be evaluated this

--- a/llo/dev/v31/history_metrics_test.go
+++ b/llo/dev/v31/history_metrics_test.go
@@ -1,0 +1,55 @@
+package llo
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+// TestCaptureHistoryTelemetry_DeletesReclaimedPairs pins the per-pair gauge
+// lifecycle. Prometheus keeps every label set it has ever seen, so a pair whose
+// history is reclaimed has to be deleted from the gauges: otherwise it reports
+// its final value forever — an alert on an unsatisfied window would fire for a
+// pair that no longer exists — and cardinality grows with the number of distinct
+// pairs ever configured, which MaxHistoryPairs does not bound because it caps
+// live pairs only.
+//
+// Deletion is asserted through DeleteLabelValues, which reports whether it
+// removed anything: after telemetry has run for the reclaiming round, there must
+// be nothing left to remove.
+func TestCaptureHistoryTelemetry_DeletesReclaimedPairs(t *testing.T) {
+	kv := newCountingKV()
+	key := histKey{streamID: 4242, aggregator: testAggMedian}
+
+	p := &Plugin{Logger: logger.Test(t), DonID: 7}
+	donID := strconv.FormatUint(uint64(p.DonID), 10)
+	streamID := strconv.FormatUint(uint64(key.streamID), 10)
+	aggregator := strconv.FormatUint(uint64(key.aggregator), 10)
+
+	// Round one: the pair holds history, so the gauges carry its labels.
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(key.streamID, key.aggregator, 1))
+	_, err := s.Append(key.streamID, key.aggregator, 1_000, testDecimal(1))
+	require.NoError(t, err)
+	require.NoError(t, s.Flush(kv))
+	p.captureHistoryTelemetry(s, historyRequirements{})
+
+	// Round two: nothing requires the pair, so Flush reclaims it.
+	s = newTestHistoryStore(t, kv)
+	require.NoError(t, s.Flush(kv))
+	require.Contains(t, s.reclaimed, key, "a pair with no capacity must be reclaimed")
+	p.captureHistoryTelemetry(s, historyRequirements{})
+
+	assert.False(t, historyRecordsMetric.DeleteLabelValues(donID, streamID, aggregator),
+		"records gauge must not outlive the pair")
+	assert.False(t, historyRequiredMetric.DeleteLabelValues(donID, streamID, aggregator),
+		"required gauge must not outlive the pair")
+	assert.False(t, historySatisfiedMetric.DeleteLabelValues(donID, streamID, aggregator),
+		"satisfied gauge must not outlive the pair")
+	assert.False(t, historyBytesMetric.DeleteLabelValues(donID, streamID, aggregator),
+		"bytes gauge must not outlive the pair")
+}

--- a/llo/dev/v31/history_requirements.go
+++ b/llo/dev/v31/history_requirements.go
@@ -1,0 +1,176 @@
+package llo
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol/calculated"
+)
+
+// historyRequirements is the depth of history each pair needs this round: the
+// maximum any live channel's expressions ask for.
+type historyRequirements struct {
+	// depths holds the admitted pairs and their required window depth.
+	depths map[histKey]uint32
+	// denied holds pairs that were required but could not be admitted within
+	// the pair and byte caps, sorted. Channels referencing them cannot evaluate
+	// and so are not reportable; they are reported here so the caller can say so
+	// loudly rather than silently producing shorter windows.
+	denied []histKey
+}
+
+// computeHistoryRequirements derives, from replicated state alone, how deep each
+// pair's history window must be.
+//
+// Determinism is the whole point: the inputs are the channel definitions and
+// their opts (both replicated) and expression analysis (a pure function of the
+// expression string), and every map is drained into a sorted slice before it
+// influences anything. Two oracles running this on the same state must produce
+// identical depths, because those depths become persisted state.
+//
+// Channels whose expressions cannot be analyzed, or that aggregate one stream
+// two ways, contribute nothing: they cannot be evaluated either (see
+// calculated.ProcessCalculatedStreams), so reserving history for them would keep
+// dead windows alive.
+func computeHistoryRequirements(defs llotypes.ChannelDefinitions, optsCache *protocol.OptsCache, lggr logger.Logger) historyRequirements {
+	required := map[histKey]uint32{}
+
+	// Channels are visited in sorted order so that logging and the
+	// admission decision below cannot depend on map iteration order.
+	channelIDs := make([]llotypes.ChannelID, 0, len(defs))
+	for cid := range defs {
+		channelIDs = append(channelIDs, cid)
+	}
+	sortChannelIDs(channelIDs)
+
+	for _, cid := range channelIDs {
+		cd := defs[cid]
+		if cd.Tombstone || cd.ReportFormat != llotypes.ReportFormatEVMABIEncodeUnpackedExpr {
+			continue
+		}
+
+		aggByStream, err := calculated.AggregatorByStream(cd)
+		if err != nil {
+			lggr.Errorw("Skipping history requirements for channel with ambiguous stream aggregators",
+				"channelID", cid, "err", err)
+			continue
+		}
+
+		expressions, err := calculated.Expressions(optsCache, cd, cid)
+		if err != nil {
+			lggr.Errorw("Skipping history requirements for channel with unresolvable opts",
+				"channelID", cid, "err", err)
+			continue
+		}
+
+		for _, expression := range expressions {
+			refs, err := calculated.AnalyzeExpressionHistory(expression)
+			if err != nil {
+				lggr.Errorw("Skipping history requirements for invalid expression",
+					"channelID", cid, "expression", expression, "err", err)
+				continue
+			}
+			for _, ref := range refs {
+				aggregator, ok := aggByStream[ref.StreamID]
+				if !ok {
+					lggr.Errorw("Expression reads history for a stream the channel does not observe",
+						"channelID", cid, "streamID", ref.StreamID, "expression", expression)
+					continue
+				}
+				key := histKey{streamID: ref.StreamID, aggregator: aggregator}
+				// The field is not part of the key: one window serves every
+				// field, so the depth is the deepest request across fields too.
+				if ref.Count > required[key] {
+					required[key] = ref.Count
+				}
+			}
+		}
+	}
+
+	return admitHistoryRequirements(required, lggr)
+}
+
+// admitHistoryRequirements applies the pair and byte caps.
+//
+// Pairs are considered in (streamID, aggregator) order and admitted until a cap
+// is reached; the rest are denied. Ordering by key rather than by, say, depth or
+// channel count is what makes the outcome identical on every oracle — the
+// admission decision is part of what determines persisted state.
+//
+// Denial is deliberately visible and total for the pair: a channel referencing a
+// denied pair produces no value and does not report, rather than silently
+// evaluating over a shorter window than it asked for.
+//
+// The pair cap is the only rule. Under the chunked layout a round rewrites one
+// chunk and one header per pair whatever the depth, so a pair's cost against the
+// per-round byte budget is a constant — MaxHistoryPairs of them fit inside
+// MaxHistoryTotalBytes by construction, which TestHistoryBudgetFitsPairCap
+// asserts. That was not true of the single-blob layout, where cost scaled with
+// depth and the budget denied pairs long before the cap did.
+func admitHistoryRequirements(required map[histKey]uint32, lggr logger.Logger) historyRequirements {
+	keys := make([]histKey, 0, len(required))
+	for key := range required {
+		keys = append(keys, key)
+	}
+	sortHistKeys(keys)
+
+	out := historyRequirements{depths: make(map[histKey]uint32, len(keys))}
+	for _, key := range keys {
+		if len(out.depths) >= protocol.MaxHistoryPairs {
+			lggr.Errorw("Denying stream history: too many pairs require history",
+				"streamID", key.streamID, "aggregator", key.aggregator,
+				"depth", required[key], "maxPairs", protocol.MaxHistoryPairs)
+			out.denied = append(out.denied, key)
+			continue
+		}
+		out.depths[key] = required[key]
+	}
+	return out
+}
+
+// apply sets the required depth of every admitted pair on the round's store, and
+// clears any pair that is no longer required so Flush can reclaim it.
+//
+// Pairs are applied in sorted order; every stored pair not admitted this round is
+// explicitly set to zero, which is what turns "no longer referenced" into a
+// deletion rather than state that lingers forever.
+func (r historyRequirements) apply(store *historyStore) error {
+	keys := make([]histKey, 0, len(r.depths))
+	for key := range r.depths {
+		keys = append(keys, key)
+	}
+	sortHistKeys(keys)
+
+	for _, key := range keys {
+		if err := store.SetRequired(key.streamID, key.aggregator, r.depths[key]); err != nil {
+			return fmt.Errorf("set history requirement for stream %d aggregator %d: %w", key.streamID, key.aggregator, err)
+		}
+	}
+
+	for _, key := range store.indexKeys() {
+		if _, admitted := r.depths[key]; admitted {
+			continue
+		}
+		if err := store.SetRequired(key.streamID, key.aggregator, 0); err != nil {
+			return fmt.Errorf("clear history requirement for stream %d aggregator %d: %w", key.streamID, key.aggregator, err)
+		}
+	}
+	return nil
+}
+
+// requires reports whether a pair was admitted, i.e. whether this round should
+// append to its window.
+func (r historyRequirements) requires(sid llotypes.StreamID, agg llotypes.Aggregator) bool {
+	_, ok := r.depths[histKey{streamID: sid, aggregator: agg}]
+	return ok
+}
+
+// sortedDenied returns denied pairs for logging and telemetry.
+func (r historyRequirements) sortedDenied() []histKey {
+	denied := append([]histKey{}, r.denied...)
+	sortHistKeys(denied)
+	return denied
+}

--- a/llo/dev/v31/history_requirements.go
+++ b/llo/dev/v31/history_requirements.go
@@ -16,7 +16,7 @@ type historyRequirements struct {
 	// depths holds the admitted pairs and their required window depth.
 	depths map[histKey]uint32
 	// denied holds pairs that were required but could not be admitted within
-	// the pair and byte caps, sorted. Channels referencing them cannot evaluate
+	// the pair cap, sorted. Channels referencing them cannot evaluate
 	// and so are not reportable; they are reported here so the caller can say so
 	// loudly rather than silently producing shorter windows.
 	denied []histKey

--- a/llo/dev/v31/history_requirements_test.go
+++ b/llo/dev/v31/history_requirements_test.go
@@ -1,0 +1,293 @@
+package llo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+func exprChannel(streams []llotypes.Stream, expressions ...string) llotypes.ChannelDefinition {
+	abi := ""
+	for i, expression := range expressions {
+		if i > 0 {
+			abi += ","
+		}
+		abi += fmt.Sprintf(`{"type":"int256","expression":%q,"expressionStreamID":%d}`, expression, 900+i)
+	}
+	return llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+		Streams:      streams,
+		Opts:         []byte(fmt.Sprintf(`{"abi":[%s]}`, abi)),
+	}
+}
+
+func medianStream(id llotypes.StreamID) llotypes.Stream {
+	return llotypes.Stream{StreamID: id, Aggregator: llotypes.AggregatorMedian}
+}
+
+func requirementsFor(t *testing.T, defs llotypes.ChannelDefinitions) historyRequirements {
+	t.Helper()
+	cache := protocol.NewOptsCache()
+	cache.ResetTo(defs)
+	return computeHistoryRequirements(defs, cache, logger.Test(t))
+}
+
+func TestComputeHistoryRequirements(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no expressions using history", func(t *testing.T) {
+		t.Parallel()
+		got := requirementsFor(t, llotypes.ChannelDefinitions{
+			1: exprChannel([]llotypes.Stream{medianStream(1), medianStream(2)}, "Add(s1, s2)"),
+		})
+		assert.Empty(t, got.depths)
+		assert.Empty(t, got.denied)
+	})
+
+	t.Run("single window", func(t *testing.T) {
+		t.Parallel()
+		got := requirementsFor(t, llotypes.ChannelDefinitions{
+			1: exprChannel([]llotypes.Stream{medianStream(1)}, "Count(History(s1, 10))"),
+		})
+		assert.Equal(t, map[histKey]uint32{
+			{streamID: 1, aggregator: llotypes.AggregatorMedian}: 10,
+		}, got.depths)
+	})
+
+	t.Run("depth is the maximum across channels", func(t *testing.T) {
+		t.Parallel()
+		// Two channels want different depths of the same pair; the deeper one
+		// wins, and the shallower reads a prefix of the same window.
+		got := requirementsFor(t, llotypes.ChannelDefinitions{
+			1: exprChannel([]llotypes.Stream{medianStream(1)}, "Count(History(s1, 10))"),
+			2: exprChannel([]llotypes.Stream{medianStream(1)}, "Count(History(s1, 300))"),
+			3: exprChannel([]llotypes.Stream{medianStream(1)}, "Count(History(s1, 50))"),
+		})
+		assert.Equal(t, map[histKey]uint32{
+			{streamID: 1, aggregator: llotypes.AggregatorMedian}: 300,
+		}, got.depths)
+	})
+
+	t.Run("depth is the maximum across fields of one pair", func(t *testing.T) {
+		t.Parallel()
+		// The field is not part of the key: one window serves all of them, so
+		// the depth must cover the deepest field request.
+		got := requirementsFor(t, llotypes.ChannelDefinitions{
+			1: exprChannel([]llotypes.Stream{medianStream(1)},
+				"Add(Count(History(s1_bid, 10)), Count(History(s1_ask, 40)))"),
+		})
+		assert.Equal(t, map[histKey]uint32{
+			{streamID: 1, aggregator: llotypes.AggregatorMedian}: 40,
+		}, got.depths)
+	})
+
+	t.Run("depth is the maximum across expressions of one channel", func(t *testing.T) {
+		t.Parallel()
+		got := requirementsFor(t, llotypes.ChannelDefinitions{
+			1: exprChannel([]llotypes.Stream{medianStream(1)},
+				"Count(History(s1, 5))", "Count(History(s1, 25))"),
+		})
+		assert.Equal(t, map[histKey]uint32{
+			{streamID: 1, aggregator: llotypes.AggregatorMedian}: 25,
+		}, got.depths)
+	})
+
+	t.Run("aggregator is part of the identity", func(t *testing.T) {
+		t.Parallel()
+		got := requirementsFor(t, llotypes.ChannelDefinitions{
+			1: exprChannel([]llotypes.Stream{medianStream(1)}, "Count(History(s1, 10))"),
+			2: exprChannel([]llotypes.Stream{{StreamID: 1, Aggregator: llotypes.AggregatorMode}}, "Count(History(s1, 20))"),
+		})
+		assert.Equal(t, map[histKey]uint32{
+			{streamID: 1, aggregator: llotypes.AggregatorMedian}: 10,
+			{streamID: 1, aggregator: llotypes.AggregatorMode}:   20,
+		}, got.depths)
+	})
+
+	t.Run("tombstoned and non-expression channels contribute nothing", func(t *testing.T) {
+		t.Parallel()
+		tombstoned := exprChannel([]llotypes.Stream{medianStream(1)}, "Count(History(s1, 10))")
+		tombstoned.Tombstone = true
+		other := exprChannel([]llotypes.Stream{medianStream(2)}, "Count(History(s2, 10))")
+		other.ReportFormat = llotypes.ReportFormatJSON
+
+		got := requirementsFor(t, llotypes.ChannelDefinitions{1: tombstoned, 2: other})
+		assert.Empty(t, got.depths)
+	})
+
+	t.Run("ambiguous aggregation contributes nothing", func(t *testing.T) {
+		t.Parallel()
+		// The channel cannot be evaluated either, so reserving history for it
+		// would keep a window alive that nothing can read.
+		got := requirementsFor(t, llotypes.ChannelDefinitions{
+			1: exprChannel([]llotypes.Stream{
+				medianStream(1),
+				{StreamID: 1, Aggregator: llotypes.AggregatorMode},
+			}, "Count(History(s1, 10))"),
+		})
+		assert.Empty(t, got.depths)
+	})
+
+	t.Run("invalid expression contributes nothing", func(t *testing.T) {
+		t.Parallel()
+		got := requirementsFor(t, llotypes.ChannelDefinitions{
+			1: exprChannel([]llotypes.Stream{medianStream(1)}, "Add(History(s1, 10), 1)"),
+		})
+		assert.Empty(t, got.depths)
+	})
+
+	t.Run("undeclared stream contributes nothing", func(t *testing.T) {
+		t.Parallel()
+		got := requirementsFor(t, llotypes.ChannelDefinitions{
+			1: exprChannel([]llotypes.Stream{medianStream(1)}, "Count(History(s2, 10))"),
+		})
+		assert.Empty(t, got.depths)
+	})
+
+	t.Run("undecodable opts contribute nothing", func(t *testing.T) {
+		t.Parallel()
+		cd := exprChannel([]llotypes.Stream{medianStream(1)}, "Count(History(s1, 10))")
+		cd.Opts = []byte(`{"abi":`)
+		got := requirementsFor(t, llotypes.ChannelDefinitions{1: cd})
+		assert.Empty(t, got.depths)
+	})
+
+	// Determinism is the property the whole design rests on: these depths become
+	// persisted state, so two oracles must derive them identically.
+	t.Run("deterministic across repeated computation", func(t *testing.T) {
+		t.Parallel()
+		defs := llotypes.ChannelDefinitions{}
+		for i := range 40 {
+			id := llotypes.ChannelID(i + 1)
+			streamID := llotypes.StreamID(i%7 + 1)
+			defs[id] = exprChannel([]llotypes.Stream{medianStream(streamID)},
+				fmt.Sprintf("Count(History(s%d, %d))", streamID, i+1))
+		}
+		first := requirementsFor(t, defs)
+		for range 20 {
+			require.Equal(t, first.depths, requirementsFor(t, defs).depths)
+		}
+	})
+}
+
+func TestAdmitHistoryRequirements(t *testing.T) {
+	t.Parallel()
+
+	t.Run("admits within the caps", func(t *testing.T) {
+		t.Parallel()
+		got := admitHistoryRequirements(map[histKey]uint32{
+			{streamID: 1, aggregator: llotypes.AggregatorMedian}: 10,
+			{streamID: 2, aggregator: llotypes.AggregatorMedian}: 20,
+		}, logger.Test(t))
+		assert.Len(t, got.depths, 2)
+		assert.Empty(t, got.denied)
+	})
+
+	t.Run("denies pairs beyond the pair cap, lowest keys first", func(t *testing.T) {
+		t.Parallel()
+		required := map[histKey]uint32{}
+		for i := range protocol.MaxHistoryPairs + 5 {
+			required[histKey{streamID: llotypes.StreamID(i + 1), aggregator: llotypes.AggregatorMedian}] = 1
+		}
+		got := admitHistoryRequirements(required, logger.Test(t))
+		assert.Len(t, got.depths, protocol.MaxHistoryPairs)
+		require.Len(t, got.denied, 5)
+		// Admission is by (streamID, aggregator) order, so the denied set is the
+		// tail. Any other rule risks differing between oracles.
+		for i, key := range got.sortedDenied() {
+			assert.Equal(t, llotypes.StreamID(protocol.MaxHistoryPairs+i+1), key.streamID)
+		}
+	})
+
+	t.Run("depth does not affect admission", func(t *testing.T) {
+		t.Parallel()
+		// Under the chunked layout a pair costs the same per round however deep
+		// it is, so a full-depth pair is admitted on exactly the same terms as a
+		// shallow one.
+		required := map[histKey]uint32{}
+		for i := range protocol.MaxHistoryPairs {
+			required[histKey{streamID: llotypes.StreamID(i + 1), aggregator: llotypes.AggregatorMedian}] = protocol.MaxHistoryRecordsPerPair
+		}
+		got := admitHistoryRequirements(required, logger.Test(t))
+		assert.Len(t, got.depths, protocol.MaxHistoryPairs)
+		assert.Empty(t, got.denied)
+	})
+
+	t.Run("denial is deterministic", func(t *testing.T) {
+		t.Parallel()
+		required := map[histKey]uint32{}
+		for i := range protocol.MaxHistoryPairs + 10 {
+			required[histKey{streamID: llotypes.StreamID(i + 1), aggregator: llotypes.AggregatorMedian}] = 8
+		}
+		first := admitHistoryRequirements(required, logger.Test(t))
+		for range 20 {
+			again := admitHistoryRequirements(required, logger.Test(t))
+			require.Equal(t, first.depths, again.depths)
+			require.Equal(t, first.sortedDenied(), again.sortedDenied())
+		}
+	})
+}
+
+func TestHistoryRequirements_Apply(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	key := histKey{streamID: 1, aggregator: llotypes.AggregatorMedian}
+
+	// Round 1: the pair is required, so a window is stored.
+	store := newTestHistoryStore(t, kv)
+	require.NoError(t, historyRequirements{depths: map[histKey]uint32{key: 5}}.apply(store))
+	_, err := store.Append(key.streamID, key.aggregator, 1_000, testDecimal(1))
+	require.NoError(t, err)
+	require.NoError(t, store.Flush(kv))
+
+	stored := readHistory(t, kv, key.streamID, key.aggregator)
+	require.NotNil(t, stored)
+
+	// Round 2: the pair is no longer required. apply must clear it explicitly,
+	// otherwise the window would linger forever.
+	store = newTestHistoryStore(t, kv)
+	require.NoError(t, historyRequirements{depths: map[histKey]uint32{}}.apply(store))
+	require.NoError(t, store.Flush(kv))
+
+	stored = readHistory(t, kv, key.streamID, key.aggregator)
+	assert.Nil(t, stored, "a pair that stopped being required must be reclaimed")
+}
+
+func TestHistoryRequirements_Requires(t *testing.T) {
+	t.Parallel()
+
+	r := historyRequirements{depths: map[histKey]uint32{
+		{streamID: 1, aggregator: llotypes.AggregatorMedian}: 5,
+	}}
+	assert.True(t, r.requires(1, llotypes.AggregatorMedian))
+	assert.False(t, r.requires(1, llotypes.AggregatorMode), "the aggregator is part of the identity")
+	assert.False(t, r.requires(2, llotypes.AggregatorMedian))
+
+	// A pair denied by the caps is not required, so nothing is appended for it.
+	denied := historyRequirements{depths: map[histKey]uint32{}, denied: []histKey{{streamID: 1, aggregator: llotypes.AggregatorMedian}}}
+	assert.False(t, denied.requires(1, llotypes.AggregatorMedian))
+}
+
+// TestHistoryBudgetFitsPairCap is what lets admission apply the pair cap alone.
+//
+// A pair rewrites one chunk and one header per round whatever its depth, so if
+// MaxHistoryPairs of them fit inside the per-round byte budget then the budget
+// can never be the binding constraint and there is nothing for admission to
+// check. Under the single-blob layout this did not hold — a pair cost
+// requiredCount * MaxHistoryRecordBytes and the budget denied pairs well before
+// the cap did.
+func TestHistoryBudgetFitsPairCap(t *testing.T) {
+	t.Parallel()
+
+	worstCase := protocol.MaxHistoryPairs * protocol.MaxHistoryPairRoundBytes
+	assert.LessOrEqual(t, worstCase, protocol.MaxHistoryTotalBytes,
+		"admission relies on the pair cap alone, which requires every admitted pair to fit the byte budget")
+}

--- a/llo/dev/v31/history_test.go
+++ b/llo/dev/v31/history_test.go
@@ -867,6 +867,59 @@ func TestHistoryStore_ResetsOnLayoutChange(t *testing.T) {
 	assert.Equal(t, writesBefore, kv.writes[string(keyHistoryVersion)], "the version must be written once, not every round")
 }
 
+// TestHistoryStore_LayoutChangeAbandonsStoredWindows covers the two things a
+// layout reset must do to state that was actually written: a pair still required
+// re-warms from empty rather than adopting bytes that merely happen to decode,
+// and a pair no longer required has all of its keys deleted rather than being
+// stranded by an index that no longer names it.
+func TestHistoryStore_LayoutChangeAbandonsStoredWindows(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	kept := histKey{streamID: 1, aggregator: testAggMedian}
+	dropped := histKey{streamID: 2, aggregator: testAggMedian}
+
+	// Real stored state under the current layout: two pairs, each with a header,
+	// a chunk and an index entry.
+	seed := newTestHistoryStore(t, kv)
+	for _, k := range []histKey{kept, dropped} {
+		require.NoError(t, seed.SetRequired(k.streamID, k.aggregator, 3))
+		_, err := seed.Append(k.streamID, k.aggregator, 1_000, testDecimal(7))
+		require.NoError(t, err)
+	}
+	require.NoError(t, seed.Flush(kv))
+	require.Len(t, readHistoryRecords(t, kv, kept.streamID, kept.aggregator), 1)
+	require.Len(t, readHistoryRecords(t, kv, dropped.streamID, dropped.aggregator), 1)
+
+	// A node comes up on a different layout.
+	require.NoError(t, kv.Write(keyHistoryVersion, []byte{historyLayoutVersion + 1}))
+
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(kept.streamID, kept.aggregator, 3))
+	_, err := s.Append(kept.streamID, kept.aggregator, 2_000, testDecimal(9))
+	require.NoError(t, err)
+	require.NoError(t, s.Flush(kv))
+
+	// The still-required pair starts over: the pre-reset record is gone, even
+	// though it was stored in a form this layout can decode.
+	records := readHistoryRecords(t, kv, kept.streamID, kept.aggregator)
+	require.Len(t, records, 1, "the abandoned record must not be carried over")
+	assert.Equal(t, uint64(2_000), records[0].ObservedAtNanoseconds)
+
+	// The pair nobody requires is reclaimed, keys and all.
+	assert.Nil(t, readHistory(t, kv, dropped.streamID, dropped.aggregator), "the header must be deleted")
+	for _, key := range historyKeys(dropped.streamID, dropped.aggregator) {
+		b, err := kv.Read(key)
+		require.NoError(t, err)
+		assert.Empty(t, b, "key %x must be deleted", key)
+	}
+
+	// And the rewritten index names only what survived.
+	index, err := readHistoryIndex(kv)
+	require.NoError(t, err)
+	assert.Equal(t, []histKey{kept}, index)
+}
+
 // TestHistoryStore_UnusedStateStaysUntouched checks the layout reset does not
 // stamp a version onto a DON that has never stored any history.
 func TestHistoryStore_UnusedStateStaysUntouched(t *testing.T) {

--- a/llo/dev/v31/history_test.go
+++ b/llo/dev/v31/history_test.go
@@ -1,0 +1,1005 @@
+package llo
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol/calculated"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
+)
+
+// countingKV counts accesses per key so tests can assert the one-read,
+// one-write-per-pair-per-round guarantee that makes history affordable inside
+// the OCR3.1 round budget.
+type countingKV struct {
+	*memKV
+	reads   map[string]int
+	writes  map[string]int
+	deletes map[string]int
+}
+
+func newCountingKV() *countingKV {
+	return &countingKV{
+		memKV:   newMemKV(),
+		reads:   map[string]int{},
+		writes:  map[string]int{},
+		deletes: map[string]int{},
+	}
+}
+
+func (k *countingKV) Read(key []byte) ([]byte, error) {
+	k.reads[string(key)]++
+	return k.memKV.Read(key)
+}
+
+func (k *countingKV) Write(key, value []byte) error {
+	k.writes[string(key)]++
+	return k.memKV.Write(key, value)
+}
+
+func (k *countingKV) Delete(key []byte) error {
+	k.deletes[string(key)]++
+	return k.memKV.Delete(key)
+}
+
+var _ ocr3_1types.KeyValueStateReadWriter = &countingKV{}
+
+const (
+	testAggMedian = llotypes.AggregatorMedian
+	testAggMode   = llotypes.AggregatorMode
+)
+
+func newTestHistoryStore(t *testing.T, kv ocr3_1types.KeyValueStateReader) *historyStore {
+	t.Helper()
+	s, err := newHistoryStore(kv, logger.Test(t))
+	require.NoError(t, err)
+	return s
+}
+
+func testDecimal(i int64) protocol.StreamValue {
+	return protocol.ToDecimal(decimal.NewFromInt(i))
+}
+
+// readHistory reassembles a stored window from its header and chunks, or
+// returns nil when the pair holds no header.
+//
+// Tests assert against what is actually in the key-value state rather than
+// against a store's in-memory copy, so they need to walk the same keys the store
+// does. Unlike the store it loads every retained chunk, which is what makes it
+// a check on the stored form rather than on the read plan.
+func readHistory(t *testing.T, r ocr3_1types.KeyValueStateReader, sid llotypes.StreamID, agg llotypes.Aggregator) *protocol.RingWindow {
+	t.Helper()
+
+	header, err := readHistoryHeader(r, sid, agg)
+	require.NoError(t, err)
+	if header == nil {
+		return nil
+	}
+
+	w := protocol.NewRingWindow(header)
+	for _, sequence := range header.Sequences() {
+		chunk, err := readHistoryChunk(r, sid, agg, protocol.HistoryChunkSlot(sequence))
+		require.NoError(t, err)
+		require.NotNil(t, chunk, "header retains chunk %d but the slot is empty", sequence)
+		require.NoError(t, w.Provide(chunk))
+	}
+	return w
+}
+
+// requireHistoryRetention asserts the retention rule: a warm window holds at
+// least the required depth and overshoots it by less than one chunk, because
+// chunks are evicted whole.
+func requireHistoryRetention(t *testing.T, w *protocol.RingWindow) {
+	t.Helper()
+
+	require.NotNil(t, w)
+	assert.GreaterOrEqual(t, w.Len(), int(w.RequiredCount()), "a window must cover the depth it was asked for")
+	assert.Less(t, w.Len(), int(w.RequiredCount())+protocol.MaxHistoryChunkRecords,
+		"retention keeps as few whole chunks as cover the requirement")
+}
+
+// readHistoryNewest returns the newest n records of a stored window.
+func readHistoryNewest(t *testing.T, r ocr3_1types.KeyValueStateReader, sid llotypes.StreamID, agg llotypes.Aggregator, n uint32) []protocol.StreamHistoryRecord {
+	t.Helper()
+
+	records, err := readHistory(t, r, sid, agg).Newest(n)
+	require.NoError(t, err)
+	return records
+}
+
+// historyTimestamps extracts the observation timestamps of a run of records.
+func historyTimestamps(records []protocol.StreamHistoryRecord) []uint64 {
+	timestamps := make([]uint64, 0, len(records))
+	for _, record := range records {
+		timestamps = append(timestamps, record.ObservedAtNanoseconds)
+	}
+	return timestamps
+}
+
+// readHistoryRecords returns every record of a stored window, oldest first.
+func readHistoryRecords(t *testing.T, r ocr3_1types.KeyValueStateReader, sid llotypes.StreamID, agg llotypes.Aggregator) []protocol.StreamHistoryRecord {
+	t.Helper()
+
+	w := readHistory(t, r, sid, agg)
+	if w == nil {
+		return nil
+	}
+	records, err := w.Newest(uint32(w.Len()))
+	require.NoError(t, err)
+	return records
+}
+
+// historyKeys returns every key a pair may occupy: the header and the whole
+// ring slot space.
+func historyKeys(sid llotypes.StreamID, agg llotypes.Aggregator) [][]byte {
+	keys := [][]byte{historyHeaderKey(sid, agg)}
+	for slot := range uint32(protocol.MaxHistoryChunkSlots) {
+		keys = append(keys, historyChunkKey(sid, agg, slot))
+	}
+	return keys
+}
+
+// historyKeyWrites totals the writes across every key belonging to a pair.
+func historyKeyWrites(kv *countingKV, sid llotypes.StreamID, agg llotypes.Aggregator) int {
+	writes := 0
+	for _, key := range historyKeys(sid, agg) {
+		writes += kv.writes[string(key)]
+	}
+	return writes
+}
+
+// historyKeyReads totals the reads across every key belonging to a pair.
+func historyKeyReads(kv *countingKV, sid llotypes.StreamID, agg llotypes.Aggregator) int {
+	reads := 0
+	for _, key := range historyKeys(sid, agg) {
+		reads += kv.reads[string(key)]
+	}
+	return reads
+}
+
+// historyStoredBytes totals the bytes a pair occupies across all of its keys.
+func historyStoredBytes(t *testing.T, kv *countingKV, sid llotypes.StreamID, agg llotypes.Aggregator) int {
+	t.Helper()
+
+	bytes := 0
+	for _, key := range historyKeys(sid, agg) {
+		b, err := kv.Read(key)
+		require.NoError(t, err)
+		bytes += len(b)
+	}
+	return bytes
+}
+
+func TestHistoryStore_EmptyState(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	s := newTestHistoryStore(t, kv)
+
+	h, err := s.Load(1, testAggMedian)
+	require.NoError(t, err)
+	require.NotNil(t, h, "an unstored pair must load as an empty window, not nil")
+	assert.Equal(t, 0, h.Len())
+	assert.Zero(t, h.RequiredCount())
+
+	// Nothing was required, so nothing is persisted.
+	require.NoError(t, s.Flush(kv))
+	assert.Empty(t, kv.writes)
+}
+
+func TestHistoryStore_AppendAndFlush(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	s := newTestHistoryStore(t, kv)
+
+	require.NoError(t, s.SetRequired(1, testAggMedian, 3))
+	appended, err := s.Append(1, testAggMedian, 1_000, testDecimal(10))
+	require.NoError(t, err)
+	assert.True(t, appended)
+	require.NoError(t, s.Flush(kv))
+
+	// The window and the index are both persisted.
+	stored := readHistory(t, kv, 1, testAggMedian)
+	require.NotNil(t, stored)
+	assert.Equal(t, 1, stored.Len())
+	assert.Equal(t, uint32(3), stored.RequiredCount())
+
+	idx, err := readHistoryIndex(kv)
+	require.NoError(t, err)
+	assert.Equal(t, []histKey{{streamID: 1, aggregator: testAggMedian}}, idx)
+}
+
+// TestHistoryStore_ReadOnceWriteOnce is the core cost guarantee: however many
+// channels or expressions touch a pair in a round, each of its keys is read
+// once and written once.
+func TestHistoryStore_ReadOnceWriteOnce(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	s := newTestHistoryStore(t, kv)
+
+	// Ten channels all declaring History(s1, 300), then reading it back.
+	for range 10 {
+		require.NoError(t, s.SetRequired(1, testAggMedian, 300))
+		_, err := s.Load(1, testAggMedian)
+		require.NoError(t, err)
+	}
+	_, err := s.Append(1, testAggMedian, 1_000, testDecimal(1))
+	require.NoError(t, err)
+	for range 10 {
+		_, err := s.Load(1, testAggMedian)
+		require.NoError(t, err)
+	}
+	require.NoError(t, s.Flush(kv))
+
+	// Nothing is stored yet, so the round reads the header and no chunk: an
+	// empty window has none to append into.
+	assert.Equal(t, 1, historyKeyReads(kv, 1, testAggMedian), "each history key must be read at most once per round")
+	assert.Equal(t, 1, kv.reads[string(historyHeaderKey(1, testAggMedian))])
+	assert.Equal(t, 2, historyKeyWrites(kv, 1, testAggMedian), "a round writes the header and the newest chunk, nothing else")
+	assert.Equal(t, 1, kv.writes[string(keyHistoryIndex)], "index must be written at most once per round")
+}
+
+// TestHistoryStore_ReadsOnlyWhatItNeeds is the property the chunked layout buys:
+// the number of chunks a round reads follows the depth it actually asks for, not
+// the depth of the window.
+func TestHistoryStore_ReadsOnlyWhatItNeeds(t *testing.T) {
+	t.Parallel()
+
+	const depth = protocol.MaxHistoryChunkRecords * 4
+	kv := newCountingKV()
+	for round := 1; round <= depth; round++ {
+		s := newTestHistoryStore(t, kv)
+		require.NoError(t, s.SetRequired(1, testAggMedian, depth))
+		_, err := s.Append(1, testAggMedian, uint64(round)*1_000, testDecimal(int64(round)))
+		require.NoError(t, err)
+		require.NoError(t, s.Flush(kv))
+	}
+
+	for _, tc := range []struct {
+		count uint32
+		reads int
+	}{
+		{count: 1, reads: 2}, // header + newest chunk
+		{count: protocol.MaxHistoryChunkRecords, reads: 2},     //
+		{count: protocol.MaxHistoryChunkRecords + 1, reads: 3}, //
+		{count: depth, reads: 5},                               // header + all four chunks
+		{count: depth + 1, reads: 1},                           // unsatisfiable: header only
+	} {
+		t.Run(strconv.Itoa(int(tc.count)), func(t *testing.T) {
+			kv := &countingKV{memKV: kv.memKV, reads: map[string]int{}, writes: map[string]int{}, deletes: map[string]int{}}
+			s := newTestHistoryStore(t, kv)
+
+			_, err := s.Series(1, testAggMedian, tc.count, calculated.FieldValue)
+			if tc.count > depth {
+				require.ErrorIs(t, err, protocol.ErrInsufficientStreamHistory)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.reads, historyKeyReads(kv, 1, testAggMedian))
+		})
+	}
+}
+
+// TestHistoryStore_UnchangedWindowNotWritten keeps modifiedKeys low: a round
+// that neither appends nor changes capacity must not touch the key.
+func TestHistoryStore_UnchangedWindowNotWritten(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(1, testAggMedian, 5))
+	_, err := s.Append(1, testAggMedian, 1_000, testDecimal(1))
+	require.NoError(t, err)
+	require.NoError(t, s.Flush(kv))
+
+	writesAfterFirstRound := historyKeyWrites(kv, 1, testAggMedian)
+	indexWritesAfterFirstRound := kv.writes[string(keyHistoryIndex)]
+
+	// Next round: same requirement, and a stale observation timestamp that
+	// must not be re-appended.
+	s = newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(1, testAggMedian, 5))
+	appended, err := s.Append(1, testAggMedian, 1_000, testDecimal(2))
+	require.NoError(t, err)
+	assert.False(t, appended, "a non-advancing timestamp must not be appended")
+	require.NoError(t, s.Flush(kv))
+
+	assert.Equal(t, writesAfterFirstRound, historyKeyWrites(kv, 1, testAggMedian), "unchanged window must not be rewritten")
+	assert.Equal(t, indexWritesAfterFirstRound, kv.writes[string(keyHistoryIndex)], "unchanged index must not be rewritten")
+}
+
+func TestHistoryStore_MultiRoundAccumulation(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+
+	for round := 1; round <= 6; round++ {
+		s := newTestHistoryStore(t, kv)
+		require.NoError(t, s.SetRequired(1, testAggMedian, 3))
+		appended, err := s.Append(1, testAggMedian, uint64(round)*1_000, testDecimal(int64(round)))
+		require.NoError(t, err)
+		assert.True(t, appended)
+		require.NoError(t, s.Flush(kv))
+	}
+
+	// Records accumulate across rounds and the newest are the ones an expression
+	// reads. Retention works in whole chunks, so with a capacity far below the
+	// chunk size nothing has been evicted yet — what is bounded is what is read.
+	stored := readHistory(t, kv, 1, testAggMedian)
+	requireHistoryRetention(t, stored)
+	assert.Equal(t, uint64(6_000), stored.LastObservationTimestampNanoseconds())
+	assert.Equal(t, []uint64{4_000, 5_000, 6_000},
+		historyTimestamps(readHistoryNewest(t, kv, 1, testAggMedian, 3)))
+}
+
+func TestHistoryStore_RequirementChanges(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+
+	// Warm five records at capacity 5.
+	for round := 1; round <= 5; round++ {
+		s := newTestHistoryStore(t, kv)
+		require.NoError(t, s.SetRequired(1, testAggMedian, 5))
+		_, err := s.Append(1, testAggMedian, uint64(round)*1_000, testDecimal(int64(round)))
+		require.NoError(t, err)
+		require.NoError(t, s.Flush(kv))
+	}
+
+	// Lowering the requirement trims immediately.
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(1, testAggMedian, 2))
+	require.NoError(t, s.Flush(kv))
+
+	stored := readHistory(t, kv, 1, testAggMedian)
+	assert.Equal(t, uint32(2), stored.RequiredCount())
+	requireHistoryRetention(t, stored)
+	assert.Equal(t, []uint64{4_000, 5_000}, historyTimestamps(readHistoryNewest(t, kv, 1, testAggMedian, 2)))
+
+	// Raising it keeps what is there; the extra depth fills over later rounds.
+	s = newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(1, testAggMedian, 10))
+	require.NoError(t, s.Flush(kv))
+
+	stored = readHistory(t, kv, 1, testAggMedian)
+	assert.Equal(t, uint32(10), stored.RequiredCount())
+	_, err := stored.Newest(10)
+	assert.ErrorIs(t, err, protocol.ErrInsufficientStreamHistory, "the extra depth is not yet available")
+}
+
+// warmHistory runs n rounds appending to a pair, leaving the store flushed.
+func warmHistory(t *testing.T, kv ocr3_1types.KeyValueStateReadWriter, k histKey, required uint32, rounds int) {
+	t.Helper()
+	for round := 1; round <= rounds; round++ {
+		s := newTestHistoryStore(t, kv)
+		require.NoError(t, s.SetRequired(k.streamID, k.aggregator, required))
+		_, err := s.Append(k.streamID, k.aggregator, uint64(round)*1_000, testDecimal(int64(round)))
+		require.NoError(t, err)
+		require.NoError(t, s.Flush(kv))
+	}
+}
+
+// TestHistoryStore_ShrinkReclaimsState covers a config change that lowers the
+// requested depth: the deeper window must be trimmed to the new depth in the
+// round the requirement drops, not carried until it happens to evict.
+func TestHistoryStore_ShrinkReclaimsState(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	key := histKey{streamID: 1, aggregator: testAggMedian}
+	warmHistory(t, kv, key, 300, 300)
+
+	deep := readHistory(t, kv, key.streamID, key.aggregator)
+	requireHistoryRetention(t, deep)
+	require.Equal(t, 300, deep.Len())
+	deepBytes := historyStoredBytes(t, kv, key.streamID, key.aggregator)
+
+	// A channel edit lowers the deepest requirement for this pair to 10.
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(key.streamID, key.aggregator, 10))
+	require.NoError(t, s.Flush(kv))
+
+	shallow := readHistory(t, kv, key.streamID, key.aggregator)
+	assert.Equal(t, uint32(10), shallow.RequiredCount())
+	requireHistoryRetention(t, shallow)
+	assert.Less(t, shallow.Len(), deep.Len(), "the window must be trimmed in the round the requirement drops")
+	// The newest records are the ones kept.
+	assert.Equal(t, uint64(300_000), shallow.LastObservationTimestampNanoseconds())
+	assert.Equal(t, uint64(291_000), readHistoryNewest(t, kv, key.streamID, key.aggregator, 10)[0].ObservedAtNanoseconds)
+
+	shallowBytes := historyStoredBytes(t, kv, key.streamID, key.aggregator)
+	assert.Less(t, shallowBytes, deepBytes, "trimming must actually reclaim stored bytes")
+
+	// The lower capacity persists: later rounds must not regrow past it.
+	warmHistory(t, kv, key, 10, 5)
+	stored := readHistory(t, kv, key.streamID, key.aggregator)
+	assert.Equal(t, uint32(10), stored.RequiredCount())
+	requireHistoryRetention(t, stored)
+}
+
+// TestHistoryStore_ShrinkBelowStoredButAboveNothing checks the shrink case where
+// the stored window is already shorter than the new capacity: nothing is
+// trimmed, but the lower capacity is still persisted.
+func TestHistoryStore_ShrinkWithoutTrim(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	key := histKey{streamID: 1, aggregator: testAggMedian}
+	warmHistory(t, kv, key, 300, 3)
+
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(key.streamID, key.aggregator, 10))
+	require.NoError(t, s.Flush(kv))
+
+	stored := readHistory(t, kv, key.streamID, key.aggregator)
+	assert.Equal(t, 3, stored.Len())
+	assert.Equal(t, uint32(10), stored.RequiredCount())
+}
+
+// TestHistoryStore_UnreferencedStreamFullyRemoved covers a stream that no
+// expression references any more: its window and its index entry must both go,
+// while its siblings are left untouched.
+func TestHistoryStore_UnreferencedStreamFullyRemoved(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	kept := histKey{streamID: 1, aggregator: testAggMedian}
+	dropped := histKey{streamID: 2, aggregator: testAggMedian}
+	alsoKept := histKey{streamID: 3, aggregator: testAggMode}
+
+	s := newTestHistoryStore(t, kv)
+	for _, k := range []histKey{kept, dropped, alsoKept} {
+		require.NoError(t, s.SetRequired(k.streamID, k.aggregator, 5))
+		_, err := s.Append(k.streamID, k.aggregator, 1_000, testDecimal(1))
+		require.NoError(t, err)
+	}
+	require.NoError(t, s.Flush(kv))
+
+	keptBytesBefore := historyStoredBytes(t, kv, kept.streamID, kept.aggregator)
+	keptWritesBefore := historyKeyWrites(kv, kept.streamID, kept.aggregator)
+
+	// Stream 2 is no longer referenced: it is simply absent from this round's
+	// requirements, which is what channel removal looks like.
+	s = newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(kept.streamID, kept.aggregator, 5))
+	require.NoError(t, s.SetRequired(alsoKept.streamID, alsoKept.aggregator, 5))
+	require.NoError(t, s.Flush(kv))
+
+	gone := readHistory(t, kv, dropped.streamID, dropped.aggregator)
+	assert.Nil(t, gone, "unreferenced stream must have its window deleted")
+	assert.Equal(t, 1, kv.deletes[string(historyHeaderKey(dropped.streamID, dropped.aggregator))],
+		"the header is what makes a window findable, so it must be deleted exactly once")
+
+	idx, err := readHistoryIndex(kv)
+	require.NoError(t, err)
+	assert.Equal(t, []histKey{kept, alsoKept}, idx, "index must be pruned to the surviving pairs")
+
+	// Siblings are untouched: no rewrite, no data change.
+	assert.Equal(t, keptBytesBefore, historyStoredBytes(t, kv, kept.streamID, kept.aggregator))
+	assert.Equal(t, keptWritesBefore, historyKeyWrites(kv, kept.streamID, kept.aggregator),
+		"removing one pair must not rewrite the others")
+}
+
+// TestHistoryStore_RemovingAllStreamsEmptiesIndex checks the state fully drains
+// when every calculated channel goes away.
+func TestHistoryStore_RemovingAllStreamsEmptiesIndex(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	pairs := []histKey{
+		{streamID: 1, aggregator: testAggMedian},
+		{streamID: 2, aggregator: testAggMedian},
+		{streamID: 2, aggregator: testAggMode},
+	}
+
+	s := newTestHistoryStore(t, kv)
+	for _, k := range pairs {
+		require.NoError(t, s.SetRequired(k.streamID, k.aggregator, 5))
+		_, err := s.Append(k.streamID, k.aggregator, 1_000, testDecimal(1))
+		require.NoError(t, err)
+	}
+	require.NoError(t, s.Flush(kv))
+
+	// A round with no calculated channels at all.
+	s = newTestHistoryStore(t, kv)
+	require.NoError(t, s.Flush(kv))
+
+	for _, k := range pairs {
+		stored := readHistory(t, kv, k.streamID, k.aggregator)
+		assert.Nilf(t, stored, "window for stream %d aggregator %d must be deleted", k.streamID, k.aggregator)
+	}
+	idx, err := readHistoryIndex(kv)
+	require.NoError(t, err)
+	assert.Empty(t, idx)
+
+	// The index is rewritten once for the whole cleanup, not once per pair.
+	assert.Equal(t, 2, kv.writes[string(keyHistoryIndex)])
+}
+
+// TestHistoryStore_IndexEntryWithoutWindow covers index/window divergence in the
+// direction the store can repair: an indexed pair whose window is already gone
+// must be pruned without failing the round.
+func TestHistoryStore_IndexEntryWithoutWindow(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	stale := histKey{streamID: 9, aggregator: testAggMedian}
+	require.NoError(t, writeHistoryIndex(kv, []histKey{stale}))
+
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.Flush(kv))
+
+	idx, err := readHistoryIndex(kv)
+	require.NoError(t, err)
+	assert.Empty(t, idx, "stale index entry must be pruned")
+}
+
+func TestHistoryStore_AggregatorScoping(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	s := newTestHistoryStore(t, kv)
+
+	// The same stream aggregated two ways must not share a series.
+	require.NoError(t, s.SetRequired(1, testAggMedian, 5))
+	require.NoError(t, s.SetRequired(1, testAggMode, 5))
+	_, err := s.Append(1, testAggMedian, 1_000, testDecimal(10))
+	require.NoError(t, err)
+	_, err = s.Append(1, testAggMode, 1_000, testDecimal(20))
+	require.NoError(t, err)
+	require.NoError(t, s.Flush(kv))
+
+	medianValue, ok := readHistoryRecords(t, kv, 1, testAggMedian)[0].Value.(*protocol.Decimal)
+	require.True(t, ok)
+	modeValue, ok := readHistoryRecords(t, kv, 1, testAggMode)[0].Value.(*protocol.Decimal)
+	require.True(t, ok)
+	assert.Equal(t, "10", medianValue.Decimal().String())
+	assert.Equal(t, "20", modeValue.Decimal().String())
+}
+
+func TestHistoryStore_OrphanCleanup(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+
+	// Two pairs get history.
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(1, testAggMedian, 5))
+	require.NoError(t, s.SetRequired(2, testAggMedian, 5))
+	_, err := s.Append(1, testAggMedian, 1_000, testDecimal(1))
+	require.NoError(t, err)
+	_, err = s.Append(2, testAggMedian, 1_000, testDecimal(2))
+	require.NoError(t, err)
+	require.NoError(t, s.Flush(kv))
+
+	idx, err := readHistoryIndex(kv)
+	require.NoError(t, err)
+	require.Len(t, idx, 2)
+
+	// Next round only stream 1 is required: stream 2's channel was removed, so
+	// its window must not be carried forward as dead state.
+	s = newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(1, testAggMedian, 5))
+	_, err = s.Append(1, testAggMedian, 2_000, testDecimal(3))
+	require.NoError(t, err)
+	require.NoError(t, s.Flush(kv))
+
+	orphan := readHistory(t, kv, 2, testAggMedian)
+	assert.Nil(t, orphan, "orphaned window must be deleted")
+
+	idx, err = readHistoryIndex(kv)
+	require.NoError(t, err)
+	assert.Equal(t, []histKey{{streamID: 1, aggregator: testAggMedian}}, idx)
+}
+
+// TestHistoryStore_ExplicitZeroRequirementDeletes covers the requirement
+// dropping to zero for a pair that is still loaded this round.
+func TestHistoryStore_ExplicitZeroRequirementDeletes(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(1, testAggMedian, 5))
+	_, err := s.Append(1, testAggMedian, 1_000, testDecimal(1))
+	require.NoError(t, err)
+	require.NoError(t, s.Flush(kv))
+
+	s = newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(1, testAggMedian, 0))
+	require.NoError(t, s.Flush(kv))
+
+	stored := readHistory(t, kv, 1, testAggMedian)
+	assert.Nil(t, stored)
+
+	idx, err := readHistoryIndex(kv)
+	require.NoError(t, err)
+	assert.Empty(t, idx)
+}
+
+// TestHistoryStore_CorruptWindow checks the fail-soft path: a malformed stored
+// window is discarded and re-warmed rather than halting the round.
+func TestHistoryStore_CorruptWindow(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	require.NoError(t, kv.Write(historyHeaderKey(1, testAggMedian), []byte("garbage")))
+	require.NoError(t, writeHistoryIndex(kv, []histKey{{streamID: 1, aggregator: testAggMedian}}))
+	require.NoError(t, writeHistoryLayoutVersion(kv))
+
+	s := newTestHistoryStore(t, kv)
+	h, err := s.Load(1, testAggMedian)
+	require.NoError(t, err, "corruption must not fail the round")
+	assert.Equal(t, 0, h.Len())
+	assert.True(t, s.corrupt[histKey{streamID: 1, aggregator: testAggMedian}])
+
+	// The bad bytes are overwritten with a valid empty-then-warming window.
+	require.NoError(t, s.SetRequired(1, testAggMedian, 3))
+	_, err = s.Append(1, testAggMedian, 1_000, testDecimal(1))
+	require.NoError(t, err)
+	require.NoError(t, s.Flush(kv))
+
+	stored := readHistory(t, kv, 1, testAggMedian)
+	require.NotNil(t, stored)
+	assert.Equal(t, 1, stored.Len())
+}
+
+// TestHistoryStore_CorruptWindowNoLongerRequired makes sure a corrupt window
+// belonging to a pair nothing needs is deleted rather than rewritten.
+func TestHistoryStore_CorruptWindowNoLongerRequired(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	require.NoError(t, kv.Write(historyHeaderKey(1, testAggMedian), []byte("garbage")))
+	require.NoError(t, writeHistoryIndex(kv, []histKey{{streamID: 1, aggregator: testAggMedian}}))
+	require.NoError(t, writeHistoryLayoutVersion(kv))
+
+	s := newTestHistoryStore(t, kv)
+	_, err := s.Load(1, testAggMedian)
+	require.NoError(t, err)
+	require.NoError(t, s.Flush(kv))
+
+	stored := readHistory(t, kv, 1, testAggMedian)
+	assert.Nil(t, stored)
+}
+
+func TestHistoryStore_SetRequiredOverCap(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	s := newTestHistoryStore(t, kv)
+
+	err := s.SetRequired(1, testAggMedian, protocol.MaxHistoryRecordsPerPair+1)
+	require.ErrorContains(t, err, "exceeds MaxHistoryRecordsPerPair")
+}
+
+func TestHistoryStore_AppendNilValue(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(1, testAggMedian, 3))
+
+	_, err := s.Append(1, testAggMedian, 1_000, nil)
+	require.ErrorIs(t, err, protocol.ErrNilStreamValue)
+}
+
+// TestHistoryStore_FlushDeterministic checks that two oracles running the same
+// round produce byte-identical state, including for pairs offered in different
+// iteration orders.
+func TestHistoryStore_FlushDeterministic(t *testing.T) {
+	t.Parallel()
+
+	pairs := []histKey{
+		{streamID: 7, aggregator: testAggMode},
+		{streamID: 1, aggregator: testAggMedian},
+		{streamID: 7, aggregator: testAggMedian},
+		{streamID: 3, aggregator: testAggMedian},
+	}
+
+	run := func(order []histKey) map[string][]byte {
+		kv := newCountingKV()
+		s := newTestHistoryStore(t, kv)
+		for i, k := range order {
+			require.NoError(t, s.SetRequired(k.streamID, k.aggregator, 4))
+			_, err := s.Append(k.streamID, k.aggregator, 1_000, testDecimal(int64(i)))
+			require.NoError(t, err)
+		}
+		require.NoError(t, s.Flush(kv))
+		return kv.m
+	}
+
+	forward := run(pairs)
+	reversed := make([]histKey, len(pairs))
+	for i, k := range pairs {
+		reversed[len(pairs)-1-i] = k
+	}
+
+	// Values differ (they are indexed by offer order), so compare the key set
+	// and the index blob, which are what must agree.
+	backward := run(reversed)
+	require.Len(t, backward, len(forward))
+	for k := range forward {
+		require.Contains(t, backward, k)
+	}
+	assert.Equal(t, forward[string(keyHistoryIndex)], backward[string(keyHistoryIndex)])
+}
+
+func TestHistoryIndexCodec(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round trips sorted", func(t *testing.T) {
+		t.Parallel()
+		in := []histKey{
+			{streamID: 7, aggregator: testAggMode},
+			{streamID: 1, aggregator: testAggMedian},
+			{streamID: 7, aggregator: testAggMedian},
+		}
+		got := decodeHistoryIndex(encodeHistoryIndex(in))
+		assert.Equal(t, []histKey{
+			{streamID: 1, aggregator: testAggMedian},
+			{streamID: 7, aggregator: testAggMedian},
+			{streamID: 7, aggregator: testAggMode},
+		}, got)
+	})
+
+	t.Run("encoding is order independent", func(t *testing.T) {
+		t.Parallel()
+		a := encodeHistoryIndex([]histKey{{streamID: 2}, {streamID: 1}})
+		b := encodeHistoryIndex([]histKey{{streamID: 1}, {streamID: 2}})
+		assert.Equal(t, a, b)
+	})
+
+	t.Run("does not mutate the input", func(t *testing.T) {
+		t.Parallel()
+		in := []histKey{{streamID: 2}, {streamID: 1}}
+		encodeHistoryIndex(in)
+		assert.Equal(t, []histKey{{streamID: 2}, {streamID: 1}}, in)
+	})
+
+	t.Run("empty and partial input", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, decodeHistoryIndex(nil))
+		assert.Empty(t, decodeHistoryIndex([]byte{}))
+		// A trailing partial entry is ignored rather than failing the round.
+		assert.Empty(t, decodeHistoryIndex([]byte{0, 0, 0, 1}))
+		assert.Len(t, decodeHistoryIndex([]byte{0, 0, 0, 1, 0, 0, 0, 2, 0xff}), 1)
+	})
+}
+
+func TestHistoryKey(t *testing.T) {
+	t.Parallel()
+
+	// Keys are prefixed and big-endian so the persisted ordering is
+	// deterministic.
+	assert.Equal(t, []byte("hh/\x00\x00\x00\x01\x00\x00\x00\x02"), historyHeaderKey(1, 2))
+	assert.Equal(t, []byte("hc/\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x05"), historyChunkKey(1, 2, 5))
+
+	// History keys share a namespace with the channel and hot records, so they
+	// must never collide with them, with each other, or across pairs.
+	for _, other := range [][]byte{keyLifecycle, keyChannelState, keyChannelSeqNr, keyHotState, keyHistoryIndex, keyHistoryVersion} {
+		assert.NotEqual(t, other, historyHeaderKey(1, 2))
+		assert.NotEqual(t, other, historyChunkKey(1, 2, 0))
+	}
+	assert.NotEqual(t, historyHeaderKey(1, 2), historyHeaderKey(2, 1))
+	assert.NotEqual(t, historyChunkKey(1, 2, 0), historyChunkKey(1, 2, 1))
+	assert.NotEqual(t, historyChunkKey(1, 2, 0), historyChunkKey(2, 1, 0))
+	for slot := range uint32(protocol.MaxHistoryChunkSlots) {
+		assert.NotEqual(t, historyHeaderKey(1, 2), historyChunkKey(1, 2, slot))
+	}
+}
+
+// TestHistoryStore_AppendAndReadInOneRound is a regression test: a pair that is
+// both appended to and read in the same round must not re-read the chunk it just
+// appended to.
+//
+// The stored bytes are stale until the flush, so re-reading them would fail the
+// header/chunk consistency check and be taken for corruption — discarding a
+// perfectly good window every round, silently, for as long as the channel ran.
+func TestHistoryStore_AppendAndReadInOneRound(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	for round := 1; round <= 3; round++ {
+		s := newTestHistoryStore(t, kv)
+		require.NoError(t, s.SetRequired(1, testAggMedian, 3))
+		_, err := s.Append(1, testAggMedian, uint64(round)*1_000, testDecimal(int64(round)))
+		require.NoError(t, err)
+
+		if round == 3 {
+			series, err := s.Series(1, testAggMedian, 3, calculated.FieldValue)
+			require.NoError(t, err, "the round that fills the window must be able to read it")
+			assert.Equal(t, 3, series.Len())
+			assert.Empty(t, s.corrupt, "reading what this round appended must not look like corruption")
+		}
+		require.NoError(t, s.Flush(kv))
+	}
+
+	assert.Equal(t, 3, readHistory(t, kv, 1, testAggMedian).Len())
+}
+
+// TestHistoryStore_ResetsOnLayoutChange covers a layout bump: the stored
+// windows are abandoned rather than read, because v31 is under llo/dev and a
+// layout change costs a warmup rather than a dual-read shim.
+func TestHistoryStore_ResetsOnLayoutChange(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	key := histKey{streamID: 1, aggregator: testAggMedian}
+
+	// State as a node running a different layout left it: an index naming a
+	// pair, and a version that is not the current one.
+	require.NoError(t, writeHistoryIndex(kv, []histKey{key}))
+	require.NoError(t, kv.Write(keyHistoryVersion, []byte{historyLayoutVersion + 1}))
+
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(key.streamID, key.aggregator, 5))
+	_, err := s.Append(key.streamID, key.aggregator, 2_000, testDecimal(2))
+	require.NoError(t, err)
+	require.NoError(t, s.Flush(kv))
+
+	// The version is re-stamped and the pair starts over from empty.
+	version, err := readHistoryLayoutVersion(kv)
+	require.NoError(t, err)
+	assert.Equal(t, historyLayoutVersion, version)
+
+	records := readHistoryRecords(t, kv, key.streamID, key.aggregator)
+	require.Len(t, records, 1, "the window re-warms from empty; nothing is carried over")
+	assert.Equal(t, uint64(2_000), records[0].ObservedAtNanoseconds)
+
+	// And the reset does not run again.
+	writesBefore := kv.writes[string(keyHistoryVersion)]
+	s = newTestHistoryStore(t, kv)
+	require.NoError(t, s.SetRequired(key.streamID, key.aggregator, 5))
+	require.NoError(t, s.Flush(kv))
+	assert.Equal(t, writesBefore, kv.writes[string(keyHistoryVersion)], "the version must be written once, not every round")
+}
+
+// TestHistoryStore_UnusedStateStaysUntouched checks the layout reset does not
+// stamp a version onto a DON that has never stored any history.
+func TestHistoryStore_UnusedStateStaysUntouched(t *testing.T) {
+	t.Parallel()
+
+	kv := newCountingKV()
+	s := newTestHistoryStore(t, kv)
+	require.NoError(t, s.Flush(kv))
+	assert.Empty(t, kv.writes)
+}
+
+// TestHistoryStore_CorruptChunk covers the other half of the fail-soft path: the
+// header decodes but a chunk it names does not.
+func TestHistoryStore_CorruptChunk(t *testing.T) {
+	t.Parallel()
+
+	for name, damage := range map[string]func(t *testing.T, kv *countingKV){
+		"garbage": func(t *testing.T, kv *countingKV) {
+			require.NoError(t, kv.Write(historyChunkKey(1, testAggMedian, 0), []byte("garbage")))
+		},
+		"missing": func(t *testing.T, kv *countingKV) {
+			require.NoError(t, kv.Delete(historyChunkKey(1, testAggMedian, 0)))
+		},
+		"stale lap": func(t *testing.T, kv *countingKV) {
+			// A chunk from an earlier lap: well formed, but its sequence is not
+			// one the header retains.
+			stale := protocol.NewRingWindow(nil)
+			_, err := stale.SetRequiredCount(5)
+			require.NoError(t, err)
+			_, err = stale.Append(999, testDecimal(99))
+			require.NoError(t, err)
+			b, err := stale.WriteSet().Chunk.MarshalBinary()
+			require.NoError(t, err)
+			require.NoError(t, kv.Write(historyChunkKey(1, testAggMedian, 0), b))
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Deep enough to span several chunks, so the reset has more than
+			// the damaged slot to clear.
+			const depth = protocol.MaxHistoryChunkRecords * 2
+
+			kv := newCountingKV()
+			warmHistory(t, kv, histKey{streamID: 1, aggregator: testAggMedian}, depth, depth)
+			require.Equal(t, 2, readHistory(t, kv, 1, testAggMedian).Header().ChunkCount())
+			damage(t, kv)
+
+			// The round must survive, discard the window and start warming again.
+			s := newTestHistoryStore(t, kv)
+			require.NoError(t, s.SetRequired(1, testAggMedian, depth))
+			_, err := s.Series(1, testAggMedian, depth, calculated.FieldValue)
+			require.Error(t, err, "a channel must not evaluate over a window that could not be trusted")
+			assert.True(t, s.corrupt[histKey{streamID: 1, aggregator: testAggMedian}])
+
+			appended, err := s.Append(1, testAggMedian, 10_000_000, testDecimal(7))
+			require.NoError(t, err)
+			assert.True(t, appended)
+			require.NoError(t, s.Flush(kv))
+
+			records := readHistoryRecords(t, kv, 1, testAggMedian)
+			require.Len(t, records, 1, "the window must re-warm from empty")
+			assert.Equal(t, uint64(10_000_000), records[0].ObservedAtNanoseconds)
+
+			// Nothing of the discarded window is left addressable.
+			for slot := range uint32(protocol.MaxHistoryChunkSlots) {
+				if slot == protocol.HistoryChunkSlot(0) {
+					continue // the re-warmed window's first chunk
+				}
+				b, err := kv.Read(historyChunkKey(1, testAggMedian, slot))
+				require.NoError(t, err)
+				assert.Empty(t, b, "slot %d must have been cleared by the reset", slot)
+			}
+		})
+	}
+}
+
+// TestHistoryStore_LapsTheRing runs enough rounds to reuse every slot several
+// times, which is where a stale chunk or a slot collision would show up.
+func TestHistoryStore_LapsTheRing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		required = protocol.MaxHistoryChunkRecords * 2
+		rounds   = protocol.MaxHistoryChunkRecords * protocol.MaxHistoryChunkSlots * 3
+	)
+	kv := newCountingKV()
+	key := histKey{streamID: 1, aggregator: testAggMedian}
+	warmHistory(t, kv, key, required, rounds)
+
+	w := readHistory(t, kv, key.streamID, key.aggregator)
+	requireHistoryRetention(t, w)
+	require.Greater(t, w.Header().FirstSequence(), uint64(2*protocol.MaxHistoryChunkSlots), "the ring must have wrapped")
+
+	records := readHistoryNewest(t, kv, key.streamID, key.aggregator, required)
+	require.Len(t, records, required)
+	for i, record := range records {
+		assert.Equal(t, uint64(rounds-required+1+i)*1_000, record.ObservedAtNanoseconds)
+	}
+
+	// Stored keys stay bounded by the ring however long it runs.
+	slots := 0
+	for slot := range uint32(protocol.MaxHistoryChunkSlots) {
+		b, err := kv.Read(historyChunkKey(key.streamID, key.aggregator, slot))
+		require.NoError(t, err)
+		if len(b) > 0 {
+			slots++
+		}
+	}
+	assert.Equal(t, w.Header().ChunkCount(), slots, "the stored slots must be exactly the retained chunks")
+}
+
+// TestHistoryStore_DeterministicAcrossALap is the property a divergence would
+// halt the DON over, exercised across ring wraparound and a capacity change.
+func TestHistoryStore_DeterministicAcrossALap(t *testing.T) {
+	t.Parallel()
+
+	run := func() map[string][]byte {
+		kv := newCountingKV()
+		key := histKey{streamID: 1, aggregator: testAggMedian}
+		for round := 1; round <= protocol.MaxHistoryChunkRecords*8; round++ {
+			required := uint32(protocol.MaxHistoryChunkRecords * 3)
+			if round > protocol.MaxHistoryChunkRecords*5 {
+				required = protocol.MaxHistoryChunkRecords / 2
+			}
+			s := newTestHistoryStore(t, kv)
+			require.NoError(t, s.SetRequired(key.streamID, key.aggregator, required))
+			_, err := s.Append(key.streamID, key.aggregator, uint64(round)*1_000, testDecimal(int64(round)))
+			require.NoError(t, err)
+			require.NoError(t, s.Flush(kv))
+		}
+		return kv.m
+	}
+
+	assert.Equal(t, run(), run(), "two oracles running identical rounds must end with byte-identical state")
+}

--- a/llo/dev/v31/kv.go
+++ b/llo/dev/v31/kv.go
@@ -24,16 +24,43 @@ import (
 //	r/agg       -> LLOHotStateProto: observation timestamp, validAfter
 //	               watermarks, per-channel reportability, and carry-forward
 //	               timestamped aggregates (written every round)
+//	hh/<streamID BE><aggregator BE>          -> deterministic LLOStreamHistoryHeaderProto (history window index)
+//	hc/<streamID BE><aggregator BE><slot BE> -> deterministic LLOStreamHistoryChunkProto (one ring slot of records)
+//	hidx        -> concatenated (uint32 BE streamID, uint32 BE aggregator) pairs,
+//	               sorted (the history index)
+//	hv          -> 1 byte: history layout version
 //
 // c/seqnr lets readers cache the decoded c/defs in memory across rounds and
 // re-read it only when the stored sequence number differs from the cached one
 // (see protocol.ChannelCache).
+//
+// History is stored as a chunked ring rather than one blob per pair: a slot
+// holds MaxHistoryChunkRecords records, and a round rewrites only the newest
+// one. That makes the per-round write cost a function of the chunk size instead
+// of the window depth (~2 KiB rather than ~60 KiB for a full quote window), at
+// a read cost of depth/chunkSize point reads instead of one. See
+// protocol.RingWindow.
 var (
 	keyLifecycle    = []byte("c/lifecycle")
 	keyChannelState = []byte("c/defs")
 	keyChannelSeqNr = []byte("c/seqnr")
 	keyHotState     = []byte("r/agg")
+
+	keyHistoryIndex   = []byte("hidx")
+	keyHistoryVersion = []byte("hv")
+
+	prefixHistoryHead  = []byte("hh/")
+	prefixHistoryChunk = []byte("hc/")
 )
+
+// historyLayoutVersion is the schema version of the history keys. A stored
+// value other than this one means the layout changed and every window must be
+// dropped and re-warmed.
+//
+// v31 lives under llo/dev and carries no compatibility promise, so a layout
+// change is handled by resetting rather than by a dual-read shim — cheap now,
+// expensive after graduation.
+const historyLayoutVersion byte = 1
 
 // deterministicMarshal marshals a proto message deterministically. All KV
 // values and the precursor rely on this for cross-oracle agreement.
@@ -43,6 +70,25 @@ func beU64(v uint64) []byte {
 	b := make([]byte, 8)
 	binary.BigEndian.PutUint64(b, v)
 	return b
+}
+
+func beU32(v uint32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, v)
+	return b
+}
+
+func historyHeaderKey(streamID llotypes.StreamID, agg llotypes.Aggregator) []byte {
+	k := append([]byte{}, prefixHistoryHead...)
+	k = append(k, beU32(streamID)...)
+	return append(k, beU32(uint32(agg))...)
+}
+
+func historyChunkKey(streamID llotypes.StreamID, agg llotypes.Aggregator, slot uint32) []byte {
+	k := append([]byte{}, prefixHistoryChunk...)
+	k = append(k, beU32(streamID)...)
+	k = append(k, beU32(uint32(agg))...)
+	return append(k, beU32(slot)...)
 }
 
 // kvState is the in-memory projection of the replicated KeyValueState for a
@@ -289,4 +335,150 @@ func writeHotState(
 		return fmt.Errorf("marshal hot state: %w", err)
 	}
 	return w.Write(keyHotState, b)
+}
+
+// histKey identifies one history window. The aggregator is part of the identity
+// because the same stream can be aggregated differently by different channels,
+// and mixing those series would be silently wrong.
+type histKey struct {
+	streamID   llotypes.StreamID
+	aggregator llotypes.Aggregator
+}
+
+// readHistoryHeader returns the stored header for a pair, or nil if none is
+// stored.
+//
+// Decode failures are returned wrapped in protocol.ErrCorruptStreamHistory so
+// callers can tell untrusted stored state apart from an actual read failure:
+// the first is discarded and re-warmed, the second fails the round.
+func readHistoryHeader(r ocr3_1types.KeyValueStateReader, sid llotypes.StreamID, agg llotypes.Aggregator) (*protocol.StreamHistoryHeader, error) {
+	b, err := r.Read(historyHeaderKey(sid, agg))
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	header, err := protocol.UnmarshalStreamHistoryHeader(b)
+	if err != nil {
+		return nil, fmt.Errorf("read history header for stream %d aggregator %d: %w", sid, agg, err)
+	}
+	return header, nil
+}
+
+// writeHistoryHeader persists a history header deterministically, returning the
+// number of bytes written for telemetry.
+func writeHistoryHeader(w ocr3_1types.KeyValueStateReadWriter, sid llotypes.StreamID, agg llotypes.Aggregator, header *protocol.StreamHistoryHeader) (int, error) {
+	b, err := header.MarshalBinary()
+	if err != nil {
+		return 0, fmt.Errorf("marshal history header for stream %d aggregator %d: %w", sid, agg, err)
+	}
+	return len(b), w.Write(historyHeaderKey(sid, agg), b)
+}
+
+// deleteHistoryHeader removes a history header.
+func deleteHistoryHeader(w ocr3_1types.KeyValueStateReadWriter, sid llotypes.StreamID, agg llotypes.Aggregator) error {
+	return w.Delete(historyHeaderKey(sid, agg))
+}
+
+// readHistoryChunk returns the chunk stored in a ring slot, or nil if the slot
+// is empty. As with the header, a decode failure is corruption rather than a
+// read error.
+//
+// A chunk left behind by an earlier lap of the ring decodes fine here; it is
+// rejected when it is matched against the header, which is what makes slot
+// reuse safe. See protocol.RingWindow.Provide.
+func readHistoryChunk(r ocr3_1types.KeyValueStateReader, sid llotypes.StreamID, agg llotypes.Aggregator, slot uint32) (*protocol.StreamHistoryChunk, error) {
+	b, err := r.Read(historyChunkKey(sid, agg, slot))
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	chunk, err := protocol.UnmarshalStreamHistoryChunk(b)
+	if err != nil {
+		return nil, fmt.Errorf("read history chunk for stream %d aggregator %d slot %d: %w", sid, agg, slot, err)
+	}
+	return chunk, nil
+}
+
+// writeHistoryChunk persists one ring slot deterministically, returning the
+// number of bytes written for telemetry.
+func writeHistoryChunk(w ocr3_1types.KeyValueStateReadWriter, sid llotypes.StreamID, agg llotypes.Aggregator, chunk *protocol.StreamHistoryChunk) (int, error) {
+	b, err := chunk.MarshalBinary()
+	if err != nil {
+		return 0, fmt.Errorf("marshal history chunk for stream %d aggregator %d slot %d: %w", sid, agg, chunk.Slot(), err)
+	}
+	return len(b), w.Write(historyChunkKey(sid, agg, chunk.Slot()), b)
+}
+
+// deleteHistoryChunk removes one ring slot.
+func deleteHistoryChunk(w ocr3_1types.KeyValueStateReadWriter, sid llotypes.StreamID, agg llotypes.Aggregator, slot uint32) error {
+	return w.Delete(historyChunkKey(sid, agg, slot))
+}
+
+// readHistoryLayoutVersion returns the stored history layout version, or zero
+// when nothing has been written yet.
+func readHistoryLayoutVersion(r ocr3_1types.KeyValueStateReader) (byte, error) {
+	b, err := r.Read(keyHistoryVersion)
+	if err != nil {
+		return 0, err
+	}
+	if len(b) != 1 {
+		return 0, nil
+	}
+	return b[0], nil
+}
+
+// writeHistoryLayoutVersion records the layout the stored history was written
+// with.
+func writeHistoryLayoutVersion(w ocr3_1types.KeyValueStateReadWriter) error {
+	return w.Write(keyHistoryVersion, []byte{historyLayoutVersion})
+}
+
+// readHistoryIndex returns the sorted set of pairs that have history.
+//
+// The index exists only because the in-round reader offers no range scan: orphan
+// cleanup and telemetry need to enumerate history keys. A trailing partial
+// entry is ignored rather than failing the round.
+func readHistoryIndex(r ocr3_1types.KeyValueStateReader) ([]histKey, error) {
+	b, err := r.Read(keyHistoryIndex)
+	if err != nil {
+		return nil, err
+	}
+	return decodeHistoryIndex(b), nil
+}
+
+// writeHistoryIndex persists the sorted set of pairs that have history.
+func writeHistoryIndex(w ocr3_1types.KeyValueStateReadWriter, keys []histKey) error {
+	return w.Write(keyHistoryIndex, encodeHistoryIndex(keys))
+}
+
+func decodeHistoryIndex(b []byte) []histKey {
+	n := len(b) / 8
+	keys := make([]histKey, 0, n)
+	for i := 0; i < n; i++ {
+		keys = append(keys, histKey{
+			streamID:   binary.BigEndian.Uint32(b[i*8:]),
+			aggregator: llotypes.Aggregator(binary.BigEndian.Uint32(b[i*8+4:])),
+		})
+	}
+	return keys
+}
+
+func encodeHistoryIndex(keys []histKey) []byte {
+	sorted := append([]histKey{}, keys...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].streamID != sorted[j].streamID {
+			return sorted[i].streamID < sorted[j].streamID
+		}
+		return sorted[i].aggregator < sorted[j].aggregator
+	})
+	b := make([]byte, 0, len(sorted)*8)
+	for _, k := range sorted {
+		b = append(b, beU32(k.streamID)...)
+		b = append(b, beU32(uint32(k.aggregator))...)
+	}
+	return b
 }

--- a/llo/dev/v31/plugin.go
+++ b/llo/dev/v31/plugin.go
@@ -175,7 +175,11 @@ func (p *Plugin) voteOnChannels(obs *Observation, state *kvState, seqNr uint64) 
 	obs.RemoveChannelIDs = map[llotypes.ChannelID]struct{}{}
 
 	expectedChannelDefs := p.ChannelDefinitionCache.Definitions(state.channelDefinitions)
-	if err := protocol.VerifyChannelDefinitions(p.ReportCodecs, expectedChannelDefs); err != nil {
+	// Only the channels this node would vote to add or change are held to the
+	// admission-only checks; the ones already committed are not, or a
+	// grandfathered channel would freeze channel voting entirely.
+	admitting := protocol.ChangedChannelIDs(state.channelDefinitions, expectedChannelDefs)
+	if err := protocol.VerifyChannelDefinitionsForAdmission(p.ReportCodecs, expectedChannelDefs, admitting); err != nil {
 		// Don't halt on an invalid channel-definitions file; just don't vote.
 		p.Logger.Errorw("ChannelDefinitionCache.Definitions is invalid", "err", err)
 		return
@@ -229,6 +233,12 @@ func (p *Plugin) ValidateObservation(ctx context.Context, seqNr uint64, _ ocrtyp
 		return fmt.Errorf("RemoveChannelIDs is too long: %v vs %v", len(observation.RemoveChannelIDs), protocol.MaxObservationRemoveChannelIDsLength)
 	}
 
+	// Only the baseline checks run here. A definition is installed on more than
+	// f votes for its exact hash, so at least one honest oracle must have voted
+	// for it, and an honest oracle only votes for what its own admission-time
+	// verification accepted (see voteOnChannels). Repeating the admission-only
+	// checks here would add nothing, and would make oracles running different
+	// versions of those checks disagree on whether an observation is valid.
 	defsForVerify := observation.UpdateChannelDefinitions
 	if len(observation.UpdateChannelDefinitions) > 0 {
 		state, serr := loadColdKVState(kvReader, p.ChannelCache)

--- a/llo/dev/v31/plugin_test.go
+++ b/llo/dev/v31/plugin_test.go
@@ -542,8 +542,18 @@ func Test_DisableNilStreamValues_CalculatedStreams(t *testing.T) {
 		require.Equal(t, []llotypes.ChannelID{1}, o.reportableChannels(0, populatedCache(o), logger.Test(t)))
 	})
 
-	t.Run("DisableNilStreamValues=false, evaluation failed -> still reportable", func(t *testing.T) {
+	t.Run("DisableNilStreamValues=false, evaluation failed -> not reportable", func(t *testing.T) {
+		// The calculated-stream gate is independent of DisableNilStreamValues,
+		// which is about observed values. A missing calculated stream cannot be
+		// reported around: the codec has nothing to encode, so Reports skips the
+		// report. Treating the channel as reportable would advance validAfter
+		// over a round that emitted nothing.
 		o := mkPrec(false, validOpts, baseStreams, baseAggregates())
+		require.Empty(t, o.reportableChannels(0, populatedCache(o), logger.Test(t)))
+	})
+
+	t.Run("DisableNilStreamValues=false, fully evaluated -> reportable", func(t *testing.T) {
+		o := mkPrec(false, validOpts, withCalculated, evaluatedAggregates())
 		require.Equal(t, []llotypes.ChannelID{1}, o.reportableChannels(0, populatedCache(o), logger.Test(t)))
 	})
 
@@ -580,7 +590,8 @@ func Test_TimestampedAggregate_CarryForward(t *testing.T) {
 		out := protocol.StreamAggregates{}
 		obs := map[llotypes.StreamID][]protocol.StreamValue{100: {tsv(ts, v), tsv(ts, v), tsv(ts, v)}}
 		next := map[llotypes.StreamID]map[llotypes.Aggregator]*protocol.TimestampedStreamValue{}
-		require.NoError(t, p.aggregate(carry, next, defs, obs, out))
+		// No history requirements: this test is about carry-forward aggregation.
+		require.NoError(t, p.aggregate(carry, next, defs, obs, out, nil, historyRequirements{}, ts))
 		carry = next
 		res, ok := out[100][llotypes.AggregatorMedian].(*protocol.TimestampedStreamValue)
 		require.True(t, ok, "expected a TimestampedStreamValue aggregate")

--- a/llo/dev/v31/plugin_test.go
+++ b/llo/dev/v31/plugin_test.go
@@ -676,7 +676,7 @@ func Test_CalculatedStreams(t *testing.T) {
 		},
 	}
 
-	calculated.ProcessCalculatedStreams(p.Logger, prec.ChannelDefinitions, prec.StreamAggregates, prec.ObservationTimestampNanoseconds, generation.Opts())
+	calculated.ProcessCalculatedStreams(p.Logger, prec.ChannelDefinitions, prec.StreamAggregates, prec.ObservationTimestampNanoseconds, generation.Opts(), nil)
 
 	// The calculated stream (999) should hold Add(s1, s2) = 7.
 	got := prec.StreamAggregates[999][llotypes.AggregatorCalculated]

--- a/llo/dev/v31/plugin_test.go
+++ b/llo/dev/v31/plugin_test.go
@@ -526,13 +526,13 @@ func Test_DisableNilStreamValues_CalculatedStreams(t *testing.T) {
 	}
 
 	t.Run("evaluation failed -> not reportable", func(t *testing.T) {
-		// ProcessCalculatedStreams bailed before appending the calculated stream
-		// and before writing its aggregate; the definition alone looks complete.
+		// ProcessCalculatedStreams bailed before writing the calculated
+		// aggregate; the definition alone looks complete.
 		o := mkPrec(true, validOpts, baseStreams, baseAggregates())
 		require.Empty(t, o.reportableChannels(0, populatedCache(o), logger.Test(t)))
 	})
 
-	t.Run("calculated stream declared but nil aggregate -> not reportable", func(t *testing.T) {
+	t.Run("inline calculated stream but nil aggregate -> not reportable", func(t *testing.T) {
 		o := mkPrec(true, validOpts, withCalculated, baseAggregates())
 		require.Empty(t, o.reportableChannels(0, populatedCache(o), logger.Test(t)))
 	})
@@ -696,10 +696,25 @@ func Test_CalculatedStreams(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, d.Decimal().Equal(decimal.NewFromInt(7)), "expected 7, got %s", d.Decimal())
 
-	// The calculated stream should have been appended to the channel definition.
-	require.Len(t, prec.ChannelDefinitions[cid].Streams, 3)
-	require.Equal(t, llotypes.StreamID(999), prec.ChannelDefinitions[cid].Streams[2].StreamID)
-	require.EqualValues(t, llotypes.AggregatorCalculated, prec.ChannelDefinitions[cid].Streams[2].Aggregator)
+	// The channel definition is left untouched: the calculated stream is derived
+	// from the opts, not stored.
+	require.Len(t, prec.ChannelDefinitions[cid].Streams, 2)
+
+	// It shows up in the derived stream list instead, as the trailing entry.
+	streams, err := protocol.EffectiveStreams(generation.Opts(), prec.ChannelDefinitions[cid], cid)
+	require.NoError(t, err)
+	require.Len(t, streams, 3)
+	require.Equal(t, llotypes.StreamID(999), streams[2].StreamID)
+	require.EqualValues(t, llotypes.AggregatorCalculated, streams[2].Aggregator)
+
+	// Deriving twice yields the same list: EffectiveStreams drops any inline
+	// calculated entries before appending the declared ones, so a definition
+	// written by older code derives identically to one that was never mutated.
+	mutated := prec.ChannelDefinitions[cid]
+	mutated.Streams = streams
+	again, err := protocol.EffectiveStreams(generation.Opts(), mutated, cid)
+	require.NoError(t, err)
+	require.Equal(t, streams, again)
 
 	// Dry-run helper should accept a valid expression.
 	require.NoError(t, calculated.ProcessCalculatedStreamsDryRun("Add(s1, s2)"))
@@ -850,4 +865,74 @@ func equalStreamValue(a, b protocol.StreamValue) bool {
 		return false
 	}
 	return string(ba) == string(bb)
+}
+
+// captureCodec records the report it was asked to encode, so a test can assert
+// on the values report assembly produced.
+type captureCodec struct{ got *protocol.Report }
+
+func (c captureCodec) Encode(r protocol.Report, _ llotypes.ChannelDefinition, _ *protocol.OptsCache) ([]byte, error) {
+	*c.got = r
+	return []byte("ok"), nil
+}
+
+func (captureCodec) Verify(llotypes.ChannelDefinition) error { return nil }
+
+var _ protocol.ReportCodec = captureCodec{}
+
+// Test_CalculatedStreams_ReportValues pins the contract report assembly and
+// ReportCodecEVMABIEncodeUnpackedExpr share: a report carries the channel's
+// observed values followed by one calculated value per declared expression, in
+// declaration order, even though the channel definition lists only the observed
+// streams.
+func Test_CalculatedStreams_ReportValues(t *testing.T) {
+	ctx := tests.Context(t)
+	cid := llotypes.ChannelID(5)
+
+	var got protocol.Report
+	p := testPlugin(t)
+	p.ReportCodecs = map[llotypes.ReportFormat]protocol.ReportCodec{
+		llotypes.ReportFormatEVMABIEncodeUnpackedExpr: captureCodec{got: &got},
+	}
+
+	definitions := llotypes.ChannelDefinitions{cid: {
+		ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+		Opts: []byte(`{"abi":[
+			{"type":"int256","expression":"Add(s1, s2)","expressionStreamID":998},
+			{"type":"int256","expression":"Sub(s1, s2)","expressionStreamID":999}
+		]}`),
+		Streams: []llotypes.Stream{
+			{StreamID: 1, Aggregator: llotypes.AggregatorMedian},
+			{StreamID: 2, Aggregator: llotypes.AggregatorMedian},
+		},
+	}}
+
+	prec := precursor{
+		LifeCycleStage:                  protocol.LifeCycleStageProduction,
+		ObservationTimestampNanoseconds: 3 * uint64(time.Second),
+		ChannelDefinitions:              definitions,
+		ValidAfterNanoseconds:           map[llotypes.ChannelID]uint64{cid: uint64(time.Second)},
+		StreamAggregates: protocol.StreamAggregates{
+			1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(3))},
+			2: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(4))},
+		},
+	}
+
+	cache := protocol.NewOptsCache()
+	cache.ResetTo(definitions)
+	calculated.ProcessCalculatedStreams(p.Logger, prec.ChannelDefinitions, prec.StreamAggregates, prec.ObservationTimestampNanoseconds, cache, nil)
+
+	precBytes, err := encodePrecursor(prec)
+	require.NoError(t, err)
+	reports, err := p.Reports(ctx, 2, precBytes)
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+
+	require.Len(t, got.Values, 4)
+	want := []int64{3, 4, 7, -1}
+	for i, w := range want {
+		d, ok := got.Values[i].(*protocol.Decimal)
+		require.True(t, ok, "value %d has type %T", i, got.Values[i])
+		require.True(t, d.Decimal().Equal(decimal.NewFromInt(w)), "value %d: expected %d, got %s", i, w, d.Decimal())
+	}
 }

--- a/llo/dev/v31/plugin_test.go
+++ b/llo/dev/v31/plugin_test.go
@@ -740,17 +740,17 @@ func Test_HistoryBackfill(t *testing.T) {
 	defs := llotypes.ChannelDefinitions{targetCID: targetCD, backfillCID: backfillCD}
 
 	// Candidate selection advances with the watermark, then completes.
-	ts, raw, opts, ok := selectBackfillCandidate(defs, map[llotypes.ChannelID]uint64{backfillCID: 0}, tenSec, backfillCID)
+	ts, raw, opts, ok := selectBackfillCandidate(defs, map[llotypes.ChannelID]uint64{backfillCID: 0}, tenSec, backfillCID, nil)
 	require.True(t, ok)
 	require.Equal(t, fiveSec, ts)
 	require.Equal(t, uint64(5), raw)
 	require.Equal(t, targetCID, opts.TargetChannelID)
 
-	ts2, _, _, ok2 := selectBackfillCandidate(defs, map[llotypes.ChannelID]uint64{backfillCID: fiveSec}, tenSec, backfillCID)
+	ts2, _, _, ok2 := selectBackfillCandidate(defs, map[llotypes.ChannelID]uint64{backfillCID: fiveSec}, tenSec, backfillCID, nil)
 	require.True(t, ok2)
 	require.Equal(t, eightSec, ts2)
 
-	_, _, _, ok3 := selectBackfillCandidate(defs, map[llotypes.ChannelID]uint64{backfillCID: eightSec}, tenSec, backfillCID)
+	_, _, _, ok3 := selectBackfillCandidate(defs, map[llotypes.ChannelID]uint64{backfillCID: eightSec}, tenSec, backfillCID, nil)
 	require.False(t, ok3, "backfill should be complete once watermark passes the last observation")
 
 	// Reports emits the backfill report, encoded with the target channel's format.

--- a/llo/dev/v31/reports.go
+++ b/llo/dev/v31/reports.go
@@ -202,32 +202,39 @@ func (o precursor) isReportable(channelID llotypes.ChannelID, minReportInterval 
 				return false
 			}
 		}
-		// Calculated streams are appended to the channel definition by
-		// ProcessCalculatedStreams only once evaluation gets that far; a channel
-		// whose expressions failed (bad input value, undecodable opts, eval
-		// error) therefore has no calculated streams to scan above and would
-		// pass. Verify against the streams the channel's opts declare instead.
-		if cd.ReportFormat == llotypes.ReportFormatEVMABIEncodeUnpackedExpr {
-			expressionStreamIDs, err := calculated.ExpressionStreamIDs(optsCache, cd, channelID)
-			if err != nil {
-				lggr.Warnw("IsReportable=false; cannot resolve calculated stream IDs", "channelID", channelID, "err", err)
+	}
+	// Calculated streams are derived state, and unlike observed streams a
+	// missing one cannot be reported around: the codec has nothing to encode, so
+	// Reports skips the report. Without this check the channel would still be
+	// counted as reported and validAfter would advance over a round that emitted
+	// nothing — a silent coverage gap. This is independent of
+	// DisableNilStreamValues, which is about observed values.
+	//
+	// The check is against the streams the channel's opts declare, not the
+	// streams on the channel definition: ProcessCalculatedStreams only appends
+	// those once evaluation gets that far, so a channel whose expressions failed
+	// (bad input, undecodable opts, eval error, or history still warming up) has
+	// nothing to scan and would otherwise pass.
+	if cd.ReportFormat == llotypes.ReportFormatEVMABIEncodeUnpackedExpr {
+		expressionStreamIDs, err := calculated.ExpressionStreamIDs(optsCache, cd, channelID)
+		if err != nil {
+			lggr.Warnw("IsReportable=false; cannot resolve calculated stream IDs", "channelID", channelID, "err", err)
+			return false
+		}
+		declared := make(map[llotypes.StreamID]struct{}, len(cd.Streams))
+		for _, strm := range cd.Streams {
+			if strm.Aggregator == llotypes.AggregatorCalculated {
+				declared[strm.StreamID] = struct{}{}
+			}
+		}
+		for _, sid := range expressionStreamIDs {
+			if _, ok := declared[sid]; !ok {
+				lggr.Warnw("IsReportable=false; calculated stream missing from channel definition", "channelID", channelID, "streamID", sid)
 				return false
 			}
-			declared := make(map[llotypes.StreamID]struct{}, len(cd.Streams))
-			for _, strm := range cd.Streams {
-				if strm.Aggregator == llotypes.AggregatorCalculated {
-					declared[strm.StreamID] = struct{}{}
-				}
-			}
-			for _, sid := range expressionStreamIDs {
-				if _, ok := declared[sid]; !ok {
-					lggr.Warnw("IsReportable=false; calculated stream missing from channel definition", "channelID", channelID, "streamID", sid)
-					return false
-				}
-				if o.StreamAggregates[sid][llotypes.AggregatorCalculated] == nil {
-					lggr.Warnw("IsReportable=false; nil calculated stream value", "channelID", channelID, "streamID", sid)
-					return false
-				}
+			if o.StreamAggregates[sid][llotypes.AggregatorCalculated] == nil {
+				lggr.Warnw("IsReportable=false; nil calculated stream value", "channelID", channelID, "streamID", sid)
+				return false
 			}
 		}
 	}

--- a/llo/dev/v31/reports.go
+++ b/llo/dev/v31/reports.go
@@ -66,7 +66,7 @@ func (p *Plugin) Reports(ctx context.Context, seqNr uint64, rawPrecursor ocr3_1t
 		cd := out.ChannelDefinitions[cid]
 
 		if cd.ReportFormat == llotypes.ReportFormatHistoryBackfill {
-			tsNanos, rawTS, opts, ok := selectBackfillCandidate(out.ChannelDefinitions, out.ValidAfterNanoseconds, out.ObservationTimestampNanoseconds, cid)
+			tsNanos, rawTS, opts, ok := selectBackfillCandidate(out.ChannelDefinitions, out.ValidAfterNanoseconds, out.ObservationTimestampNanoseconds, cid, channelOpts)
 			if !ok {
 				p.Logger.Warnw("backfill channel was reportable but selection failed", "channelID", cid, "stage", "Report", "seqNr", seqNr)
 				continue
@@ -199,7 +199,7 @@ func (o precursor) isReportable(channelID llotypes.ChannelID, minReportInterval 
 		return false
 	}
 	if cd.ReportFormat == llotypes.ReportFormatHistoryBackfill {
-		_, _, _, ok := selectBackfillCandidate(o.ChannelDefinitions, o.ValidAfterNanoseconds, o.ObservationTimestampNanoseconds, channelID)
+		_, _, _, ok := selectBackfillCandidate(o.ChannelDefinitions, o.ValidAfterNanoseconds, o.ObservationTimestampNanoseconds, channelID, optsCache)
 		return ok
 	}
 	// When DisableNilStreamValues is set, every stream must have a (non-nil)

--- a/llo/dev/v31/reports.go
+++ b/llo/dev/v31/reports.go
@@ -9,7 +9,6 @@ import (
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 
 	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
-	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol/calculated"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3_1types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
@@ -128,8 +127,17 @@ func (p *Plugin) Reports(ctx context.Context, seqNr uint64, rawPrecursor ocr3_1t
 			continue
 		}
 
-		values := make([]protocol.StreamValue, 0, len(cd.Streams))
-		for _, strm := range cd.Streams {
+		// The streams a channel reports are derived, not read off the
+		// definition: calculated streams live in the channel's opts and are
+		// appended here, in declaration order, as the trailing values the codec
+		// encodes as its payload.
+		streams, err := protocol.EffectiveStreams(channelOpts, cd, cid)
+		if err != nil {
+			p.Logger.Warnw("Error encoding report; cannot derive effective streams", "err", err, "channelID", cid, "stage", "Report", "seqNr", seqNr)
+			continue
+		}
+		values := make([]protocol.StreamValue, 0, len(streams))
+		for _, strm := range streams {
 			values = append(values, out.StreamAggregates[strm.StreamID][strm.Aggregator])
 		}
 
@@ -150,9 +158,9 @@ func (p *Plugin) Reports(ctx context.Context, seqNr uint64, rawPrecursor ocr3_1t
 			p.Logger.Warnw("Error encoding report; codec missing for ReportFormat", "reportFormat", cd.ReportFormat, "channelID", cid, "stage", "Report", "seqNr", seqNr)
 			continue
 		}
-		encoded, err := codec.Encode(report, cd, channelOpts)
-		if err != nil {
-			p.Logger.Warnw("Error encoding report", "reportFormat", cd.ReportFormat, "err", err, "channelID", cid, "stage", "Report", "seqNr", seqNr)
+		encoded, encErr := codec.Encode(report, cd, channelOpts)
+		if encErr != nil {
+			p.Logger.Warnw("Error encoding report", "reportFormat", cd.ReportFormat, "err", encErr, "channelID", cid, "stage", "Report", "seqNr", seqNr)
 			continue
 		}
 		rwis = append(rwis, ocr3types.ReportPlus[llotypes.ReportInfo]{
@@ -210,28 +218,17 @@ func (o precursor) isReportable(channelID llotypes.ChannelID, minReportInterval 
 	// nothing — a silent coverage gap. This is independent of
 	// DisableNilStreamValues, which is about observed values.
 	//
-	// The check is against the streams the channel's opts declare, not the
-	// streams on the channel definition: ProcessCalculatedStreams only appends
-	// those once evaluation gets that far, so a channel whose expressions failed
-	// (bad input, undecodable opts, eval error, or history still warming up) has
-	// nothing to scan and would otherwise pass.
-	if cd.ReportFormat == llotypes.ReportFormatEVMABIEncodeUnpackedExpr {
-		expressionStreamIDs, err := calculated.ExpressionStreamIDs(optsCache, cd, channelID)
+	// The check is against the streams the channel's opts declare, which is also
+	// what protocol.EffectiveStreams derives the report's trailing values from.
+	// A channel whose expressions failed (bad input, undecodable opts, eval
+	// error, or history still warming up) has no aggregate for them.
+	if protocol.HasCalculatedStreams(cd) {
+		calculatedStreamIDs, err := protocol.CalculatedStreamIDs(optsCache, cd, channelID)
 		if err != nil {
 			lggr.Warnw("IsReportable=false; cannot resolve calculated stream IDs", "channelID", channelID, "err", err)
 			return false
 		}
-		declared := make(map[llotypes.StreamID]struct{}, len(cd.Streams))
-		for _, strm := range cd.Streams {
-			if strm.Aggregator == llotypes.AggregatorCalculated {
-				declared[strm.StreamID] = struct{}{}
-			}
-		}
-		for _, sid := range expressionStreamIDs {
-			if _, ok := declared[sid]; !ok {
-				lggr.Warnw("IsReportable=false; calculated stream missing from channel definition", "channelID", channelID, "streamID", sid)
-				return false
-			}
+		for _, sid := range calculatedStreamIDs {
 			if o.StreamAggregates[sid][llotypes.AggregatorCalculated] == nil {
 				lggr.Warnw("IsReportable=false; nil calculated stream value", "channelID", channelID, "streamID", sid)
 				return false

--- a/llo/dev/v31/statetransition.go
+++ b/llo/dev/v31/statetransition.go
@@ -106,9 +106,8 @@ func (p *Plugin) StateTransition(ctx context.Context, seqNr uint64, _ ocrtypes.A
 
 	// Channel definition changes (skipped once retired). These apply to pending
 	// only: they take effect next round.
-	var updatedChannelIDs []llotypes.ChannelID
 	if out.LifeCycleStage != protocol.LifeCycleStageRetired {
-		updatedChannelIDs = applyChannelVotes(pending, removeChannelVotesByID, updateDefsByHash, updateVotesByHash, p.F)
+		applyChannelVotes(pending, removeChannelVotesByID, updateDefsByHash, updateVotesByHash, p.F)
 	}
 
 	// validAfter.
@@ -194,19 +193,17 @@ func (p *Plugin) StateTransition(ctx context.Context, seqNr uint64, _ ocrtypes.A
 		return nil, err
 	}
 
-	// Evaluate calculated streams (EVMABIEncodeUnpackedExpr channels): appends
-	// the calculated streams to their channel definitions and writes the
-	// evaluated values into StreamAggregates. The engine is shared via
+	// Evaluate calculated streams (EVMABIEncodeUnpackedExpr channels): writes
+	// the evaluated values into StreamAggregates. The engine is shared via
 	// llo/protocol/calculated. The history store is the read side: expressions
 	// using History(...) read the windows appended above, and are left
 	// unevaluated while a window is still shallower than requested.
+	//
+	// The channel definitions are not touched. Which calculated streams a
+	// channel reports is derived from its opts by protocol.EffectiveStreams, so
+	// nothing about evaluation reaches replicated state and a persisted
+	// definition stays exactly what was voted on.
 	calculated.ProcessCalculatedStreams(p.Logger, effective, out.StreamAggregates, out.ObservationTimestampNanoseconds, prev.opts, history)
-
-	// Carry any calculated streams appended above into pending, so the append
-	// is persisted and does not repeat every round. Channels whose definition
-	// was replaced by a vote this round are skipped: their replacement gets its
-	// calculated streams appended once it becomes effective.
-	adoptCalculatedStreams(pending, effective, updatedChannelIDs)
 
 	// Flush KV mutations.
 	if err := p.flushKV(kvRW, seqNr, prev, out, pending, carryForward, history); err != nil {
@@ -293,8 +290,7 @@ func (p *Plugin) decodeObservations(ctx context.Context, aos []ocrtypes.Attribut
 }
 
 // applyChannelVotes applies remove/add votes with a >F threshold, in ascending
-// channelID order, respecting MaxOutcomeChannelDefinitionsLength. Returns the
-// channel IDs whose definition was added or replaced.
+// channelID order, respecting MaxOutcomeChannelDefinitionsLength.
 //
 // defs is the PENDING set: everything applied here takes effect next round. It
 // deliberately does not touch the round's channel generation, whose definitions
@@ -305,7 +301,7 @@ func applyChannelVotes(
 	updateDefsByHash map[[32]byte]protocol.ChannelDefinitionWithID,
 	updateVotesByHash map[[32]byte]int,
 	f int,
-) []llotypes.ChannelID {
+) {
 	for channelID, voteCount := range removeVotesByID {
 		if voteCount <= f {
 			continue
@@ -322,7 +318,6 @@ func applyChannelVotes(
 		ordered = append(ordered, hashWithID{h, d})
 	}
 	sort.Slice(ordered, func(i, j int) bool { return ordered[i].def.ChannelID < ordered[j].def.ChannelID })
-	updated := make([]llotypes.ChannelID, 0, len(ordered))
 	for _, hwid := range ordered {
 		if updateVotesByHash[hwid.hash] <= f {
 			continue
@@ -334,29 +329,6 @@ func applyChannelVotes(
 			continue
 		}
 		defs[defWithID.ChannelID] = defWithID.ChannelDefinition
-		updated = append(updated, defWithID.ChannelID)
-	}
-	return updated
-}
-
-// adoptCalculatedStreams copies the calculated streams that
-// ProcessCalculatedStreams appended to the effective definitions into the
-// pending set, so the append is persisted once rather than recomputed every
-// round. Channels that a vote replaced this round keep their new definition
-// untouched, and channels a vote removed are not resurrected.
-func adoptCalculatedStreams(pending, effective llotypes.ChannelDefinitions, updatedChannelIDs []llotypes.ChannelID) {
-	updated := make(map[llotypes.ChannelID]struct{}, len(updatedChannelIDs))
-	for _, id := range updatedChannelIDs {
-		updated[id] = struct{}{}
-	}
-	for id, cd := range effective {
-		if _, wasUpdated := updated[id]; wasUpdated {
-			continue
-		}
-		if _, stillPending := pending[id]; !stillPending {
-			continue
-		}
-		pending[id] = cd
 	}
 }
 
@@ -408,7 +380,10 @@ func (p *Plugin) aggregate(
 		for _, strm := range cd.Streams {
 			sid, agg := strm.StreamID, strm.Aggregator
 			if agg == llotypes.AggregatorCalculated {
-				continue // handled after aggregation by ProcessCalculatedStreams
+				// Not observed, so nothing to carry forward. Definitions written
+				// by older code may still list them inline; calculated values
+				// are recomputed each round by ProcessCalculatedStreams.
+				continue
 			}
 			if _, exists := out[sid][agg]; exists {
 				continue
@@ -600,7 +575,7 @@ func sortChannelIDs(cids []llotypes.ChannelID) {
 }
 
 // cloneChannelDefinitions deep-copies the definitions so that this round's
-// mutations - notably appending calculated streams - cannot reach the immutable
+// mutations - the votes applied to the pending set - cannot reach the immutable
 // generation the definitions came from, which other rounds are reading
 // concurrently.
 func cloneChannelDefinitions(in llotypes.ChannelDefinitions) llotypes.ChannelDefinitions {

--- a/llo/dev/v31/statetransition.go
+++ b/llo/dev/v31/statetransition.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 
 	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
@@ -165,22 +166,41 @@ func (p *Plugin) StateTransition(ctx context.Context, seqNr uint64, _ ocrtypes.A
 		}
 	}
 
+	// Stream history: derive the depth each (stream, aggregator) pair needs from
+	// the (replicated) channel definitions and their expressions, then set it on
+	// the round's store. This happens before aggregation because the depth is
+	// what decides whether a pair's value is recorded at all.
+	history, err := newHistoryStore(kvRW, p.Logger)
+	if err != nil {
+		return nil, err
+	}
+	requirements := computeHistoryRequirements(effective, prev.opts, p.Logger)
+	if err := requirements.apply(history); err != nil {
+		return nil, err
+	}
+	for _, key := range requirements.sortedDenied() {
+		// Channels reading this pair cannot evaluate and so will not report.
+		p.Logger.Errorw("Stream history denied; channels reading it will not report",
+			"streamID", key.streamID, "aggregator", key.aggregator, "seqNr", seqNr)
+	}
+
 	// Aggregation (regular fresh; timestamped with cross-round carry-forward via
 	// the r/agg record). carryForward accumulates the values to persist for the
-	// next round. Runs over the effective set, which is what was observed.
+	// next round. Runs over the effective set, which is what was observed. The
+	// agreed value of every pair history requires is recorded as it is computed.
 	carryForward := map[llotypes.StreamID]map[llotypes.Aggregator]*protocol.TimestampedStreamValue{}
-	if err := p.aggregate(prev.carryForward, carryForward, effective, streamObservations, out.StreamAggregates); err != nil {
+	if err := p.aggregate(prev.carryForward, carryForward, effective, streamObservations, out.StreamAggregates,
+		history, requirements, out.ObservationTimestampNanoseconds); err != nil {
 		return nil, err
 	}
 
 	// Evaluate calculated streams (EVMABIEncodeUnpackedExpr channels): appends
 	// the calculated streams to their channel definitions and writes the
 	// evaluated values into StreamAggregates. The engine is shared via
-	// llo/protocol/calculated.
-	// nil HistoryReader: the round's history store is not wired up yet, so
-	// expressions using History fail closed rather than evaluating against an
-	// empty window.
-	calculated.ProcessCalculatedStreams(p.Logger, effective, out.StreamAggregates, out.ObservationTimestampNanoseconds, prev.opts, nil)
+	// llo/protocol/calculated. The history store is the read side: expressions
+	// using History(...) read the windows appended above, and are left
+	// unevaluated while a window is still shallower than requested.
+	calculated.ProcessCalculatedStreams(p.Logger, effective, out.StreamAggregates, out.ObservationTimestampNanoseconds, prev.opts, history)
 
 	// Carry any calculated streams appended above into pending, so the append
 	// is persisted and does not repeat every round. Channels whose definition
@@ -189,13 +209,17 @@ func (p *Plugin) StateTransition(ctx context.Context, seqNr uint64, _ ocrtypes.A
 	adoptCalculatedStreams(pending, effective, updatedChannelIDs)
 
 	// Flush KV mutations.
-	if err := p.flushKV(kvRW, seqNr, prev, out, pending, carryForward); err != nil {
+	if err := p.flushKV(kvRW, seqNr, prev, out, pending, carryForward, history); err != nil {
 		return nil, err
 	}
 
 	if p.Config.VerboseLogging {
 		p.Logger.Debugw("Generated precursor", "lifeCycleStage", out.LifeCycleStage, "channels", len(out.ChannelDefinitions), "seqNr", seqNr)
 	}
+	// After the flush, so the recorded window sizes are the ones actually
+	// written. Node-local observation only; nothing reads these back.
+	p.captureHistoryTelemetry(history, requirements)
+	p.captureInsufficientHistory(effective, prev.opts, history)
 	p.captureOutcomeTelemetry(out, seqNr)
 	return encodePrecursor(out)
 }
@@ -350,11 +374,22 @@ func adoptCalculatedStreams(pending, effective llotypes.ChannelDefinitions, upda
 // that is not written into nextCarry is dropped from the store, which is how
 // carry-forward values orphaned by channel removal or tombstoning are
 // reclaimed.
+//
+// The agreed value of each pair is also recorded into stream history for the
+// pairs that require it. History records what the round actually agreed on --
+// the same value written into StreamAggregates -- so a window is always a series
+// of values that reached consensus. A pair with no aggregate this round
+// (aggregation failed, stream absent) contributes nothing: a gap in the series
+// is honest, whereas repeating the previous value would silently weight it
+// twice.
 func (p *Plugin) aggregate(
 	prevCarry, nextCarry map[llotypes.StreamID]map[llotypes.Aggregator]*protocol.TimestampedStreamValue,
 	defs llotypes.ChannelDefinitions,
 	streamObservations map[llotypes.StreamID][]protocol.StreamValue,
 	out protocol.StreamAggregates,
+	history *historyStore,
+	requirements historyRequirements,
+	observationTimestampNanoseconds uint64,
 ) error {
 	keep := func(sid llotypes.StreamID, agg llotypes.Aggregator, tsv *protocol.TimestampedStreamValue) {
 		if nextCarry[sid] == nil {
@@ -427,15 +462,51 @@ func (p *Plugin) aggregate(
 				// yields a non-timestamped value, drop the stale carry-forward
 				// by not writing it into nextCarry.
 			}
+
+			if err := appendHistory(history, requirements, sid, agg, m[agg], observationTimestampNanoseconds, p.Logger); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
+// appendHistory records a pair's agreed value for this round.
+//
+// The timestamp is the value's own observation time for timestamped aggregates
+// and the round's consensus observation timestamp otherwise. Either way the
+// append only takes effect if it is strictly newer than the newest stored
+// record, which is what stops a carried-forward value from being counted once
+// per round until it refreshes.
+//
+// A value too large to store is dropped with a loud log rather than failing the
+// round: the round has already agreed on it, so halting over it would take the
+// DON down for a data problem.
+func appendHistory(history *historyStore, requirements historyRequirements, sid llotypes.StreamID, agg llotypes.Aggregator, value protocol.StreamValue, observationTimestampNanoseconds uint64, lggr logger.Logger) error {
+	if history == nil || value == nil || !requirements.requires(sid, agg) {
+		return nil
+	}
+
+	observedAt := observationTimestampNanoseconds
+	if tsv, ok := value.(*protocol.TimestampedStreamValue); ok {
+		observedAt = tsv.ObservedAtNanoseconds
+	}
+
+	_, err := history.Append(sid, agg, observedAt, value)
+	if errors.Is(err, protocol.ErrHistoryRecordTooLarge) {
+		history.oversized++
+		lggr.Errorw("Dropping stream history record: value too large to store",
+			"streamID", sid, "aggregator", agg, "err", err)
+		return nil
+	}
+	return err
+}
+
 // flushKV persists the computed state. The per-round record (r/agg) is always
 // rewritten; the channel record (c/defs, c/seqnr) and the lifecycle stage are
 // written only when they actually change, so that readers can keep serving
-// their in-memory copy of the definitions (see channelCache).
+// their in-memory copy of the definitions (see channelCache). Modified history
+// windows are flushed alongside it.
 func (p *Plugin) flushKV(
 	kvRW ocr3_1types.KeyValueStateReadWriter,
 	seqNr uint64,
@@ -443,6 +514,7 @@ func (p *Plugin) flushKV(
 	out precursor,
 	pending llotypes.ChannelDefinitions,
 	carryForward map[llotypes.StreamID]map[llotypes.Aggregator]*protocol.TimestampedStreamValue,
+	history *historyStore,
 ) error {
 	if out.LifeCycleStage != prev.lifeCycleStage {
 		if err := writeLifecycle(kvRW, out.LifeCycleStage); err != nil {
@@ -467,6 +539,14 @@ func (p *Plugin) flushKV(
 	reportable := make(map[llotypes.ChannelID]bool, len(out.ChannelDefinitions))
 	for id := range out.ChannelDefinitions {
 		reportable[id] = out.isReportable(id, p.DefaultMinReportIntervalNanoseconds, prev.opts, p.Logger)
+	}
+
+	// Stream history: write modified windows, delete pairs no live channel
+	// requires, and rewrite the history index if the stored set changed.
+	if history != nil {
+		if err := history.Flush(kvRW); err != nil {
+			return err
+		}
 	}
 
 	return writeHotState(kvRW, out.ObservationTimestampNanoseconds, out.ValidAfterNanoseconds, reportable, carryForward)

--- a/llo/dev/v31/statetransition.go
+++ b/llo/dev/v31/statetransition.go
@@ -177,7 +177,10 @@ func (p *Plugin) StateTransition(ctx context.Context, seqNr uint64, _ ocrtypes.A
 	// the calculated streams to their channel definitions and writes the
 	// evaluated values into StreamAggregates. The engine is shared via
 	// llo/protocol/calculated.
-	calculated.ProcessCalculatedStreams(p.Logger, effective, out.StreamAggregates, out.ObservationTimestampNanoseconds, prev.opts)
+	// nil HistoryReader: the round's history store is not wired up yet, so
+	// expressions using History fail closed rather than evaluating against an
+	// empty window.
+	calculated.ProcessCalculatedStreams(p.Logger, effective, out.StreamAggregates, out.ObservationTimestampNanoseconds, prev.opts, nil)
 
 	// Carry any calculated streams appended above into pending, so the append
 	// is persisted and does not repeat every round. Channels whose definition

--- a/llo/dev/v31/statetransition.go
+++ b/llo/dev/v31/statetransition.go
@@ -136,7 +136,7 @@ func (p *Plugin) StateTransition(ctx context.Context, seqNr uint64, _ ocrtypes.A
 			if cd.ReportFormat == llotypes.ReportFormatHistoryBackfill {
 				// Backfill: the watermark advances to whatever observation the
 				// previous round would have selected (and emitted), or stays put.
-				if tsNanos, _, _, found := selectBackfillCandidate(effective, prev.validAfterNanoseconds, prev.observationTimestampNs, channelID); found {
+				if tsNanos, _, _, found := selectBackfillCandidate(effective, prev.validAfterNanoseconds, prev.observationTimestampNs, channelID, prev.opts); found {
 					out.ValidAfterNanoseconds[channelID] = tsNanos
 				} else {
 					out.ValidAfterNanoseconds[channelID] = prevValidAfter

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -69,6 +69,7 @@ var defaultEnv = map[string]any{
 	"Delta":     Delta,
 	"PctChange": PctChange,
 	"Spread":    Spread,
+	"SMA":       SMA,
 	// History is rewritten away at compile time (see history_ast.go). It is
 	// registered only so that a call surviving to evaluation fails loudly
 	// instead of resolving to an undefined identifier or, worse, to something

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -1,6 +1,7 @@
 package calculated
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -507,6 +508,10 @@ func ParseDuration(x string) (time.Duration, error) {
 // toDecimal converts x to a decimal.Decimal
 func toDecimal(x any) (decimal.Decimal, error) {
 	switch v := x.(type) {
+	case Series:
+		// Static analysis rejects windows in scalar positions, so this is a
+		// backstop for a bypassed analysis rather than an expected path.
+		return decimal.Decimal{}, fmt.Errorf("%w (length %d)", ErrSeriesAsScalar, v.Len())
 	case string:
 		return decimal.NewFromString(v)
 	case int:
@@ -592,7 +597,7 @@ func evalDecimal(stmt string, env map[string]any) (decimal.Decimal, error) {
 // channel definitions and writing the evaluated values into streamAggregates.
 // It is version-agnostic: both the v30 and v31 plugins call it with their own
 // outcome/precursor fields.
-func ProcessCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.ChannelDefinitions, streamAggregates protocol.StreamAggregates, observationTimestampNanoseconds uint64, optsCache *protocol.OptsCache) {
+func ProcessCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.ChannelDefinitions, streamAggregates protocol.StreamAggregates, observationTimestampNanoseconds uint64, optsCache *protocol.OptsCache, history HistoryReader) {
 	for cid, cd := range channelDefinitions {
 		if cd.Tombstone {
 			continue
@@ -602,7 +607,17 @@ func ProcessCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.Ch
 			continue
 		}
 
-		var err error
+		// aggByStream resolves the aggregator a History call refers to. The DSL
+		// names only a stream, so the channel definition is what says which
+		// aggregation of it the expression sees.
+		aggByStream, err := AggregatorByStream(cd)
+		if err != nil {
+			// Ambiguous aggregation cannot be resolved deterministically, so
+			// the channel is skipped rather than guessed at.
+			lggr.Errorw("skipping channel with ambiguous stream aggregators", "channelID", cid, "error", err)
+			continue
+		}
+
 		env := NewEnv(observationTimestampNanoseconds)
 		for _, stream := range cd.Streams {
 			if stream.Aggregator == llotypes.AggregatorCalculated {
@@ -647,8 +662,15 @@ func ProcessCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.Ch
 			channelDefinitions[cid] = cd
 		}
 
-		if err := evalExpression(&copt, cid, env, streamAggregates); err != nil {
-			lggr.Errorw("failed to process expression", "channelID", cid, "error", err)
+		if err := evalExpression(&copt, cid, env, streamAggregates, history, aggByStream); err != nil {
+			if errors.Is(err, ErrInsufficientHistory) {
+				// Expected while history warms up, after a depth increase, or
+				// after corrupt state was discarded. No aggregate is written,
+				// so the channel is not reportable this round.
+				lggr.Infow("insufficient stream history; channel not reportable this round", "channelID", cid, "error", err)
+			} else {
+				lggr.Errorw("failed to process expression", "channelID", cid, "error", err)
+			}
 		}
 		env.release()
 	}
@@ -678,7 +700,47 @@ func AggregatorByStream(cd llotypes.ChannelDefinition) (map[llotypes.StreamID]ll
 	return byStream, nil
 }
 
-func evalExpression(o *calculatedStreamOpts, cid llotypes.ChannelID, env environment, streamAggregates protocol.StreamAggregates) error {
+// bindHistory loads every window an expression declares and binds it into the
+// environment under the identifier the compile-time rewrite will use.
+//
+// Returns ErrInsufficientHistory if any window is not yet deep enough. That is
+// not an error in the operational sense — it is the warmup gate — but the
+// expression must not be evaluated, because a short window would silently
+// change the meaning of the result.
+func bindHistory(expression string, env environment, history HistoryReader, aggByStream map[llotypes.StreamID]llotypes.Aggregator) error {
+	refs, err := AnalyzeExpressionHistory(expression)
+	if err != nil {
+		return err
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	if history == nil {
+		// v30 has no replicated key-value state, so there is nowhere for
+		// history to live. Fail closed rather than evaluate against nothing.
+		return fmt.Errorf("expression uses %s but stream history is unavailable in this protocol version", HistoryFunctionName)
+	}
+
+	for _, ref := range refs {
+		aggregator, ok := aggByStream[ref.StreamID]
+		if !ok {
+			return fmt.Errorf("%s references stream %d, which the channel does not observe", HistoryFunctionName, ref.StreamID)
+		}
+		series, err := history.Series(ref.StreamID, aggregator, ref.Count, ref.Field)
+		if err != nil {
+			return fmt.Errorf("%s: %w", ref, err)
+		}
+		if uint32(series.Len()) != ref.Count {
+			// Defensive: a reader returning a differently sized window would
+			// change what the expression computes.
+			return fmt.Errorf("%s: reader returned %d records, expected %d", ref, series.Len(), ref.Count)
+		}
+		env[ref.envName()] = series
+	}
+	return nil
+}
+
+func evalExpression(o *calculatedStreamOpts, cid llotypes.ChannelID, env environment, streamAggregates protocol.StreamAggregates, history HistoryReader, aggByStream map[llotypes.StreamID]llotypes.Aggregator) error {
 	for _, abi := range o.ABI {
 		if abi.ExpressionStreamID == 0 {
 			return fmt.Errorf("expression stream ID is 0, channelID: %d, expression: %s",
@@ -695,6 +757,12 @@ func evalExpression(o *calculatedStreamOpts, cid llotypes.ChannelID, env environ
 			return fmt.Errorf(
 				"calculated stream aggregate ID already exists, channelID: %d, expressionStreamID: %d, expression: %s",
 				cid, abi.ExpressionStreamID, abi.Expression)
+		}
+
+		if err := bindHistory(abi.Expression, env, history, aggByStream); err != nil {
+			return fmt.Errorf(
+				"failed to bind stream history, channelID: %d, expression: %s, error: %w",
+				cid, abi.Expression, err)
 		}
 
 		value, err := evalDecimal(abi.Expression, env)
@@ -850,7 +918,10 @@ func ProcessCalculatedStreamsDryRun(expression string) error {
 		},
 	}
 
-	env := NewEnv(uint64(time.Now().UnixNano()))
+	// The same timestamp anchors the environment and the synthesized history, so
+	// window-relative functions see records inside their window.
+	dryRunObservationTimestampNanoseconds := uint64(time.Now().UnixNano())
+	env := NewEnv(dryRunObservationTimestampNanoseconds)
 	defer env.release()
 	for _, stream := range cd[1].Streams {
 		if err := env.SetStreamValue(stream.StreamID, aggr[stream.StreamID][stream.Aggregator]); err != nil {
@@ -872,7 +943,21 @@ func ProcessCalculatedStreamsDryRun(expression string) error {
 			},
 		},
 	}
-	err = evalExpression(o, 1, env, aggr)
+	aggByStream, err := AggregatorByStream(cd[1])
+	if err != nil {
+		return fmt.Errorf("failed to index channel streams: %w", err)
+	}
+
+	// History windows are synthesized: there is no persisted state offline, and
+	// what is being validated is the shape of the expression, not the values.
+	// The reader always returns the full requested depth so validation
+	// exercises the evaluable path rather than the warmup gate.
+	dryRunHistory := syntheticHistoryReader{
+		endNanoseconds:      dryRunObservationTimestampNanoseconds,
+		intervalNanoseconds: uint64(time.Second),
+	}
+
+	err = evalExpression(o, 1, env, aggr, dryRunHistory, aggByStream)
 	if err != nil {
 		return fmt.Errorf("failed to process expression: %w", err)
 	}

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -196,63 +196,42 @@ func Floor(x any) (decimal.Decimal, error) {
 	return ad.Floor(), nil
 }
 
-// Avg returns the average of x elements
+// Avg returns the average of x elements, which may be a single history window or
+// a list of scalars.
+//
+// NOTE: the division is pinned to legacyDivisionPrecision, which is what this
+// function has always effectively used via decimal.DivisionPrecision. Raising it
+// would change the trailing digits of every existing calculated stream.
 func Avg(x ...any) (decimal.Decimal, error) {
-	if len(x) == 0 {
-		return decimal.Decimal{}, fmt.Errorf("no elements to calculate avg")
-	}
-
-	sum := decimal.Zero
-	for _, v := range x {
-		ad, err := toDecimal(v)
-		if err != nil {
-			return decimal.Decimal{}, err
-		}
-		sum = sum.Add(ad)
-	}
-	return sum.Div(decimal.NewFromInt(int64(len(x)))), nil
-}
-
-// Max returns the maximum of x elements
-func Max(x ...any) (decimal.Decimal, error) {
-	if len(x) == 0 {
-		return decimal.Decimal{}, fmt.Errorf("no elements to calculate max")
-	}
-
-	max, err := toDecimal(x[0])
+	values, err := scalarsOrWindow("Avg", x)
 	if err != nil {
 		return decimal.Decimal{}, err
 	}
 
-	for _, v := range x[1:] {
-		ad, err := toDecimal(v)
-		if err != nil {
-			return decimal.Decimal{}, err
-		}
-		max = decimal.Max(max, ad)
+	sum := decimal.Zero
+	for _, v := range values {
+		sum = sum.Add(v)
 	}
-	return max, nil
+	return divRoundByInt(sum, len(values), legacyDivisionPrecision)
+}
+
+// Max returns the maximum of x elements, which may be a single history window or
+// a list of scalars.
+func Max(x ...any) (decimal.Decimal, error) {
+	values, err := scalarsOrWindow("Max", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	return decimal.Max(values[0], values[1:]...), nil
 }
 
 // Min returns the minimum of x elements
 func Min(x ...any) (decimal.Decimal, error) {
-	if len(x) == 0 {
-		return decimal.Decimal{}, fmt.Errorf("no elements to calculate min")
-	}
-
-	min, err := toDecimal(x[0])
+	values, err := scalarsOrWindow("Min", x)
 	if err != nil {
 		return decimal.Decimal{}, err
 	}
-
-	for _, v := range x[1:] {
-		ad, err := toDecimal(v)
-		if err != nil {
-			return decimal.Decimal{}, err
-		}
-		min = decimal.Min(min, ad)
-	}
-	return min, nil
+	return decimal.Min(values[0], values[1:]...), nil
 }
 
 // GreaterThan returns true if x is greater than y
@@ -339,11 +318,10 @@ func Div(x, y any) (decimal.Decimal, error) {
 	if err != nil {
 		return decimal.Decimal{}, err
 	}
-	if bd.IsZero() {
-		return decimal.Decimal{}, fmt.Errorf("division by zero")
-	}
-
-	return ad.Div(bd), nil
+	// NOTE: pinned to legacyDivisionPrecision, the precision this has always
+	// effectively used via the mutable decimal.DivisionPrecision global. Raising
+	// it would change the trailing digits of every existing calculated stream.
+	return divRound(ad, bd, legacyDivisionPrecision)
 }
 
 // Add returns the sum of x and y
@@ -383,7 +361,7 @@ func Pow(x, y any) (decimal.Decimal, error) {
 		return decimal.Decimal{}, err
 	}
 	// We use double precision here in order to offset any float approximation errors.
-	res, err := base.PowWithPrecision(power, doublePrecision)
+	res, err := decimalPow(base, power, doublePrecision)
 	if err != nil {
 		return decimal.Decimal{}, err
 	}
@@ -401,7 +379,7 @@ func Sqrt(x any) (decimal.Decimal, error) {
 	}
 	sqrtPow, _ := toDecimal(0.5)
 	// We use double precision here in order to offset any float approximation errors.
-	res, err := n.PowWithPrecision(sqrtPow, doublePrecision)
+	res, err := decimalPow(n, sqrtPow, doublePrecision)
 	if err != nil {
 		return decimal.Decimal{}, err
 	}
@@ -417,7 +395,7 @@ func Ln(x any) (decimal.Decimal, error) {
 	if n.IsZero() {
 		return decimal.Decimal{}, fmt.Errorf("cannot represent natural logarithm of 0")
 	}
-	return n.Ln(precision)
+	return decimalLn(n, precision)
 }
 
 // Log returns the logarithms of y with base x. This is equivalent to log_x(y).
@@ -432,7 +410,7 @@ func Log(x, y any) (decimal.Decimal, error) {
 	if err != nil {
 		return decimal.Decimal{}, err
 	}
-	lnLog, err := log.Ln(doublePrecision) // double precision, since we're going to divide them
+	lnLog, err := decimalLn(log, doublePrecision) // double precision, since we're going to divide them
 	if err != nil {
 		return decimal.Decimal{}, err
 	}
@@ -441,7 +419,7 @@ func Log(x, y any) (decimal.Decimal, error) {
 	if err != nil {
 		return decimal.Decimal{}, err
 	}
-	lnBase, err := base.Ln(doublePrecision) // double precision, since we're going to divide them
+	lnBase, err := decimalLn(base, doublePrecision) // double precision, since we're going to divide them
 	if err != nil {
 		return decimal.Decimal{}, err
 	}

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -60,6 +60,10 @@ var defaultEnv = map[string]any{
 	"Avg":                Avg,
 	"Duration":           ParseDuration,
 
+	// History window functions. See history_ast.go for which of these a window
+	// may be passed to; that list and these registrations must agree, or an
+	// expression will either fail to compile or be rejected as misusing a
+	// window.
 	"Count":     Count,
 	"First":     First,
 	"Last":      Last,
@@ -70,8 +74,12 @@ var defaultEnv = map[string]any{
 	"PctChange": PctChange,
 	"Spread":    Spread,
 	"SMA":       SMA,
-	"EMA":       EMA,
 	"WMA":       WMA,
+	"EMA":       EMA,
+	// TWAP needs the round's observation timestamp to anchor its window, so
+	// NewEnv rebinds it per round. This default only reports that it was called
+	// against an environment NewEnv did not build.
+	"TWAP": twapUnbound,
 	// History is rewritten away at compile time (see history_ast.go). It is
 	// registered only so that a call surviving to evaluation fails loudly
 	// instead of resolving to an undefined identifier or, worse, to something
@@ -173,6 +181,10 @@ func (e environment) release() {
 func NewEnv(observationTimestampNanoseconds uint64) environment {
 	env := pool.Get().(environment)
 	env["observations_timestamp"] = observationTimestampNanoseconds
+	// TWAP's window is anchored on the round's consensus observation timestamp,
+	// not on the data, so it is bound per round. release() restores the default
+	// binding, which fails if called.
+	env["TWAP"] = twapFunc(observationTimestampNanoseconds)
 	return env
 }
 

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -12,9 +12,9 @@ import (
 	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
 
 	"github.com/expr-lang/expr"
-	"github.com/goccy/go-json"
 	"github.com/expr-lang/expr/ast"
 	"github.com/expr-lang/expr/parser"
+	"github.com/goccy/go-json"
 	"github.com/shopspring/decimal"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -58,6 +58,19 @@ var defaultEnv = map[string]any{
 	"Floor":              Floor,
 	"Avg":                Avg,
 	"Duration":           ParseDuration,
+
+	"Count": Count,
+	// History is rewritten away at compile time (see history_ast.go). It is
+	// registered only so that a call surviving to evaluation fails loudly
+	// instead of resolving to an undefined identifier or, worse, to something
+	// that quietly works on scalars. Reaching it means the AST pass was
+	// bypassed.
+	HistoryFunctionName: historyCallReached,
+}
+
+// historyCallReached is the runtime stub for History. See defaultEnv.
+func historyCallReached(...any) (decimal.Decimal, error) {
+	return decimal.Decimal{}, fmt.Errorf("%s was not resolved at compile time; this is a bug in expression compilation", HistoryFunctionName)
 }
 
 var (
@@ -530,17 +543,38 @@ func toDecimal(x any) (decimal.Decimal, error) {
 	}
 }
 
-// evalDecimal evaluates the given expression and returns the result as a decimal.Decimal
+// evalDecimal evaluates the given expression and returns the result as a decimal.Decimal.
+//
+// History calls are resolved at compile time by rewriting them into window
+// identifiers (see history_ast.go), which the caller must already have bound
+// into env. Compiled programs are cached per expression string, so parsing,
+// patching and compiling happen once per distinct expression per node rather
+// than once per round.
 func evalDecimal(stmt string, env map[string]any) (decimal.Decimal, error) {
-	// compile with the environment for	type checking
-	// disable all builtins to avoid unexpected behaviors
-	p, err := expr.Compile(stmt, expr.Env(env), expr.DisableAllBuiltins())
-
-	if err != nil {
-		return decimal.Decimal{}, fmt.Errorf("failed to compile expression: %w", err)
+	// NOTE: the env parameter is deliberately map[string]any rather than the
+	// named environment type, and must stay that way. Patching an expression
+	// discards the checker's type information, so identifier reads fall back to
+	// a dynamic fetch that type-asserts the environment to exactly
+	// map[string]any; passing the named type through would fail that assertion
+	// at run time with "interface conversion: interface {} is
+	// calculated.environment".
+	program := historyAnalysisCache.program(stmt)
+	if program == nil {
+		var err error
+		// compile with the environment for type checking, disable all builtins
+		// to avoid unexpected behaviors, and patch History calls into the
+		// window identifiers bound by the caller.
+		program, err = expr.Compile(stmt, expr.Env(env), expr.DisableAllBuiltins(), expr.Patch(newHistoryPatcher()))
+		if err != nil {
+			// Not cached: unlike analysis, a compile failure can be caused by
+			// the environment (a stream missing from this channel), so it is
+			// not a property of the expression alone.
+			return decimal.Decimal{}, fmt.Errorf("failed to compile expression: %w", err)
+		}
+		historyAnalysisCache.storeProgram(stmt, program)
 	}
 
-	r, err := expr.Run(p, env)
+	r, err := expr.Run(program, env)
 	if err != nil {
 		return decimal.Decimal{}, fmt.Errorf("failed to evaluate expression: %w", err)
 	}
@@ -618,6 +652,30 @@ func ProcessCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.Ch
 		}
 		env.release()
 	}
+}
+
+// AggregatorByStream indexes a channel's non-calculated streams by stream ID.
+// It is the mapping from what a History call names (a stream) to what history is
+// keyed by (a stream and an aggregator), and is exported so the plugin derives
+// its persisted requirements from exactly the same mapping evaluation uses.
+//
+// A stream appearing twice under different aggregators makes any History call
+// naming it ambiguous — the DSL has no way to say which aggregation is meant —
+// so this is rejected rather than resolved arbitrarily. Rejecting is
+// deterministic; picking one would differ between nodes if map iteration order
+// ever leaked in.
+func AggregatorByStream(cd llotypes.ChannelDefinition) (map[llotypes.StreamID]llotypes.Aggregator, error) {
+	byStream := make(map[llotypes.StreamID]llotypes.Aggregator, len(cd.Streams))
+	for _, stream := range cd.Streams {
+		if stream.Aggregator == llotypes.AggregatorCalculated {
+			continue
+		}
+		if existing, ok := byStream[stream.StreamID]; ok && existing != stream.Aggregator {
+			return nil, fmt.Errorf("stream %d appears with aggregators %d and %d", stream.StreamID, existing, stream.Aggregator)
+		}
+		byStream[stream.StreamID] = stream.Aggregator
+	}
+	return byStream, nil
 }
 
 func evalExpression(o *calculatedStreamOpts, cid llotypes.ChannelID, env environment, streamAggregates protocol.StreamAggregates) error {
@@ -711,6 +769,32 @@ func ExpressionStreamIDs(optsCache *protocol.OptsCache, cd llotypes.ChannelDefin
 		ids = append(ids, abi.ExpressionStreamID)
 	}
 	return ids, nil
+}
+
+// Expressions returns a channel's expressions in declaration order.
+//
+// It exists so the plugin can derive history requirements from the same source of
+// truth evaluation uses — the channel's opts — rather than from the streams
+// appended to the channel definition, which only appear once evaluation has got
+// that far.
+//
+// An ABI entry with no expression is an error, not a skip. Such an entry names a
+// calculated stream that nothing can produce: evalExpression fails on it, the
+// stream stays absent, and the channel is therefore never reportable. Reporting
+// that when the definition is validated is the whole point of validating it.
+func Expressions(optsCache *protocol.OptsCache, cd llotypes.ChannelDefinition, cid llotypes.ChannelID) ([]string, error) {
+	o, err := getCalculatedStreamOpts(optsCache, cd, cid)
+	if err != nil {
+		return nil, err
+	}
+	expressions := make([]string, 0, len(o.ABI))
+	for i, abi := range o.ABI {
+		if abi.Expression == "" {
+			return nil, fmt.Errorf("expression is empty, channelID: %d, abi index: %d, expressionStreamID: %d", cid, i, abi.ExpressionStreamID)
+		}
+		expressions = append(expressions, abi.Expression)
+	}
+	return expressions, nil
 }
 
 // ProcessCalculatedStreamsDryRun processes the calculated streams for the given expression

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -150,7 +150,12 @@ func (e environment) SetStreamValue(id llotypes.StreamID, value protocol.StreamV
 	case protocol.LLOStreamValue_TimestampedStreamValue:
 		tsv := value.(*protocol.TimestampedStreamValue)
 		e[fmt.Sprintf("s%d_timestamp", id)] = tsv.ObservedAtNanoseconds
-		e.SetStreamValue(id, tsv.StreamValue)
+		// The wrapped value is what expressions actually name, so failing to
+		// bind it is the caller's error to see here: reported later it surfaces
+		// as an unknown-name compile failure instead.
+		if err := e.SetStreamValue(id, tsv.StreamValue); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -70,6 +70,7 @@ var defaultEnv = map[string]any{
 	"PctChange": PctChange,
 	"Spread":    Spread,
 	"SMA":       SMA,
+	"WMA":       WMA,
 	// History is rewritten away at compile time (see history_ast.go). It is
 	// registered only so that a call surviving to evaluation fails loudly
 	// instead of resolving to an undefined identifier or, worse, to something

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -18,7 +18,6 @@ import (
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/ast"
 	"github.com/expr-lang/expr/parser"
-	"github.com/goccy/go-json"
 	"github.com/shopspring/decimal"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -613,10 +612,14 @@ const maxEvaluationWorkers = 8
 const minParallelEvaluationWeight = 256
 
 // ProcessCalculatedStreams evaluates expressions for each channel of the
-// EVMABIEncodeUnpackedExpr format, appending the calculated streams to their
-// channel definitions and writing the evaluated values into streamAggregates.
-// It is version-agnostic: both the v30 and v31 plugins call it with their own
-// outcome/precursor fields.
+// EVMABIEncodeUnpackedExpr format and writes the evaluated values into
+// streamAggregates. It is version-agnostic: both the v3.0 and v3.1 plugins call
+// it with their own outcome/precursor fields.
+//
+// channelDefinitions is read-only. The calculated streams a channel reports are
+// derived from its opts by protocol.EffectiveStreams, not stored on the
+// definition, so a definition is exactly what was voted on and evaluation
+// contributes nothing to replicated state.
 //
 // Processing runs in three phases — prepare, evaluate, apply — so that only the
 // pure part is parallelized:
@@ -629,15 +632,29 @@ const minParallelEvaluationWeight = 256
 //     environment is all it needs, and nothing it touches is shared with
 //     another channel.
 //   - apply is sequential and walks channels in ascending channel ID order, so
-//     the aggregates written, the definitions mutated and the errors logged do
-//     not depend on how the work was scheduled.
+//     the aggregates written and the errors logged do not depend on how the
+//     work was scheduled.
 func ProcessCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.ChannelDefinitions, streamAggregates protocol.StreamAggregates, observationTimestampNanoseconds uint64, optsCache *protocol.OptsCache, history HistoryReader) {
+	process(lggr, channelDefinitions, streamAggregates, observationTimestampNanoseconds, optsCache, history, false)
+}
+
+// ProcessCalculatedStreamsWithDefinitionAppend behaves as
+// ProcessCalculatedStreams but additionally appends each channel's calculated
+// streams to its channel definition.
+//
+// Deprecated: for v3.0 only.
+// v3.0 commits channelDefinitions as part of its outcome.
+func ProcessCalculatedStreamsWithDefinitionAppend(lggr logger.Logger, channelDefinitions llotypes.ChannelDefinitions, streamAggregates protocol.StreamAggregates, observationTimestampNanoseconds uint64, optsCache *protocol.OptsCache, history HistoryReader) {
+	process(lggr, channelDefinitions, streamAggregates, observationTimestampNanoseconds, optsCache, history, true)
+}
+
+func process(lggr logger.Logger, channelDefinitions llotypes.ChannelDefinitions, streamAggregates protocol.StreamAggregates, observationTimestampNanoseconds uint64, optsCache *protocol.OptsCache, history HistoryReader, appendToDefinitions bool) {
 	works := prepareCalculatedStreams(lggr, channelDefinitions, streamAggregates, observationTimestampNanoseconds, optsCache, history)
 	if len(works) == 0 {
 		return
 	}
 	results := evaluateCalculatedStreams(works)
-	applyCalculatedStreams(lggr, channelDefinitions, streamAggregates, works, results)
+	applyCalculatedStreams(lggr, channelDefinitions, streamAggregates, works, results, appendToDefinitions)
 }
 
 // channelWork is one channel's fully materialized evaluation input: everything
@@ -803,22 +820,27 @@ func evaluationWeight(works []channelWork) int {
 //
 // The duplicate-aggregate check lives here rather than in evaluation because it
 // is the one check whose answer depends on what earlier channels wrote.
-func applyCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.ChannelDefinitions, streamAggregates protocol.StreamAggregates, works []channelWork, results []channelResult) {
+//
+// appendToDefinitions is the deprecated v3.0 behaviour; see
+// ProcessCalculatedStreamsWithDefinitionAppend.
+func applyCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.ChannelDefinitions, streamAggregates protocol.StreamAggregates, works []channelWork, results []channelResult, appendToDefinitions bool) {
 	for i := range works {
 		work := &works[i]
 		result := &results[i]
 
-		// channel definitions are inherited from the previous outcome,
-		// so we only update the channel definition streams if we haven't done it before
-		cd := work.cd
-		if cd.Streams[len(cd.Streams)-1].StreamID != work.opts.ABI[len(work.opts.ABI)-1].ExpressionStreamID {
-			for _, abi := range work.opts.ABI {
-				cd.Streams = append(cd.Streams, llotypes.Stream{
-					StreamID:   abi.ExpressionStreamID,
-					Aggregator: llotypes.AggregatorCalculated,
-				})
+		if appendToDefinitions {
+			// channel definitions are inherited from the previous outcome,
+			// so we only update the channel definition streams if we haven't done it before
+			cd := work.cd
+			if cd.Streams[len(cd.Streams)-1].StreamID != work.opts.ABI[len(work.opts.ABI)-1].ExpressionStreamID {
+				for _, abi := range work.opts.ABI {
+					cd.Streams = append(cd.Streams, llotypes.Stream{
+						StreamID:   abi.ExpressionStreamID,
+						Aggregator: llotypes.AggregatorCalculated,
+					})
+				}
+				channelDefinitions[work.cid] = cd
 			}
-			channelDefinitions[work.cid] = cd
 		}
 
 		err := result.err
@@ -986,61 +1008,32 @@ func evalChannel(work *channelWork) channelResult {
 	return channelResult{values: values, err: work.err}
 }
 
-// calculatedStreamOpts is the options structure for expression/calculated streams.
-// It is used with protocol.OptsCache for decoding channel opts in ProcessCalculatedStreams.
-type calculatedStreamOpts struct {
-	ABI []struct {
-		Type               string            `json:"type"`
-		Expression         string            `json:"expression"`
-		ExpressionStreamID llotypes.StreamID `json:"expressionStreamID"`
-	} `json:"abi"`
-}
+// calculatedStreamOpts is the options structure for expression/calculated
+// streams. It aliases the protocol-level shape so that evaluation, channel
+// definition verification and effective-stream derivation all decode the same
+// declaration.
+type calculatedStreamOpts = protocol.CalculatedStreamOpts
 
-// getCalculatedStreamOpts resolves a channel's calculated-stream opts, preferring
-// the (node-local) decode cache and falling back to decoding the channel
-// definition's opts on a cache miss. The fallback keeps the result deterministic
-// across oracles even when the cache has not been populated (e.g. after a
-// restart, or in stages that never reset it).
-//
-// Returns an error if the opts cannot be decoded or declare no expressions.
+// getCalculatedStreamOpts resolves a channel's calculated-stream opts. See
+// protocol.DecodeCalculatedStreamOpts for the cache/fallback behaviour.
 func getCalculatedStreamOpts(optsCache *protocol.OptsCache, cd llotypes.ChannelDefinition, cid llotypes.ChannelID) (calculatedStreamOpts, error) {
-	var o calculatedStreamOpts
-	var err error
-	if optsCache != nil {
-		o, err = protocol.GetOpts[calculatedStreamOpts](optsCache, cid)
-	}
-	if optsCache == nil || err != nil {
-		o = calculatedStreamOpts{}
-		if uerr := json.Unmarshal(cd.Opts, &o); uerr != nil {
-			return o, fmt.Errorf("failed to decode calculated stream opts, channelID: %d: %w", cid, uerr)
-		}
-	}
-	if len(o.ABI) == 0 {
-		return o, fmt.Errorf("no expressions found in channel definition, channelID: %d", cid)
+	o, err := protocol.DecodeCalculatedStreamOpts(optsCache, cd, cid)
+	if err != nil {
+		return o, fmt.Errorf("%w, channelID: %d", err, cid)
 	}
 	return o, nil
 }
 
 // ExpressionStreamIDs returns the calculated (expression) stream IDs declared by
 // a channel's opts, in declaration order. It is the source of truth for which
-// calculated streams a channel is expected to produce: the streams appended to
-// the channel definition by ProcessCalculatedStreams are only present when
-// evaluation reached that point, so callers that need to verify completeness
-// (e.g. reportability checks) must consult the opts instead.
+// calculated streams a channel is expected to produce.
 //
 // Returns an error if the opts cannot be resolved, declare no expressions, or
 // declare a zero expression stream ID.
 func ExpressionStreamIDs(optsCache *protocol.OptsCache, cd llotypes.ChannelDefinition, cid llotypes.ChannelID) ([]llotypes.StreamID, error) {
-	o, err := getCalculatedStreamOpts(optsCache, cd, cid)
+	ids, err := protocol.CalculatedStreamIDs(optsCache, cd, cid)
 	if err != nil {
-		return nil, err
-	}
-	ids := make([]llotypes.StreamID, 0, len(o.ABI))
-	for _, abi := range o.ABI {
-		if abi.ExpressionStreamID == 0 {
-			return nil, fmt.Errorf("expression stream ID is 0, channelID: %d, expression: %s", cid, abi.Expression)
-		}
-		ids = append(ids, abi.ExpressionStreamID)
+		return nil, fmt.Errorf("%w, channelID: %d", err, cid)
 	}
 	return ids, nil
 }
@@ -1137,11 +1130,7 @@ func ProcessCalculatedStreamsDryRun(expression string) error {
 
 	// Process the calculated streams
 	o := &calculatedStreamOpts{
-		ABI: []struct {
-			Type               string            `json:"type"`
-			Expression         string            `json:"expression"`
-			ExpressionStreamID llotypes.StreamID `json:"expressionStreamID"`
-		}{
+		ABI: []protocol.CalculatedStreamABI{
 			{
 				Type:               "int256",
 				Expression:         expression,

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -43,7 +43,7 @@ var defaultEnv = map[string]any{
 	"Mul":                Mul,
 	"Div":                Div,
 	"Add":                Add,
-	"Sum":                Add,
+	"Sum":                Sum,
 	"Sub":                Sub,
 	"Pow":                Pow,
 	"Sqrt":               Sqrt,
@@ -60,7 +60,15 @@ var defaultEnv = map[string]any{
 	"Avg":                Avg,
 	"Duration":           ParseDuration,
 
-	"Count": Count,
+	"Count":     Count,
+	"First":     First,
+	"Last":      Last,
+	"Median":    Median,
+	"Variance":  Variance,
+	"Stddev":    Stddev,
+	"Delta":     Delta,
+	"PctChange": PctChange,
+	"Spread":    Spread,
 	// History is rewritten away at compile time (see history_ast.go). It is
 	// registered only so that a call surviving to evaluation fails loudly
 	// instead of resolving to an undefined identifier or, worse, to something

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -70,6 +70,7 @@ var defaultEnv = map[string]any{
 	"PctChange": PctChange,
 	"Spread":    Spread,
 	"SMA":       SMA,
+	"EMA":       EMA,
 	"WMA":       WMA,
 	// History is rewritten away at compile time (see history_ast.go). It is
 	// registered only so that a call surviving to evaluation fails loudly

--- a/llo/protocol/calculated/calculated.go
+++ b/llo/protocol/calculated/calculated.go
@@ -6,8 +6,11 @@ import (
 	"math"
 	"math/big"
 	"regexp"
+	"runtime"
+	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
@@ -593,20 +596,99 @@ func evalDecimal(stmt string, env map[string]any) (decimal.Decimal, error) {
 	return d, nil
 }
 
+// maxEvaluationWorkers bounds the goroutines used to evaluate channels
+// concurrently. Evaluation is CPU bound and short, and the process has other
+// work to do in the same round, so more workers than this buys contention
+// rather than throughput.
+const maxEvaluationWorkers = 8
+
+// minParallelEvaluationWeight is the amount of evaluation work below which a
+// round is evaluated inline. Dispatching goroutines costs more than evaluating a
+// handful of scalar expressions — measurably so: a round of 32 scalar channels
+// is ~20% slower when it is spread over workers than when it is not.
+//
+// Weight is measured in evaluated values (see evaluationWeight), and the
+// threshold sits above a round of purely scalar channels and far below any round
+// that reads history, which is where the work actually is.
+const minParallelEvaluationWeight = 256
+
 // ProcessCalculatedStreams evaluates expressions for each channel of the
 // EVMABIEncodeUnpackedExpr format, appending the calculated streams to their
 // channel definitions and writing the evaluated values into streamAggregates.
 // It is version-agnostic: both the v30 and v31 plugins call it with their own
 // outcome/precursor fields.
+//
+// Processing runs in three phases — prepare, evaluate, apply — so that only the
+// pure part is parallelized:
+//
+//   - prepare is sequential. It touches everything that is shared or not
+//     goroutine-safe: the opts cache, the stream aggregates it reads inputs
+//     from, and the HistoryReader, whose one-read-per-pair memoization is
+//     inherently stateful.
+//   - evaluate is pure and runs concurrently. A compiled program plus an
+//     environment is all it needs, and nothing it touches is shared with
+//     another channel.
+//   - apply is sequential and walks channels in ascending channel ID order, so
+//     the aggregates written, the definitions mutated and the errors logged do
+//     not depend on how the work was scheduled.
 func ProcessCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.ChannelDefinitions, streamAggregates protocol.StreamAggregates, observationTimestampNanoseconds uint64, optsCache *protocol.OptsCache, history HistoryReader) {
-	for cid, cd := range channelDefinitions {
-		if cd.Tombstone {
-			continue
-		}
+	works := prepareCalculatedStreams(lggr, channelDefinitions, streamAggregates, observationTimestampNanoseconds, optsCache, history)
+	if len(works) == 0 {
+		return
+	}
+	results := evaluateCalculatedStreams(works)
+	applyCalculatedStreams(lggr, channelDefinitions, streamAggregates, works, results)
+}
 
-		if cd.ReportFormat != llotypes.ReportFormatEVMABIEncodeUnpackedExpr {
+// channelWork is one channel's fully materialized evaluation input: everything
+// read out of shared state, so that evaluation itself reads nothing but this
+// struct.
+type channelWork struct {
+	cid  llotypes.ChannelID
+	cd   llotypes.ChannelDefinition
+	opts calculatedStreamOpts
+	env  environment
+
+	// windows holds the history bound for each of the first len(windows)
+	// expressions, in declaration order. It is shorter than opts.ABI when
+	// binding failed, in which case err says why and expressions from
+	// len(windows) on are not evaluated.
+	windows [][]boundSeries
+	err     error
+}
+
+// channelResult is one channel's evaluation output. values holds the value of
+// each of the first len(values) expressions; err, if set, is why the expression
+// at index len(values) could not be produced and why the ones after it were not
+// attempted.
+type channelResult struct {
+	values []decimal.Decimal
+	err    error
+}
+
+// prepareCalculatedStreams builds the evaluation input for every eligible
+// channel, in ascending channel ID order.
+//
+// It is deliberately sequential: it is the only phase that reads the opts cache,
+// the stream aggregates and the HistoryReader, and the reader's contract is one
+// underlying state read per (streamID, aggregator) pair per round, which a
+// memoizing implementation cannot honour from several goroutines at once.
+func prepareCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.ChannelDefinitions, streamAggregates protocol.StreamAggregates, observationTimestampNanoseconds uint64, optsCache *protocol.OptsCache, history HistoryReader) []channelWork {
+	cids := make([]llotypes.ChannelID, 0, len(channelDefinitions))
+	for cid, cd := range channelDefinitions {
+		if cd.Tombstone || cd.ReportFormat != llotypes.ReportFormatEVMABIEncodeUnpackedExpr {
 			continue
 		}
+		cids = append(cids, cid)
+	}
+	if len(cids) == 0 {
+		return nil
+	}
+	slices.Sort(cids)
+
+	works := make([]channelWork, 0, len(cids))
+	for _, cid := range cids {
+		cd := channelDefinitions[cid]
 
 		// aggByStream resolves the aggregator a History call refers to. The DSL
 		// names only a stream, so the channel definition is what says which
@@ -651,29 +733,120 @@ func ProcessCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.Ch
 			continue
 		}
 
+		work := channelWork{cid: cid, cd: cd, opts: copt, env: env}
+		work.windows, work.err = bindChannelHistory(&copt, cid, history, aggByStream)
+		works = append(works, work)
+	}
+	return works
+}
+
+// evaluateCalculatedStreams evaluates every prepared channel. This is the only
+// phase that runs concurrently, and it is pure: each channel reads its own
+// environment and windows and writes its own result slot, so no synchronization
+// beyond the wait is needed and the results do not depend on scheduling.
+//
+// Small batches run inline — spawning goroutines costs more than evaluating a
+// handful of expressions.
+func evaluateCalculatedStreams(works []channelWork) []channelResult {
+	results := make([]channelResult, len(works))
+
+	workers := min(len(works), runtime.GOMAXPROCS(0), maxEvaluationWorkers)
+	if evaluationWeight(works) < minParallelEvaluationWeight {
+		workers = 1
+	}
+	if workers <= 1 {
+		for i := range works {
+			results[i] = evalChannel(&works[i])
+		}
+		return results
+	}
+
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for {
+				i := int(next.Add(1)) - 1
+				if i >= len(works) {
+					return
+				}
+				results[i] = evalChannel(&works[i])
+			}
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+// evaluationWeight estimates how much evaluation a round holds, in values that
+// will be visited: one per expression, plus one per record in each window it
+// reads. It is the cheapest predictor of cost that distinguishes the two cases
+// that matter — a round of scalar arithmetic from a round of window functions —
+// and it is derived from prepared work, so it costs nothing to compute.
+func evaluationWeight(works []channelWork) int {
+	weight := 0
+	for i := range works {
+		for _, window := range works[i].windows {
+			weight++
+			for _, bound := range window {
+				weight += bound.series.Len()
+			}
+		}
+	}
+	return weight
+}
+
+// applyCalculatedStreams commits the evaluated values, in ascending channel ID
+// order so that the outcome does not depend on the order the work completed in.
+//
+// The duplicate-aggregate check lives here rather than in evaluation because it
+// is the one check whose answer depends on what earlier channels wrote.
+func applyCalculatedStreams(lggr logger.Logger, channelDefinitions llotypes.ChannelDefinitions, streamAggregates protocol.StreamAggregates, works []channelWork, results []channelResult) {
+	for i := range works {
+		work := &works[i]
+		result := &results[i]
+
 		// channel definitions are inherited from the previous outcome,
 		// so we only update the channel definition streams if we haven't done it before
-		if cd.Streams[len(cd.Streams)-1].StreamID != copt.ABI[len(copt.ABI)-1].ExpressionStreamID {
-			for _, abi := range copt.ABI {
+		cd := work.cd
+		if cd.Streams[len(cd.Streams)-1].StreamID != work.opts.ABI[len(work.opts.ABI)-1].ExpressionStreamID {
+			for _, abi := range work.opts.ABI {
 				cd.Streams = append(cd.Streams, llotypes.Stream{
 					StreamID:   abi.ExpressionStreamID,
 					Aggregator: llotypes.AggregatorCalculated,
 				})
 			}
-			channelDefinitions[cid] = cd
+			channelDefinitions[work.cid] = cd
 		}
 
-		if err := evalExpression(&copt, cid, env, streamAggregates, history, aggByStream); err != nil {
+		err := result.err
+		for j, value := range result.values {
+			abi := work.opts.ABI[j]
+			if len(streamAggregates[abi.ExpressionStreamID]) > 0 {
+				err = fmt.Errorf(
+					"calculated stream aggregate ID already exists, channelID: %d, expressionStreamID: %d, expression: %s",
+					work.cid, abi.ExpressionStreamID, abi.Expression)
+				break
+			}
+			// update the aggregates with the new stream value if expression was successfully evaluated
+			streamAggregates[abi.ExpressionStreamID] = map[llotypes.Aggregator]protocol.StreamValue{
+				llotypes.AggregatorCalculated: protocol.ToDecimal(value),
+			}
+		}
+
+		if err != nil {
 			if errors.Is(err, ErrInsufficientHistory) {
 				// Expected while history warms up, after a depth increase, or
 				// after corrupt state was discarded. No aggregate is written,
 				// so the channel is not reportable this round.
-				lggr.Infow("insufficient stream history; channel not reportable this round", "channelID", cid, "error", err)
+				lggr.Infow("insufficient stream history; channel not reportable this round", "channelID", work.cid, "error", err)
 			} else {
-				lggr.Errorw("failed to process expression", "channelID", cid, "error", err)
+				lggr.Errorw("failed to process expression", "channelID", work.cid, "error", err)
 			}
 		}
-		env.release()
+		work.env.release()
 	}
 }
 
@@ -701,84 +874,116 @@ func AggregatorByStream(cd llotypes.ChannelDefinition) (map[llotypes.StreamID]ll
 	return byStream, nil
 }
 
-// bindHistory loads every window an expression declares and binds it into the
-// environment under the identifier the compile-time rewrite will use.
+// bindChannelHistory loads every window each of a channel's expressions
+// declares, keyed by the identifier the compile-time rewrite will use.
 //
-// Returns ErrInsufficientHistory if any window is not yet deep enough. That is
-// not an error in the operational sense — it is the warmup gate — but the
-// expression must not be evaluated, because a short window would silently
-// change the meaning of the result.
-func bindHistory(expression string, env environment, history HistoryReader, aggByStream map[llotypes.StreamID]llotypes.Aggregator) error {
-	refs, err := AnalyzeExpressionHistory(expression)
-	if err != nil {
-		return err
-	}
-	if len(refs) == 0 {
-		return nil
-	}
-	if history == nil {
-		// v30 has no replicated key-value state, so there is nowhere for
-		// history to live. Fail closed rather than evaluate against nothing.
-		return fmt.Errorf("expression uses %s but stream history is unavailable in this protocol version", HistoryFunctionName)
-	}
-
-	for _, ref := range refs {
-		aggregator, ok := aggByStream[ref.StreamID]
-		if !ok {
-			return fmt.Errorf("%s references stream %d, which the channel does not observe", HistoryFunctionName, ref.StreamID)
-		}
-		series, err := history.Series(ref.StreamID, aggregator, ref.Count, ref.Field)
-		if err != nil {
-			return fmt.Errorf("%s: %w", ref, err)
-		}
-		if uint32(series.Len()) != ref.Count {
-			// Defensive: a reader returning a differently sized window would
-			// change what the expression computes.
-			return fmt.Errorf("%s: reader returned %d records, expected %d", ref, series.Len(), ref.Count)
-		}
-		env[ref.envName()] = series
-	}
-	return nil
-}
-
-func evalExpression(o *calculatedStreamOpts, cid llotypes.ChannelID, env environment, streamAggregates protocol.StreamAggregates, history HistoryReader, aggByStream map[llotypes.StreamID]llotypes.Aggregator) error {
+// It runs in the sequential prepare phase because it is the only part of
+// evaluation that reads persisted state. Binding stops at the first expression
+// that cannot be satisfied: the returned slice covers the expressions before it,
+// and the error says why that one — and therefore every one after it — is not
+// evaluated.
+//
+// An unsatisfiable window wraps ErrInsufficientHistory. That is not an error in
+// the operational sense — it is the warmup gate — but the expression must not be
+// evaluated, because a short window would silently change the meaning of the
+// result.
+func bindChannelHistory(o *calculatedStreamOpts, cid llotypes.ChannelID, history HistoryReader, aggByStream map[llotypes.StreamID]llotypes.Aggregator) ([][]boundSeries, error) {
+	windows := make([][]boundSeries, 0, len(o.ABI))
 	for _, abi := range o.ABI {
 		if abi.ExpressionStreamID == 0 {
-			return fmt.Errorf("expression stream ID is 0, channelID: %d, expression: %s",
+			return windows, fmt.Errorf("expression stream ID is 0, channelID: %d, expression: %s",
 				cid, abi.Expression)
 		}
 
 		if abi.Expression == "" {
-			return fmt.Errorf(
+			return windows, fmt.Errorf(
 				"expression is empty, channelID: %d, expressionStreamID: %d",
 				cid, abi.ExpressionStreamID)
 		}
 
-		if len(streamAggregates[abi.ExpressionStreamID]) > 0 {
-			return fmt.Errorf(
-				"calculated stream aggregate ID already exists, channelID: %d, expressionStreamID: %d, expression: %s",
-				cid, abi.ExpressionStreamID, abi.Expression)
-		}
-
-		if err := bindHistory(abi.Expression, env, history, aggByStream); err != nil {
-			return fmt.Errorf(
+		window, err := resolveHistory(abi.Expression, history, aggByStream)
+		if err != nil {
+			return windows, fmt.Errorf(
 				"failed to bind stream history, channelID: %d, expression: %s, error: %w",
 				cid, abi.Expression, err)
 		}
-
-		value, err := evalDecimal(abi.Expression, env)
-		if err != nil {
-			return fmt.Errorf(
-				"failed to evaluate expression, channelID: %d, expression: %s, error: %w",
-				cid, abi.Expression, err)
-		}
-
-		// update the aggregates with the new stream value if expression was successfully evaluated
-		streamAggregates[abi.ExpressionStreamID] = map[llotypes.Aggregator]protocol.StreamValue{
-			llotypes.AggregatorCalculated: protocol.ToDecimal(value),
-		}
+		windows = append(windows, window)
 	}
-	return nil
+	return windows, nil
+}
+
+// boundSeries is a window and the environment identifier the compile-time
+// rewrite of a History call binds it to.
+//
+// A slice of these rather than a map: a window carries at most a handful of
+// series, and the binding is walked once per round per expression, so a map
+// would cost an allocation and a hash to save nothing.
+type boundSeries struct {
+	name   string
+	series Series
+}
+
+// resolveHistory reads the windows one expression declares, keyed by the
+// identifier the compile-time rewrite binds them to. A nil result means the
+// expression declares no windows.
+func resolveHistory(expression string, history HistoryReader, aggByStream map[llotypes.StreamID]llotypes.Aggregator) ([]boundSeries, error) {
+	refs, err := AnalyzeExpressionHistory(expression)
+	if err != nil {
+		return nil, err
+	}
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	if history == nil {
+		// v30 has no replicated key-value state, so there is nowhere for
+		// history to live. Fail closed rather than evaluate against nothing.
+		return nil, fmt.Errorf("expression uses %s but stream history is unavailable in this protocol version", HistoryFunctionName)
+	}
+
+	window := make([]boundSeries, 0, len(refs))
+	for _, ref := range refs {
+		aggregator, ok := aggByStream[ref.StreamID]
+		if !ok {
+			return nil, fmt.Errorf("%s references stream %d, which the channel does not observe", HistoryFunctionName, ref.StreamID)
+		}
+		series, err := history.Series(ref.StreamID, aggregator, ref.Count, ref.Field)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", ref, err)
+		}
+		if uint32(series.Len()) != ref.Count {
+			// Defensive: a reader returning a differently sized window would
+			// change what the expression computes.
+			return nil, fmt.Errorf("%s: reader returned %d records, expected %d", ref, series.Len(), ref.Count)
+		}
+		window = append(window, boundSeries{name: ref.envName(), series: series})
+	}
+	return window, nil
+}
+
+// evalChannel evaluates a channel's expressions against its prepared
+// environment. It is pure — it reads only the work it is given and writes only
+// the result it returns — which is what makes it safe to run concurrently.
+//
+// Expressions do not see each other's values: the environment carries observed
+// streams only, so they are independent and evaluation order is immaterial.
+// Evaluation still stops at the first failure, so a channel either contributes a
+// prefix of its expressions or, at apply time, none of them.
+func evalChannel(work *channelWork) channelResult {
+	values := make([]decimal.Decimal, 0, len(work.windows))
+	for i, window := range work.windows {
+		for _, bound := range window {
+			work.env[bound.name] = bound.series
+		}
+
+		value, err := evalDecimal(work.opts.ABI[i].Expression, work.env)
+		if err != nil {
+			return channelResult{values: values, err: fmt.Errorf(
+				"failed to evaluate expression, channelID: %d, expression: %s, error: %w",
+				work.cid, work.opts.ABI[i].Expression, err)}
+		}
+		values = append(values, value)
+	}
+	return channelResult{values: values, err: work.err}
 }
 
 // calculatedStreamOpts is the options structure for expression/calculated streams.
@@ -958,9 +1163,16 @@ func ProcessCalculatedStreamsDryRun(expression string) error {
 		intervalNanoseconds: uint64(time.Second),
 	}
 
-	err = evalExpression(o, 1, env, aggr, dryRunHistory, aggByStream)
-	if err != nil {
-		return fmt.Errorf("failed to process expression: %w", err)
+	work := channelWork{cid: 1, cd: cd[1], opts: *o, env: env}
+	work.windows, work.err = bindChannelHistory(o, 1, dryRunHistory, aggByStream)
+	result := evalChannel(&work)
+	if result.err != nil {
+		return fmt.Errorf("failed to process expression: %w", result.err)
+	}
+	for i, value := range result.values {
+		aggr[o.ABI[i].ExpressionStreamID] = map[llotypes.Aggregator]protocol.StreamValue{
+			llotypes.AggregatorCalculated: protocol.ToDecimal(value),
+		}
 	}
 
 	if _, ok := aggr[999]; !ok {

--- a/llo/protocol/calculated/calculated_concurrent_test.go
+++ b/llo/protocol/calculated/calculated_concurrent_test.go
@@ -1,0 +1,194 @@
+package calculated
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+// concurrentAnchorNs sits just past the newest synthesized record so that
+// window-relative functions see a populated window.
+const concurrentAnchorNs = uint64(1_000_000)
+
+// countingHistoryReader serves a fixed window and records how many times each
+// pair was read, without any locking of its own: the reader is documented as
+// being driven from one goroutine, so a concurrent read is both a race the
+// detector will flag and a violation of the one-read-per-pair contract.
+type countingHistoryReader struct {
+	window Series
+	reads  map[llotypes.StreamID]int
+}
+
+func (r *countingHistoryReader) Series(sid llotypes.StreamID, _ llotypes.Aggregator, count uint32, _ Field) (Series, error) {
+	r.reads[sid]++
+	if uint32(r.window.Len()) < count {
+		return Series{}, ErrInsufficientHistory
+	}
+	return r.window, nil
+}
+
+// concurrentFixture builds a channel set wide enough to exercise the worker
+// pool, mixing scalar, history and deliberately failing channels so that the
+// error paths are scheduled alongside the successful ones.
+func concurrentFixture(t testing.TB, channels int) (llotypes.ChannelDefinitions, protocol.StreamAggregates, *countingHistoryReader) {
+	t.Helper()
+
+	defs := llotypes.ChannelDefinitions{}
+	for c := range channels {
+		cid := llotypes.ChannelID(c + 1)
+		expressionStreamID := llotypes.StreamID(1000 + c)
+
+		var expression string
+		switch c % 4 {
+		case 0:
+			expression = "Add(s1, s2)"
+		case 1:
+			expression = "Avg(History(s1, 4))"
+		case 2:
+			// Deeper than the reader holds: fails the warmup gate.
+			expression = "Avg(History(s2, 64))"
+		case 3:
+			// Evaluation failure: division by zero.
+			expression = "Div(s1, Sub(s2, s2))"
+		}
+
+		defs[cid] = llotypes.ChannelDefinition{
+			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+			Streams:      medianStreams(1, 2),
+			Opts: fmt.Appendf(nil,
+				`{"abi":[{"type":"int256","expression":%q,"expressionStreamID":%d}]}`,
+				expression, expressionStreamID),
+		}
+	}
+
+	aggregates := protocol.StreamAggregates{
+		1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(3))},
+		2: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(4))},
+	}
+
+	values := make([]decimal.Decimal, 0, 4)
+	timestamps := make([]uint64, 0, 4)
+	for i := range 4 {
+		values = append(values, decimal.NewFromInt(int64(i+1)))
+		timestamps = append(timestamps, uint64(i+1))
+	}
+	window, err := NewSeries(values, timestamps)
+	require.NoError(t, err)
+
+	return defs, aggregates, &countingHistoryReader{window: window, reads: map[llotypes.StreamID]int{}}
+}
+
+// snapshot flattens the aggregates into a comparable form. Comparing the map
+// directly would compare pointers, which say nothing about the values computed.
+func snapshot(t testing.TB, aggregates protocol.StreamAggregates) map[llotypes.StreamID]string {
+	t.Helper()
+
+	out := make(map[llotypes.StreamID]string, len(aggregates))
+	for sid, byAggregator := range aggregates {
+		value, ok := byAggregator[llotypes.AggregatorCalculated]
+		if !ok {
+			continue
+		}
+		d, ok := value.(*protocol.Decimal)
+		require.True(t, ok)
+		out[sid] = d.Decimal().String()
+	}
+	return out
+}
+
+// TestProcessCalculatedStreams_Deterministic is the property concurrency must
+// not cost: the same inputs must produce the same outcome every time, whatever
+// order the workers happened to finish in. Run it with -race to also cover the
+// shared maps the phases write.
+func TestProcessCalculatedStreams_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	var want map[llotypes.StreamID]string
+	for round := range 32 {
+		defs, aggregates, reader := concurrentFixture(t, 64)
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, concurrentAnchorNs, protocol.NewOptsCache(), reader)
+
+		got := snapshot(t, aggregates)
+		require.NotEmpty(t, got, "expected calculated aggregates")
+		if round == 0 {
+			want = got
+			continue
+		}
+		assert.Equal(t, want, got, "round %d differed", round)
+	}
+}
+
+// TestProcessCalculatedStreams_HistoryReadOncePerPair pins the reader contract
+// the sequential prepare phase exists to honour: however many channels ask for
+// a pair, evaluation reads it once per channel and never from more than one
+// goroutine. A reader driven concurrently would trip the race detector here.
+func TestProcessCalculatedStreams_HistoryReadOncePerPair(t *testing.T) {
+	t.Parallel()
+
+	defs, aggregates, reader := concurrentFixture(t, 64)
+	ProcessCalculatedStreams(logger.Test(t), defs, aggregates, concurrentAnchorNs, protocol.NewOptsCache(), reader)
+
+	// 64 channels, one in four using each history expression.
+	assert.Equal(t, 16, reader.reads[1])
+	assert.Equal(t, 16, reader.reads[2])
+}
+
+// TestProcessCalculatedStreams_ParallelRounds covers several plugin instances
+// evaluating at once, which is what the process-wide analysis cache, the
+// environment pool and the compiled-program cache are shared across.
+func TestProcessCalculatedStreams_ParallelRounds(t *testing.T) {
+	t.Parallel()
+
+	const rounds = 8
+
+	results := make([]map[llotypes.StreamID]string, rounds)
+	var wg sync.WaitGroup
+	wg.Add(rounds)
+	for i := range rounds {
+		defs, aggregates, reader := concurrentFixture(t, 32)
+		go func() {
+			defer wg.Done()
+			ProcessCalculatedStreams(logger.Test(t), defs, aggregates, concurrentAnchorNs, protocol.NewOptsCache(), reader)
+			results[i] = snapshot(t, aggregates)
+		}()
+	}
+	wg.Wait()
+
+	for i := 1; i < rounds; i++ {
+		assert.Equal(t, results[0], results[i], "round %d differed", i)
+	}
+}
+
+// TestProcessCalculatedStreams_ChannelIsolation checks that a channel that
+// cannot be evaluated costs only itself, even when its neighbours are evaluated
+// on other workers.
+func TestProcessCalculatedStreams_ChannelIsolation(t *testing.T) {
+	t.Parallel()
+
+	defs, aggregates, reader := concurrentFixture(t, 64)
+	ProcessCalculatedStreams(logger.Test(t), defs, aggregates, concurrentAnchorNs, protocol.NewOptsCache(), reader)
+
+	for c := range 64 {
+		sid := llotypes.StreamID(1000 + c)
+		_, ok := aggregates[sid][llotypes.AggregatorCalculated]
+		switch c % 4 {
+		case 0:
+			assert.True(t, ok, "scalar channel %d should have produced a value", c+1)
+		case 1:
+			assert.True(t, ok, "history channel %d should have produced a value", c+1)
+		case 2:
+			assert.False(t, ok, "channel %d is short of history and must not report", c+1)
+		case 3:
+			assert.False(t, ok, "channel %d fails evaluation and must not report", c+1)
+		}
+	}
+}

--- a/llo/protocol/calculated/calculated_test.go
+++ b/llo/protocol/calculated/calculated_test.go
@@ -1748,3 +1748,16 @@ func TestExpressionStreamIDs(t *testing.T) {
 		require.ErrorContains(t, err, "failed to decode calculated stream opts")
 	})
 }
+
+func Test_environment_SetStreamValue_NestedNil(t *testing.T) {
+	// A timestamped value binds its timestamp and then recurses for the value
+	// expressions actually name. Dropping the recursive error would leave the
+	// environment with s1_timestamp and no s1, and the channel would fail later
+	// with "unknown name s1" instead of saying the value was nil.
+	env := NewEnv(uint64(1750169759775700000))
+	defer env.release()
+
+	err := env.SetStreamValue(1, &protocol.TimestampedStreamValue{ObservedAtNanoseconds: 1, StreamValue: nil})
+	require.ErrorContains(t, err, "stream value is nil")
+	require.NotContains(t, env, "s1")
+}

--- a/llo/protocol/calculated/decimalmath.go
+++ b/llo/protocol/calculated/decimalmath.go
@@ -67,7 +67,7 @@ func recoverTranscendental(operation string, input decimal.Decimal, result *deci
 // A value beyond MaxDecimalExponent could not be stored or transmitted anyway, so
 // refusing it early costs nothing real.
 func decimalPow(base, exponent decimal.Decimal, prec int32) (result decimal.Decimal, err error) {
-	if err := checkPowExponent(exponent); err != nil {
+	if err := checkPow(base, exponent); err != nil {
 		return decimal.Decimal{}, err
 	}
 
@@ -90,19 +90,56 @@ func decimalPow(base, exponent decimal.Decimal, prec int32) (result decimal.Deci
 
 // maxPowExponent bounds the magnitude of an exponent passed to a power.
 //
-// A power whose result needs more than MaxDecimalExponent decimal places, or
-// that many integer digits, is unusable downstream: protocol decoding rejects
-// such a decimal outright. The bound is expressed on the exponent alone because
-// it has to be cheap — the whole point is to refuse before the expensive
-// computation starts, not after.
+// This is only the cheap first gate, and it exists so that the size of the
+// result can be estimated without doing arithmetic on an absurd exponent. What
+// actually has to be bounded is the result: see checkPow.
 const maxPowExponent = 100_000
 
-func checkPowExponent(exponent decimal.Decimal) error {
+// checkPow refuses a power whose result would be too large to compute in useful
+// time, or to store afterwards.
+//
+// Bounding the exponent alone is not enough, because the cost is driven by the
+// size of the result. A power with a non-integer exponent is evaluated as
+// exp(exponent * ln(base)), and ExpTaylor's cost grows with the number of digits
+// it produces: Pow(3000, 50000.5) asks for exp(4e5), a number with about 174,000
+// digits, which does not complete in any useful time. An integer exponent avoids
+// the logarithm but not the size — the repeated multiplication produces the same
+// number of digits.
+//
+// So the quantity exp() guards is checked here, ahead of the work: the magnitude
+// of exponent * ln(base), against maxExpArgument, which is the largest argument
+// whose result still fits MaxDecimalExponent. The logarithm needed to estimate it
+// is taken at low precision, and its input is a stored value, so it is cheap next
+// to the power it is protecting — and exact enough that its rounding error cannot
+// move a value across a bound of 2400.
+//
+// Both operands come from consensus, so an unbounded power is not one node's
+// problem: every node computes it in the same round, inside StateTransition,
+// holding the transcendental lock.
+func checkPow(base, exponent decimal.Decimal) error {
 	if exponent.Abs().GreaterThan(decimal.NewFromInt(maxPowExponent)) {
 		return fmt.Errorf("exponent %s exceeds the maximum magnitude of %d", exponent, maxPowExponent)
 	}
+	// A zero base is 0 or 1 whatever the exponent, and has no logarithm.
+	abs := base.Abs()
+	if abs.IsZero() {
+		return nil
+	}
+	lnBase, err := decimalLn(abs, powEstimatePrecision)
+	if err != nil {
+		return fmt.Errorf("power of %s by %s could not be bounded: %w", base, exponent, err)
+	}
+	if magnitude := exponent.Mul(lnBase).Abs(); magnitude.GreaterThan(decimal.NewFromInt(maxExpArgument)) {
+		return fmt.Errorf("power of %s by %s has a natural logarithm of %s, which exceeds the maximum magnitude of %d",
+			base, exponent, magnitude, maxExpArgument)
+	}
 	return nil
 }
+
+// powEstimatePrecision is the precision of the logarithm used to size a power's
+// result. It only has to place the result on the right side of maxExpArgument, so
+// it is deliberately far below the precision of the calculation itself.
+const powEstimatePrecision = 8
 
 // decimalToInt converts an integral decimal to an int, refusing anything outside
 // [minimum, maximum].

--- a/llo/protocol/calculated/decimalmath.go
+++ b/llo/protocol/calculated/decimalmath.go
@@ -104,6 +104,30 @@ func checkPowExponent(exponent decimal.Decimal) error {
 	return nil
 }
 
+// decimalToInt converts an integral decimal to an int, refusing anything outside
+// [minimum, maximum].
+//
+// The bounds are checked as decimals, before the narrowing. decimal.IntPart
+// narrows through big.Int.Int64, which returns the low 64 bits of an oversized
+// value rather than failing: 2^64+1 comes back as 1. Every caller here is
+// choosing a sample count, a window length or a gap threshold, so a wrapped
+// value does not error -- it silently selects a different calculation than the
+// expression asked for. These arguments are not required to be literal, so the
+// value can come from a stream and is bounded only by MaxDecimalExponent, which
+// is far wider than an int64.
+func decimalToInt(name string, d decimal.Decimal, minimum, maximum int64) (int, error) {
+	if !d.IsInteger() {
+		return 0, fmt.Errorf("%s must be a whole number, got %s", name, d)
+	}
+	if d.LessThan(decimal.NewFromInt(minimum)) {
+		return 0, fmt.Errorf("%s must be at least %d, got %s", name, minimum, d)
+	}
+	if d.GreaterThan(decimal.NewFromInt(maximum)) {
+		return 0, fmt.Errorf("%s must be at most %d, got %s", name, maximum, d)
+	}
+	return int(d.IntPart()), nil
+}
+
 // Determinism rules for every calculation in this package.
 //
 // Expression results become consensus values, so two oracles computing the same

--- a/llo/protocol/calculated/decimalmath.go
+++ b/llo/protocol/calculated/decimalmath.go
@@ -1,0 +1,194 @@
+package calculated
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/shopspring/decimal"
+)
+
+// transcendentalMu serializes every call into shopspring/decimal's
+// transcendental functions.
+//
+// Decimal.ExpTaylor memoizes factorials in an unsynchronized package-level slice
+// (decimal.go: `var factorials = []Decimal{New(1, 0)}`) that it appends to, and
+// Ln reads through the same path. Concurrent calls therefore race, and an append
+// racing with a read can yield a corrupted value rather than merely a stale one —
+// which in a consensus path means two nodes disagreeing, or a panic.
+//
+// TWAP makes it far more likely by calling ln and exp once per bucket.
+//
+// The lock is taken per call rather than per evaluation to keep hold times short.
+// The cost is negligible against the arithmetic it guards.
+var transcendentalMu sync.Mutex
+
+// decimalLn is decimal.Ln under the transcendental lock.
+func decimalLn(x decimal.Decimal, prec int32) (result decimal.Decimal, err error) {
+	transcendentalMu.Lock()
+	defer transcendentalMu.Unlock()
+	defer recoverTranscendental("logarithm", x, &result, &err)
+	return x.Ln(prec)
+}
+
+// decimalExpTaylor is decimal.ExpTaylor under the transcendental lock.
+func decimalExpTaylor(x decimal.Decimal, prec int32) (result decimal.Decimal, err error) {
+	transcendentalMu.Lock()
+	defer transcendentalMu.Unlock()
+	defer recoverTranscendental("exponential", x, &result, &err)
+	return x.ExpTaylor(prec)
+}
+
+// recoverTranscendental converts a panic from shopspring/decimal into an error.
+//
+// The library panics on some extreme inputs rather than returning an error (see
+// decimalPow for a case found by fuzzing). An expression must never be able to
+// bring the node down: turning it into an error makes the channel unreportable,
+// which is the correct fail-closed outcome.
+func recoverTranscendental(operation string, input decimal.Decimal, result *decimal.Decimal, err *error) {
+	if r := recover(); r != nil {
+		*result = decimal.Decimal{}
+		*err = fmt.Errorf("%s of %s could not be computed: %v", operation, input, r)
+	}
+}
+
+// decimalPow is decimal.PowWithPrecision under the transcendental lock. Powers
+// with a non-integer exponent are evaluated via the same logarithm and
+// exponential machinery.
+//
+// The exponent is bounded first. shopspring/decimal PANICS on an exponent large
+// enough to overflow the result's int32 scale ("exponent ... overflows an
+// int32!"), and spends a long time computing before it gets there: a fuzzed
+// Pow(s1, s2) with both values around 2.6e31 burned 22 seconds of CPU and then
+// panicked. Stream values come from consensus, so every node would hit that in
+// the same round — a panic in StateTransition takes the node down, and 22 seconds
+// blows the round budget even without one. The transcendental lock makes it worse
+// by serializing that work against every other plugin instance in the process.
+//
+// A value beyond MaxDecimalExponent could not be stored or transmitted anyway, so
+// refusing it early costs nothing real.
+func decimalPow(base, exponent decimal.Decimal, prec int32) (result decimal.Decimal, err error) {
+	if err := checkPowExponent(exponent); err != nil {
+		return decimal.Decimal{}, err
+	}
+
+	transcendentalMu.Lock()
+	defer transcendentalMu.Unlock()
+
+	// Backstop: the bound above covers the case seen in the wild, but the
+	// library reserves the right to panic on other extremes and an expression
+	// must never be able to bring the node down. Converting it to an error makes
+	// the channel unreportable, which is the correct fail-closed outcome.
+	defer func() {
+		if r := recover(); r != nil {
+			result = decimal.Decimal{}
+			err = fmt.Errorf("power of %s by %s could not be computed: %v", base, exponent, r)
+		}
+	}()
+
+	return base.PowWithPrecision(exponent, prec)
+}
+
+// maxPowExponent bounds the magnitude of an exponent passed to a power.
+//
+// A power whose result needs more than MaxDecimalExponent decimal places, or
+// that many integer digits, is unusable downstream: protocol decoding rejects
+// such a decimal outright. The bound is expressed on the exponent alone because
+// it has to be cheap — the whole point is to refuse before the expensive
+// computation starts, not after.
+const maxPowExponent = 100_000
+
+func checkPowExponent(exponent decimal.Decimal) error {
+	if exponent.Abs().GreaterThan(decimal.NewFromInt(maxPowExponent)) {
+		return fmt.Errorf("exponent %s exceeds the maximum magnitude of %d", exponent, maxPowExponent)
+	}
+	return nil
+}
+
+// Determinism rules for every calculation in this package.
+//
+// Expression results become consensus values, so two oracles computing the same
+// expression over the same inputs must produce bit-identical output. Three rules
+// follow:
+//
+//  1. No float64. math.Log and math.Exp are not guaranteed bit-identical across
+//     architectures or Go versions, so all logarithms and exponentials go through
+//     decimal.Ln and decimal.ExpTaylor at a fixed precision. This is why the TWAP
+//     implementation here is a port of the mercury float-based one, not a reuse.
+//  2. No reliance on decimal.DivisionPrecision. That is a mutable package-level
+//     global: anything in the process can change it and silently move every Div
+//     result. Every division here passes an explicit precision (divRound).
+//  3. Fixed rounding at every step of an iterative calculation, so the result
+//     cannot depend on how much internal precision happened to survive.
+const (
+	// legacyDivisionPrecision is decimal.DivisionPrecision's default, and the
+	// precision Div and Avg have effectively always used.
+	//
+	// It is pinned rather than raised to the package precision because changing
+	// it would move the trailing digits of every existing calculated stream — a
+	// DON-visible output change that would have to be a coordinated upgrade.
+	// New functions use precision instead.
+	legacyDivisionPrecision = 16
+)
+
+// divRound divides with an explicit precision, refusing division by zero.
+//
+// Always prefer this to Decimal.Div: Div reads decimal.DivisionPrecision, a
+// mutable global, so its result is a property of process state rather than of
+// the inputs.
+func divRound(x, y decimal.Decimal, prec int32) (decimal.Decimal, error) {
+	if y.IsZero() {
+		return decimal.Decimal{}, fmt.Errorf("division by zero")
+	}
+	return x.DivRound(y, prec), nil
+}
+
+// divRoundByInt divides by a positive count, for the many places an aggregate is
+// divided by a number of samples.
+func divRoundByInt(x decimal.Decimal, n int, prec int32) (decimal.Decimal, error) {
+	if n <= 0 {
+		return decimal.Decimal{}, fmt.Errorf("cannot divide by %d", n)
+	}
+	return divRound(x, decimal.NewFromInt(int64(n)), prec)
+}
+
+// ln is a deterministic natural logarithm at double precision, for values that
+// will be further combined before the result is rounded.
+func ln(x decimal.Decimal) (decimal.Decimal, error) {
+	if !x.IsPositive() {
+		return decimal.Decimal{}, fmt.Errorf("cannot take the logarithm of %s: value must be positive", x)
+	}
+	return decimalLn(x, doublePrecision)
+}
+
+// exp is a deterministic exponential at double precision, the inverse of ln.
+//
+// The argument is bounded because ExpTaylor's cost grows with the size of the
+// result, not of the input: exp(1e6) has ~434,000 digits and does not complete in
+// any useful time. Callers currently only pass logarithms of stored values, which
+// MaxDecimalExponent already bounds to about ±2302, so the limit is not reachable
+// through TWAP today — it is here so that stays true if another caller appears.
+func exp(x decimal.Decimal) (decimal.Decimal, error) {
+	if x.Abs().GreaterThan(decimal.NewFromInt(maxExpArgument)) {
+		return decimal.Decimal{}, fmt.Errorf("exponential argument %s exceeds the maximum magnitude of %d", x, maxExpArgument)
+	}
+	return decimalExpTaylor(x, doublePrecision)
+}
+
+// maxExpArgument bounds the argument to exp.
+//
+// exp(x) has roughly x/ln(10) decimal digits, so this is the largest argument
+// whose result is still within MaxDecimalExponent (1000) and therefore still
+// storable: 1000 * ln(10) is about 2302, rounded up for headroom.
+const maxExpArgument = 2400
+
+// sqrt is a deterministic square root, rounded to the package precision.
+func sqrt(x decimal.Decimal) (decimal.Decimal, error) {
+	if x.IsNegative() {
+		return decimal.Decimal{}, fmt.Errorf("cannot take the square root of a negative number: %s", x)
+	}
+	res, err := decimalPow(x, decimal.NewFromFloat(0.5), doublePrecision)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	return res.Round(precision), nil
+}

--- a/llo/protocol/calculated/decimalmath_test.go
+++ b/llo/protocol/calculated/decimalmath_test.go
@@ -3,6 +3,7 @@ package calculated
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -141,4 +142,46 @@ func TestTranscendentalsAreConcurrencySafe(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func Test_checkPow(t *testing.T) {
+	// The bound is on the size of the result, not of the exponent: an exponent
+	// well inside maxPowExponent still asks for a result nothing can compute or
+	// store.
+	for _, tc := range []struct {
+		name      string
+		base, exp string
+		wantErr   string
+	}{
+		{"large result from a modest exponent", "3000", "50000.5", "exceeds the maximum magnitude of 2400"},
+		{"large result from an integer exponent", "2", "5000", "exceeds the maximum magnitude of 2400"},
+		{"tiny result", "0.0001", "-40000", "exceeds the maximum magnitude of 2400"},
+		{"absurd exponent is refused by the cheap gate", "2", "100001", "exceeds the maximum magnitude of 100000"},
+		{"largest storable result", "10", "1000", ""},
+		{"base near one with a large exponent", "1.0001", "100000", ""},
+		{"square root", "4", "0.5", ""},
+		{"zero base has no logarithm", "0", "3", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base, err := decimal.NewFromString(tc.base)
+			require.NoError(t, err)
+			exponent, err := decimal.NewFromString(tc.exp)
+			require.NoError(t, err)
+
+			// checkPow has to be cheap, and so has to reject before the work it
+			// is protecting against would have started.
+			start := time.Now()
+			err = checkPow(base, exponent)
+			require.Less(t, time.Since(start), time.Second)
+
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErr)
+			// decimalPow reports the same refusal rather than computing.
+			_, err = decimalPow(base, exponent, doublePrecision)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
 }

--- a/llo/protocol/calculated/decimalmath_test.go
+++ b/llo/protocol/calculated/decimalmath_test.go
@@ -1,0 +1,144 @@
+package calculated
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDivisionPrecisionIsPinned is the guard on the determinism rule that matters
+// most in practice: decimal.DivisionPrecision is a mutable package global, so any
+// function relying on it would silently produce different consensus values
+// depending on process state.
+func TestDivisionPrecisionIsPinned(t *testing.T) {
+	// Must NOT call t.Parallel(): it mutates decimal.DivisionPrecision, a
+	// package-level global. Go runs non-parallel tests to completion before
+	// resuming parallel ones, so as written it cannot overlap with them; adding
+	// t.Parallel() here would make every other test in the package read a
+	// precision this one set.
+	original := decimal.DivisionPrecision
+	t.Cleanup(func() { decimal.DivisionPrecision = original })
+
+	type result struct {
+		name  string
+		value decimal.Decimal
+	}
+	compute := func(t *testing.T) []result {
+		t.Helper()
+		// Values chosen so the division does not terminate.
+		window := seriesOf(t, "1", "2", "4")
+
+		div, err := Div(1, 3)
+		require.NoError(t, err)
+		avg, err := Avg(window)
+		require.NoError(t, err)
+		avgScalars, err := Avg(1, 3)
+		require.NoError(t, err)
+		median, err := Median(seriesOf(t, "1", "2"))
+		require.NoError(t, err)
+		variance, err := Variance(window)
+		require.NoError(t, err)
+		stddev, err := Stddev(window)
+		require.NoError(t, err)
+		pct, err := PctChange(window)
+		require.NoError(t, err)
+		sma, err := SMA(window, 3)
+		require.NoError(t, err)
+		wma, err := WMA(window, 3)
+		require.NoError(t, err)
+		ema, err := EMA(window, 2)
+		require.NoError(t, err)
+
+		return []result{
+			{"Div", div}, {"Avg", avg}, {"AvgScalars", avgScalars}, {"Median", median},
+			{"Variance", variance}, {"Stddev", stddev}, {"PctChange", pct},
+			{"SMA", sma}, {"WMA", wma}, {"EMA", ema},
+		}
+	}
+
+	decimal.DivisionPrecision = 16
+	baseline := compute(t)
+
+	for _, precision := range []int{2, 8, 30, 64} {
+		decimal.DivisionPrecision = precision
+		got := compute(t)
+		require.Len(t, got, len(baseline))
+		for i, want := range baseline {
+			assert.True(t, want.value.Equal(got[i].value),
+				"%s moved when DivisionPrecision=%d: %s -> %s", want.name, precision, want.value, got[i].value)
+		}
+	}
+}
+
+// TestDivAndAvgPinnedToLegacyPrecision documents the pinned value: raising it
+// would change the trailing digits of every existing calculated stream.
+func TestDivAndAvgPinnedToLegacyPrecision(t *testing.T) {
+	t.Parallel()
+
+	got, err := Div(1, 3)
+	require.NoError(t, err)
+	assertDecimal(t, "0.3333333333333333", got) // 16 decimal places
+
+	got, err = Avg(1, 2)
+	require.NoError(t, err)
+	assertDecimal(t, "1.5", got)
+
+	// A non-terminating average also truncates at 16.
+	got, err = Avg(1, 1, 1, 2)
+	require.NoError(t, err)
+	assertDecimal(t, "1.25", got)
+
+	got, err = Avg(2, 3, 2)
+	require.NoError(t, err)
+	assertDecimal(t, "2.3333333333333333", got)
+}
+
+// TestTranscendentalsAreConcurrencySafe guards the lock around
+// shopspring/decimal's transcendental functions.
+//
+// ExpTaylor memoizes factorials in an unsynchronized package-level slice it
+// appends to, and Ln reads through the same path, so concurrent calls race. An
+// append racing with a read can produce a corrupted value rather than a merely
+// stale one, which in a consensus path means nodes disagreeing. A node runs
+// several plugin instances in one process, each evaluating on its own goroutine,
+// so this is reachable in production.
+//
+// Run under -race, this fails if the guard is removed.
+func TestTranscendentalsAreConcurrencySafe(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 24
+	window := seriesOf(t, "1.5", "2.5", "3.5", "4.5", "5.5")
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			value := decimal.NewFromInt(int64(i + 2))
+
+			got, err := ln(value)
+			assert.NoError(t, err)
+			_, err = exp(got)
+			assert.NoError(t, err)
+			_, err = sqrt(value)
+			assert.NoError(t, err)
+
+			// The exported functions share the same machinery.
+			_, err = Ln(value)
+			assert.NoError(t, err)
+			_, err = Log(2, value)
+			assert.NoError(t, err)
+			_, err = Pow(value, 3)
+			assert.NoError(t, err)
+			_, err = Sqrt(value)
+			assert.NoError(t, err)
+			_, err = Stddev(window)
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+}

--- a/llo/protocol/calculated/doc.go
+++ b/llo/protocol/calculated/doc.go
@@ -1,0 +1,116 @@
+// Package calculated evaluates the expression language used by
+// EVMABIEncodeUnpackedExpr channels to derive new stream values from observed
+// ones.
+//
+// It is shared by every plugin version, so anything here that changes an output
+// changes it for already-deployed DONs.
+//
+// # Expressions
+//
+// An expression is an expr-lang expression evaluated against an environment of
+// stream values and functions, and must evaluate to a decimal. Builtins are
+// disabled, so only the functions registered in defaultEnv are callable.
+//
+// Streams are named by identifier: s10001 for a scalar stream, and
+// s10001_bid / s10001_benchmark / s10001_ask for a quote stream. A quote has no
+// bare value — s10001 alone is not bound for a quote stream. s10001_timestamp is
+// bound for timestamped streams. Only streams the channel declares are in scope.
+//
+//	Div(Add(s1, s2), s3)
+//
+// # Stream history
+//
+// History(<stream identifier>, <depth>) reads the last <depth> agreed values of a
+// stream:
+//
+//	Avg(History(s10001, 10))
+//	EMA(History(s10001, 50), 20)
+//	TWAP(History(s10001, 600), {window: Duration("5m"), minSamples: 240,
+//	                            maxHeadGap: 30, maxInteriorGap: 10, maxTailGap: 30})
+//
+// The call is both the declaration of how much history to persist and the read of
+// it. There is no separate configuration: the depth kept for a stream is the
+// deepest any live channel asks for.
+//
+// It is resolved at compile time, not called at run time — the AST is rewritten
+// so each call becomes an identifier bound to the loaded window (history_ast.go).
+// Two consequences: both arguments must be literal (a bare stream identifier and
+// an integer), and the depth is known before evaluation, which is what lets the
+// plugin know how much to keep.
+//
+// History requires replicated state, so it works only on protocol versions that
+// have it. On v30 an expression using History fails closed: no value, and the
+// channel does not report.
+//
+// # Functions
+//
+// Scalar functions, unchanged by history: Add, Sub, Mul, Div, Pow, Sqrt, Ln, Log,
+// Abs, Round, Ceil, Floor, Duration, IsZero, IsNegative, IsPositive, and the
+// comparisons EQ/Equal, GT/GreaterThan, GTE/GreaterThanOrEqual, LT/LessThan,
+// LTE/LessThanOrEqual.
+//
+// Accepting either a history window or a list of scalars: Avg, Sum, Min, Max. The
+// two forms cannot be mixed — Avg(History(s1, 10), s2) is ambiguous about whether
+// the scalar is another sample or a weight, so it is rejected.
+//
+// Window-only:
+//
+//	Count      number of values
+//	First      oldest value
+//	Last       newest value (the value this round agreed on)
+//	Median     middle value; mean of the two middles for an even length
+//	Variance   population variance
+//	Stddev     population standard deviation
+//	Delta      newest minus oldest
+//	PctChange  (newest - oldest) / oldest, as a fraction: 0.05 is a 5% rise
+//	Spread     maximum minus minimum
+//	SMA(w, n)  simple mean of the newest n
+//	WMA(w, n)  linearly weighted, newest weighted n and the oldest of the n weighted 1
+//	EMA(w, n)  seeded with the mean of the oldest n, then alpha = 2/(n+1) newest-ward
+//	TWAP(w, c) time-weighted average price over c.window, filling gaps by type
+//
+// A window may only be passed directly to one of these. Add(History(s1, 10), 2) is
+// rejected when the expression is validated, not left to fail during evaluation.
+//
+// # Warmup
+//
+// A window is readable only once it holds at least the requested depth. Until
+// then the expression is not evaluated, no value is written, and the channel is
+// not reportable — so its coverage watermark does not advance and no gap is
+// falsely claimed.
+//
+// The operational consequence: adding a History call to a live channel, or
+// raising its depth, stops that channel reporting until the window fills. Deploy
+// the change as a NEW channel, wait for its history to be satisfied, then retire
+// the old one. Lowering a depth takes effect the next round with no gap.
+//
+// # Limits
+//
+// Depth per (stream, aggregator) pair, the number of such pairs, the per-round
+// byte budget and the per-record size are all bounded by constants in
+// llo/protocol/limits.go. They are hardcoded because they determine persisted
+// state and so must not vary per node.
+//
+// A pair denied history because a cap was reached gets none at all, and channels
+// reading it do not report. There is no silently shortened window.
+//
+// # Determinism
+//
+// Expression results become consensus values, so identical inputs must give
+// bit-identical output on every node. See decimalmath.go: no float64 anywhere in
+// the calculation, no reliance on decimal.DivisionPrecision (a mutable global),
+// fixed rounding at every step of an iterative calculation, and a lock around
+// shopspring/decimal's transcendental functions, which are not concurrency-safe.
+//
+// Div and Avg are pinned to the precision they have always effectively used (16);
+// functions added with stream history use 18. Changing the former would move the
+// trailing digits of every existing calculated stream.
+//
+// # Validation
+//
+// ValidateExpression and ValidateChannelExpressions apply every static rule
+// without evaluating anything, and are what a report codec's Verify should call
+// so an unusable definition cannot reach consensus.
+// ProcessCalculatedStreamsDryRun goes further, evaluating against synthesized
+// inputs, and is for offline configuration tooling.
+package calculated

--- a/llo/protocol/calculated/doc.go
+++ b/llo/protocol/calculated/doc.go
@@ -94,6 +94,26 @@
 // A pair denied history because a cap was reached gets none at all, and channels
 // reading it do not report. There is no silently shortened window.
 //
+// # Evaluation
+//
+// A round runs in three phases: prepare, evaluate, apply.
+//
+// Prepare is sequential. It reads everything shared — the opts cache, the round's
+// stream aggregates, and the HistoryReader, whose one-read-per-pair memoization
+// is stateful and so cannot be driven from several goroutines. It hands each
+// channel a fully materialized input: an environment and its bound windows.
+//
+// Evaluate is pure and runs on a small worker pool, one channel per unit of work.
+// Nothing it reads is shared and it writes only its own result slot, so no
+// synchronization is needed beyond waiting for the workers. Rounds whose total
+// work is small enough that dispatching would cost more than evaluating run
+// inline instead.
+//
+// Apply is sequential and walks channels in ascending channel ID order, writing
+// aggregates, appending calculated streams to definitions and logging failures.
+// The order is fixed there, not inherited from the worker pool, which is what
+// keeps the outcome independent of scheduling.
+//
 // # Determinism
 //
 // Expression results become consensus values, so identical inputs must give

--- a/llo/protocol/calculated/doc.go
+++ b/llo/protocol/calculated/doc.go
@@ -110,9 +110,14 @@
 // inline instead.
 //
 // Apply is sequential and walks channels in ascending channel ID order, writing
-// aggregates, appending calculated streams to definitions and logging failures.
-// The order is fixed there, not inherited from the worker pool, which is what
-// keeps the outcome independent of scheduling.
+// aggregates and logging failures. The order is fixed there, not inherited from
+// the worker pool, which is what keeps the outcome independent of scheduling.
+//
+// Channel definitions are not written. Which calculated streams a channel
+// reports is derived from its opts by protocol.EffectiveStreams, so evaluation
+// contributes nothing to replicated state. v3.0 is the exception: it commits
+// channel definitions in its outcome and so keeps appending to them, via
+// ProcessCalculatedStreamsWithDefinitionAppend.
 //
 // # Determinism
 //

--- a/llo/protocol/calculated/doc.go
+++ b/llo/protocol/calculated/doc.go
@@ -134,8 +134,10 @@
 // # Validation
 //
 // ValidateExpression and ValidateChannelExpressions apply every static rule
-// without evaluating anything, and are what a report codec's Verify should call
-// so an unusable definition cannot reach consensus.
+// without evaluating anything, and are what a report codec's VerifyForAdmission
+// should call so an unusable definition cannot reach consensus. They belong there
+// rather than in Verify because Verify also runs against already-committed
+// definitions, and rejecting one of those stops an oracle from observing at all.
 // ProcessCalculatedStreamsDryRun goes further, evaluating against synthesized
 // inputs, and is for offline configuration tooling.
 package calculated

--- a/llo/protocol/calculated/evaluate_fuzz_test.go
+++ b/llo/protocol/calculated/evaluate_fuzz_test.go
@@ -99,8 +99,12 @@ func FuzzEvaluateExpression(f *testing.F) {
 		if err := ValidateExpression(expression); err != nil {
 			return
 		}
-		if err := bindHistory(expression, env, reader, aggByStream); err != nil {
+		window, err := resolveHistory(expression, reader, aggByStream)
+		if err != nil {
 			return
+		}
+		for _, bound := range window {
+			env[bound.name] = bound.series
 		}
 
 		// The result is unconstrained; only the absence of a panic matters, and

--- a/llo/protocol/calculated/evaluate_fuzz_test.go
+++ b/llo/protocol/calculated/evaluate_fuzz_test.go
@@ -1,0 +1,110 @@
+package calculated
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+// fuzzHistoryReader serves a window of the requested depth built from a seed, so
+// evaluation is exercised against varying values rather than one fixed series.
+type fuzzHistoryReader struct {
+	seed  int64
+	scale int32
+}
+
+func (r fuzzHistoryReader) Series(_ llotypes.StreamID, _ llotypes.Aggregator, count uint32, _ Field) (Series, error) {
+	values := make([]decimal.Decimal, 0, count)
+	timestamps := make([]uint64, 0, count)
+	for i := range count {
+		values = append(values, decimal.New(r.seed+int64(i), r.scale))
+		timestamps = append(timestamps, uint64(i+1)*uint64(1_000_000_000))
+	}
+	return NewSeries(values, timestamps)
+}
+
+// FuzzEvaluateExpression fuzzes the whole evaluation path — analysis, the AST
+// rewrite, compilation and the function library — over arbitrary expression text
+// and arbitrary window contents.
+//
+// Expressions come from channel definitions, which are replicated state, and the
+// window values come from agreed aggregates. Neither is trusted to be sensible:
+// what matters is that no input reaches a panic, and that a failure is always a
+// returned error. A panic in an oracle's state transition takes the node down.
+//
+// The unit tests cover meaning; this covers survival.
+func FuzzEvaluateExpression(f *testing.F) {
+	for _, expression := range []string{
+		"Add(s1, s2)",
+		"Div(s1, s2)",
+		"Count(History(s1, 3))",
+		"Avg(History(s1, 3))",
+		"Median(History(s1, 3))",
+		"Stddev(History(s1, 3))",
+		"PctChange(History(s1, 3))",
+		"Spread(History(s1, 3))",
+		"Delta(History(s1, 3))",
+		"SMA(History(s1, 3), 2)",
+		"WMA(History(s1, 3), 2)",
+		"EMA(History(s1, 3), 2)",
+		"Sum(History(s1, 3))",
+		"Min(History(s1, 3))",
+		"Max(History(s1, 3))",
+		`TWAP(History(s1, 3), {window: Duration("3s"), minSamples: 1, maxHeadGap: 3, maxInteriorGap: 3, maxTailGap: 3})`,
+		"Ln(s1)",
+		"Log(s1, s2)",
+		"Pow(s1, s2)",
+		"Sqrt(s1)",
+		"Round(Div(s1, s2), 2)",
+		"Add(Avg(History(s1, 2)), Avg(History(s2, 2)))",
+		"",
+		"((((",
+		"Avg(History(s1, 0))",
+	} {
+		// Seeds span a zero value, a negative one and a large exponent, since
+		// those are what the arithmetic tends to trip over.
+		f.Add(expression, int64(1), int32(0))
+		f.Add(expression, int64(0), int32(0))
+		f.Add(expression, int64(-5), int32(-8))
+		f.Add(expression, int64(1), int32(30))
+	}
+
+	f.Fuzz(func(t *testing.T, expression string, seed int64, scale int32) {
+		// Bound the exponent: a decimal with an enormous scale makes the
+		// arithmetic legitimately slow rather than incorrect, and the protocol
+		// bounds it separately on decode.
+		if scale > 64 || scale < -64 {
+			return
+		}
+
+		env := NewEnv(1_000 * uint64(1_000_000_000))
+		defer env.release()
+		for _, id := range []llotypes.StreamID{1, 2} {
+			require.NoError(t, env.SetStreamValue(id, protocol.ToDecimal(decimal.New(seed, scale))))
+		}
+
+		reader := fuzzHistoryReader{seed: seed, scale: scale}
+		aggByStream := map[llotypes.StreamID]llotypes.Aggregator{
+			1: llotypes.AggregatorMedian,
+			2: llotypes.AggregatorMedian,
+		}
+
+		// Analysis first: a statically invalid expression is never evaluated, so
+		// evaluating one here would test a path the plugin cannot reach.
+		if err := ValidateExpression(expression); err != nil {
+			return
+		}
+		if err := bindHistory(expression, env, reader, aggByStream); err != nil {
+			return
+		}
+
+		// The result is unconstrained; only the absence of a panic matters, and
+		// that any failure came back as an error.
+		_, _ = evalDecimal(expression, env)
+	})
+}

--- a/llo/protocol/calculated/functions_bench_test.go
+++ b/llo/protocol/calculated/functions_bench_test.go
@@ -1,0 +1,268 @@
+package calculated
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+// Evaluation benchmarks.
+//
+// The figure to keep in mind is the round interval, on the order of a second:
+// every expression of every channel is evaluated inside one state transition, so
+// per-expression cost multiplies by the channel count.
+//
+// TWAP is the one to watch. It takes a logarithm per observed bucket and an
+// exponential per bucket in the window, and all of those serialize on the
+// process-wide transcendental lock (see decimalmath.go), so its cost does not
+// parallelize across the plugin instances sharing a process.
+
+func benchSeries(depth int, intervalSeconds int) Series {
+	values := make([]decimal.Decimal, 0, depth)
+	timestamps := make([]uint64, 0, depth)
+	for i := range depth {
+		values = append(values, decimal.New(int64(110000000000000000+i), -8))
+		timestamps = append(timestamps, uint64((i+1)*intervalSeconds)*uint64(time.Second))
+	}
+	s, err := NewSeries(values, timestamps)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func BenchmarkWindowFunctions(b *testing.B) {
+	for _, depth := range []int{10, 300, 1024} {
+		window := benchSeries(depth, 1)
+
+		for name, fn := range map[string]func(any) (decimal.Decimal, error){
+			"Count":     Count,
+			"Median":    Median,
+			"Variance":  Variance,
+			"Stddev":    Stddev,
+			"PctChange": PctChange,
+			"Spread":    Spread,
+		} {
+			b.Run(fmt.Sprintf("%s/depth=%d", name, depth), func(b *testing.B) {
+				for range b.N {
+					if _, err := fn(window); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+
+		for name, fn := range map[string]func(any, any) (decimal.Decimal, error){
+			"SMA": SMA, "WMA": WMA, "EMA": EMA,
+		} {
+			b.Run(fmt.Sprintf("%s/depth=%d", name, depth), func(b *testing.B) {
+				for range b.N {
+					if _, err := fn(window, depth/2); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkTWAP measures the settlement-window sizes an operator would actually
+// configure.
+func BenchmarkTWAP(b *testing.B) {
+	for _, windowSeconds := range []int{60, 300, 900} {
+		// One record per second, fully covering the window.
+		window := benchSeries(windowSeconds, 1)
+		anchorNs := uint64(windowSeconds+1) * uint64(time.Second)
+		cfg := map[string]any{
+			"window":         time.Duration(windowSeconds) * time.Second,
+			"minSamples":     windowSeconds / 2,
+			"maxHeadGap":     windowSeconds,
+			"maxInteriorGap": windowSeconds,
+			"maxTailGap":     windowSeconds,
+		}
+		twap := twapFunc(anchorNs)
+
+		b.Run(fmt.Sprintf("window=%ds", windowSeconds), func(b *testing.B) {
+			for range b.N {
+				if _, err := twap(window, cfg); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkTWAPSparse is the worst case for the filling strategy: only interior
+// interpolation needs log space, so cost scales with how much of the window is
+// missing. A window observed every Nth second is the expensive shape.
+func BenchmarkTWAPSparse(b *testing.B) {
+	const windowSeconds = 300
+
+	for _, everyNth := range []int{1, 2, 5, 30} {
+		depth := windowSeconds / everyNth
+		window := benchSeries(depth, everyNth)
+		anchorNs := uint64(windowSeconds+1) * uint64(time.Second)
+		cfg := map[string]any{
+			"window":         time.Duration(windowSeconds) * time.Second,
+			"minSamples":     1,
+			"maxHeadGap":     windowSeconds,
+			"maxInteriorGap": windowSeconds,
+			"maxTailGap":     windowSeconds,
+		}
+		twap := twapFunc(anchorNs)
+
+		b.Run(fmt.Sprintf("observedEvery=%ds", everyNth), func(b *testing.B) {
+			for range b.N {
+				if _, err := twap(window, cfg); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkTWAPRealisticGaps measures the worst case a production acceptance rule
+// actually admits.
+//
+// The permissive thresholds in BenchmarkTWAPSparse exist to force interpolation
+// and show where the cost lives; they are not deployable. With the spec's example
+// thresholds (minSamples 240 of 300, maxInteriorGap 10) a window can be missing at
+// most 60 buckets, so interpolation is bounded no matter how the gaps fall.
+func BenchmarkTWAPRealisticGaps(b *testing.B) {
+	const windowSeconds = 300
+	const minSamples = 240
+
+	// 240 observations in a 300-second window, with the 60 missing buckets spread
+	// as 20 interior gaps of 3 — within a maxInteriorGap of 10.
+	values := make([]decimal.Decimal, 0, minSamples)
+	timestamps := make([]uint64, 0, minSamples)
+	second := 0
+	for len(values) < minSamples && second < windowSeconds {
+		if second%15 >= 12 { // 3 missing out of every 15
+			second++
+			continue
+		}
+		values = append(values, decimal.New(int64(110000000000000000+second), -8))
+		timestamps = append(timestamps, uint64(second+1)*uint64(time.Second))
+		second++
+	}
+	window, err := NewSeries(values, timestamps)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	cfg := map[string]any{
+		"window":         time.Duration(windowSeconds) * time.Second,
+		"minSamples":     len(values),
+		"maxHeadGap":     10,
+		"maxInteriorGap": 10,
+		"maxTailGap":     10,
+	}
+	twap := twapFunc(uint64(windowSeconds+1) * uint64(time.Second))
+
+	b.ReportMetric(float64(windowSeconds-len(values)), "missingBuckets")
+	b.ResetTimer()
+	for range b.N {
+		if _, err := twap(window, cfg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkTWAPParallel shows what the transcendental lock costs when several
+// plugin instances evaluate TWAP at once. Compare ns/op against the serial
+// benchmark: no speedup means the lock is the limit.
+func BenchmarkTWAPParallel(b *testing.B) {
+	const windowSeconds = 300
+	window := benchSeries(windowSeconds, 1)
+	anchorNs := uint64(windowSeconds+1) * uint64(time.Second)
+	cfg := map[string]any{
+		"window":         time.Duration(windowSeconds) * time.Second,
+		"minSamples":     windowSeconds / 2,
+		"maxHeadGap":     windowSeconds,
+		"maxInteriorGap": windowSeconds,
+		"maxTailGap":     windowSeconds,
+	}
+	twap := twapFunc(anchorNs)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := twap(window, cfg); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkProcessCalculatedStreams measures a whole round's expression work,
+// which is what the round budget actually has to absorb.
+func BenchmarkProcessCalculatedStreams(b *testing.B) {
+	for _, tc := range []struct {
+		name       string
+		expression string
+		depth      uint32
+	}{
+		{"scalar", "Add(s1, s2)", 0},
+		{"avg/depth=300", "Avg(History(s1, 300))", 300},
+		{"ema/depth=300", "EMA(History(s1, 300), 20)", 300},
+		{"twap/window=300", `TWAP(History(s1, 300), {window: Duration("5m"), minSamples: 150, maxHeadGap: 300, maxInteriorGap: 300, maxTailGap: 300})`, 300},
+	} {
+		for _, channels := range []int{1, 32} {
+			b.Run(fmt.Sprintf("%s/channels=%d", tc.name, channels), func(b *testing.B) {
+				defs := llotypes.ChannelDefinitions{}
+				for c := range channels {
+					defs[llotypes.ChannelID(c+1)] = llotypes.ChannelDefinition{
+						ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+						Streams: []llotypes.Stream{
+							{StreamID: 1, Aggregator: llotypes.AggregatorMedian},
+							{StreamID: 2, Aggregator: llotypes.AggregatorMedian},
+						},
+						Opts: []byte(fmt.Sprintf(
+							`{"abi":[{"type":"int256","expression":%q,"expressionStreamID":%d}]}`,
+							tc.expression, 900+c)),
+					}
+				}
+				cache := protocol.NewOptsCache()
+				cache.ResetTo(defs)
+				lggr := logger.Test(b)
+
+				var reader HistoryReader
+				if tc.depth > 0 {
+					reader = benchReader{window: benchSeries(int(tc.depth), 1)}
+				}
+				// The anchor must sit just after the newest record or a
+				// window-relative function sees an empty window.
+				anchorNs := uint64(int(tc.depth)+1) * uint64(time.Second)
+
+				b.ResetTimer()
+				for range b.N {
+					aggregates := protocol.StreamAggregates{
+						1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(3))},
+						2: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(4))},
+					}
+					ProcessCalculatedStreams(lggr, defs, aggregates, anchorNs, cache, reader)
+					if len(aggregates[900]) == 0 {
+						b.Fatal("expected a calculated aggregate")
+					}
+				}
+			})
+		}
+	}
+}
+
+// benchReader serves one fixed window for every request.
+type benchReader struct{ window Series }
+
+func (r benchReader) Series(_ llotypes.StreamID, _ llotypes.Aggregator, count uint32, _ Field) (Series, error) {
+	if uint32(r.window.Len()) < count {
+		return Series{}, ErrInsufficientHistory
+	}
+	return r.window, nil
+}

--- a/llo/protocol/calculated/functions_ma.go
+++ b/llo/protocol/calculated/functions_ma.go
@@ -1,0 +1,25 @@
+package calculated
+
+import (
+	"github.com/shopspring/decimal"
+)
+
+// SMA returns the simple moving average of the newest n values of a history
+// window.
+func SMA(x any, n any) (decimal.Decimal, error) {
+	series, err := window("SMA", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	count, err := windowSize("SMA", series, n)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+
+	values := series.Values()
+	sum := decimal.Zero
+	for _, v := range values[len(values)-count:] {
+		sum = sum.Add(v)
+	}
+	return divRoundByInt(sum, count, precision)
+}

--- a/llo/protocol/calculated/functions_ma.go
+++ b/llo/protocol/calculated/functions_ma.go
@@ -23,3 +23,31 @@ func SMA(x any, n any) (decimal.Decimal, error) {
 	}
 	return divRoundByInt(sum, count, precision)
 }
+
+// WMA returns the linearly weighted moving average of the newest n values of a
+// history window, weighting the newest value n and the oldest of the n values 1.
+//
+//	WMA = (n*x[newest] + (n-1)*x[newest-1] + ... + 1*x[oldest]) / (n + (n-1) + ... + 1)
+func WMA(x any, n any) (decimal.Decimal, error) {
+	series, err := window("WMA", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	count, err := windowSize("WMA", series, n)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+
+	values := series.Values()
+	considered := values[len(values)-count:]
+
+	weighted := decimal.Zero
+	for i, v := range considered {
+		// i counts from the oldest of the considered values, so its weight is
+		// i+1 and the newest gets count.
+		weighted = weighted.Add(v.Mul(decimal.NewFromInt(int64(i + 1))))
+	}
+	// Sum of 1..count, computed exactly rather than accumulated.
+	totalWeight := count * (count + 1) / 2
+	return divRoundByInt(weighted, totalWeight, precision)
+}

--- a/llo/protocol/calculated/functions_ma.go
+++ b/llo/protocol/calculated/functions_ma.go
@@ -51,3 +51,52 @@ func WMA(x any, n any) (decimal.Decimal, error) {
 	totalWeight := count * (count + 1) / 2
 	return divRoundByInt(weighted, totalWeight, precision)
 }
+
+// EMA returns the exponential moving average of a history window with smoothing
+// period n.
+//
+// The series is seeded with the simple mean of its oldest n values, then
+// iterated newest-ward with the conventional smoothing factor:
+//
+//	alpha = 2 / (n + 1)
+//	ema   = value*alpha + ema*(1 - alpha)
+//
+// Determinism note: the recursive form is path-dependent, so the seed rule, the
+// iteration count and the rounding must all be fixed. They are: the window
+// length is exactly the depth the expression requested, the channel does not
+// evaluate until the window is that deep, alpha is an exact decimal fraction
+// rather than a float, and every step is rounded to the package precision. That
+// is what makes the result reproducible across oracles and across restarts.
+func EMA(x any, n any) (decimal.Decimal, error) {
+	series, err := window("EMA", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	count, err := windowSize("EMA", series, n)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+
+	values := series.Values()
+
+	// Seed: mean of the oldest count values.
+	seedSum := decimal.Zero
+	for _, v := range values[:count] {
+		seedSum = seedSum.Add(v)
+	}
+	ema, err := divRoundByInt(seedSum, count, precision)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+
+	alpha, err := divRoundByInt(decimal.NewFromInt(2), count+1, doublePrecision)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	oneMinusAlpha := decimal.NewFromInt(1).Sub(alpha)
+
+	for _, v := range values[count:] {
+		ema = v.Mul(alpha).Add(ema.Mul(oneMinusAlpha)).Round(precision)
+	}
+	return ema, nil
+}

--- a/llo/protocol/calculated/functions_ma_test.go
+++ b/llo/protocol/calculated/functions_ma_test.go
@@ -3,6 +3,7 @@ package calculated
 import (
 	"testing"
 
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,4 +56,88 @@ func TestWMA(t *testing.T) {
 	wma, err := WMA(window, 4)
 	require.NoError(t, err)
 	assert.True(t, wma.GreaterThan(sma), "WMA %s should exceed SMA %s on a rising series", wma, sma)
+}
+
+func TestEMA(t *testing.T) {
+	t.Parallel()
+
+	// Seed is the mean of the oldest n; with n == len there is nothing left to
+	// iterate, so EMA equals that mean.
+	got, err := EMA(seriesOf(t, "10", "20", "30", "40"), 4)
+	require.NoError(t, err)
+	assertDecimal(t, "25", got)
+
+	// A flat series is unchanged by any amount of smoothing.
+	got, err = EMA(seriesOf(t, "5", "5", "5", "5", "5"), 2)
+	require.NoError(t, err)
+	assertDecimal(t, "5", got)
+
+	// Hand-computed: n=2 over [10,20,30].
+	//   seed  = (10+20)/2 = 15
+	//   alpha = 2/3
+	//   ema   = 30*(2/3) + 15*(1/3) = 20 + 5 = 25
+	got, err = EMA(seriesOf(t, "10", "20", "30"), 2)
+	require.NoError(t, err)
+	assertDecimal(t, "25", got)
+
+	// Weighting the newest values more heavily puts EMA above the simple mean on
+	// a rising series.
+	window := seriesOf(t, "10", "20", "30", "40", "50")
+	ema, err := EMA(window, 2)
+	require.NoError(t, err)
+	sma, err := SMA(window, 5)
+	require.NoError(t, err)
+	assert.True(t, ema.GreaterThan(sma), "EMA %s should exceed SMA %s on a rising series", ema, sma)
+}
+
+// TestEMA_Deterministic covers the property that makes a path-dependent
+// recurrence safe in a consensus path: identical inputs must give an identical
+// result every time, and the rounding must not drift with repetition.
+func TestEMA_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	window := seriesOf(t, "1.1", "2.7", "3.14159", "4.000001", "5.5", "6.25", "7.77")
+	first, err := EMA(window, 3)
+	require.NoError(t, err)
+	for range 50 {
+		again, err := EMA(window, 3)
+		require.NoError(t, err)
+		require.True(t, first.Equal(again), "EMA drifted: %s vs %s", first, again)
+	}
+	// Every step rounds to the package precision, so the result cannot carry
+	// more than that.
+	assert.LessOrEqual(t, -first.Exponent(), int32(precision))
+}
+
+func TestMovingAverages_Errors(t *testing.T) {
+	t.Parallel()
+
+	for name, fn := range map[string]func(any, any) (decimal.Decimal, error){
+		"SMA": SMA, "WMA": WMA, "EMA": EMA,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			window := seriesOf(t, "1", "2", "3")
+
+			_, err := fn(decimal.NewFromInt(1), 2)
+			require.ErrorContains(t, err, "expects a history window")
+
+			_, err = fn(Series{}, 2)
+			require.ErrorContains(t, err, "empty")
+
+			// Silently using fewer samples than asked for would change the
+			// meaning of the result.
+			_, err = fn(window, 4)
+			require.ErrorContains(t, err, "exceeds the window length")
+
+			_, err = fn(window, 0)
+			require.ErrorContains(t, err, "at least 1")
+
+			_, err = fn(window, -1)
+			require.ErrorContains(t, err, "at least 1")
+
+			_, err = fn(window, 1.5)
+			require.ErrorContains(t, err, "whole number")
+		})
+	}
 }

--- a/llo/protocol/calculated/functions_ma_test.go
+++ b/llo/protocol/calculated/functions_ma_test.go
@@ -1,0 +1,27 @@
+package calculated
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSMA(t *testing.T) {
+	t.Parallel()
+
+	window := seriesOf(t, "10", "20", "30", "40")
+
+	// Newest 2: (30 + 40) / 2.
+	got, err := SMA(window, 2)
+	require.NoError(t, err)
+	assertDecimal(t, "35", got)
+
+	// The whole window matches Avg.
+	got, err = SMA(window, 4)
+	require.NoError(t, err)
+	assertDecimal(t, "25", got)
+
+	got, err = SMA(window, 1)
+	require.NoError(t, err)
+	assertDecimal(t, "40", got)
+}

--- a/llo/protocol/calculated/functions_ma_test.go
+++ b/llo/protocol/calculated/functions_ma_test.go
@@ -136,6 +136,15 @@ func TestMovingAverages_Errors(t *testing.T) {
 			_, err = fn(window, -1)
 			require.ErrorContains(t, err, "at least 1")
 
+			// decimal.IntPart narrows through int64 and returns the low 64 bits
+			// of an oversized value: 2^64+1 comes back as 1. Bounding after that
+			// would accept this as a one-sample average instead of rejecting it,
+			// and the count is not required to be literal -- it can come from a
+			// stream value, which is bounded only by MaxDecimalExponent.
+			wrapped := decimal.RequireFromString("18446744073709551617")
+			_, err = fn(window, wrapped)
+			require.ErrorContains(t, err, "exceeds the window length")
+
 			_, err = fn(window, 1.5)
 			require.ErrorContains(t, err, "whole number")
 		})

--- a/llo/protocol/calculated/functions_ma_test.go
+++ b/llo/protocol/calculated/functions_ma_test.go
@@ -3,6 +3,7 @@ package calculated
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,4 +25,34 @@ func TestSMA(t *testing.T) {
 	got, err = SMA(window, 1)
 	require.NoError(t, err)
 	assertDecimal(t, "40", got)
+}
+
+func TestWMA(t *testing.T) {
+	t.Parallel()
+
+	window := seriesOf(t, "10", "20", "30", "40")
+
+	// Newest 3 with weights 1,2,3 oldest-to-newest: (1*20 + 2*30 + 3*40) / 6.
+	// New functions round to precision (18), unlike Div and Avg which stay
+	// pinned at 16 for backwards compatibility.
+	got, err := WMA(window, 3)
+	require.NoError(t, err)
+	assertDecimal(t, "33.333333333333333333", got)
+
+	// n=1 is just the newest value.
+	got, err = WMA(window, 1)
+	require.NoError(t, err)
+	assertDecimal(t, "40", got)
+
+	// A flat window averages to its value whatever the weights.
+	got, err = WMA(seriesOf(t, "7", "7", "7"), 3)
+	require.NoError(t, err)
+	assertDecimal(t, "7", got)
+
+	// Weighting is newest-heaviest, so a rising series exceeds the simple mean.
+	sma, err := SMA(window, 4)
+	require.NoError(t, err)
+	wma, err := WMA(window, 4)
+	require.NoError(t, err)
+	assert.True(t, wma.GreaterThan(sma), "WMA %s should exceed SMA %s on a rising series", wma, sma)
 }

--- a/llo/protocol/calculated/functions_series.go
+++ b/llo/protocol/calculated/functions_series.go
@@ -1,0 +1,151 @@
+package calculated
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/shopspring/decimal"
+)
+
+// Sum returns the total of a history window or a list of scalars.
+//
+// Add remains the binary form; Sum is the aggregate one.
+func Sum(x ...any) (decimal.Decimal, error) {
+	values, err := scalarsOrWindow("Sum", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	total := decimal.Zero
+	for _, v := range values {
+		total = total.Add(v)
+	}
+	return total, nil
+}
+
+// First returns the oldest value in a history window.
+func First(x any) (decimal.Decimal, error) {
+	series, err := window("First", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	return series.Oldest()
+}
+
+// Last returns the newest value in a history window, which is the value the
+// current round agreed on.
+func Last(x any) (decimal.Decimal, error) {
+	series, err := window("Last", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	return series.Newest()
+}
+
+// Median returns the middle value of a history window: the exact middle for an
+// odd length, the mean of the two middle values for an even one.
+func Median(x any) (decimal.Decimal, error) {
+	series, err := window("Median", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+
+	// Sorted on a copy: the window is shared with the environment and with any
+	// other function reading it this round.
+	sorted := make([]decimal.Decimal, len(series.Values()))
+	copy(sorted, series.Values())
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].LessThan(sorted[j]) })
+
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid], nil
+	}
+	return divRoundByInt(sorted[mid-1].Add(sorted[mid]), 2, precision)
+}
+
+// Variance returns the population variance of a history window.
+//
+// Population rather than sample variance: the window is the whole series being
+// described, not a sample drawn from a larger one.
+func Variance(x any) (decimal.Decimal, error) {
+	series, err := window("Variance", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	values := series.Values()
+
+	// The mean is taken at double precision so that squaring it does not
+	// amplify the rounding of an intermediate value.
+	sum := decimal.Zero
+	for _, v := range values {
+		sum = sum.Add(v)
+	}
+	mean, err := divRoundByInt(sum, len(values), doublePrecision)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+
+	squares := decimal.Zero
+	for _, v := range values {
+		diff := v.Sub(mean)
+		squares = squares.Add(diff.Mul(diff))
+	}
+	return divRoundByInt(squares, len(values), precision)
+}
+
+// Stddev returns the population standard deviation of a history window.
+func Stddev(x any) (decimal.Decimal, error) {
+	variance, err := Variance(x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	return sqrt(variance)
+}
+
+// Delta returns the change across a history window: newest minus oldest.
+func Delta(x any) (decimal.Decimal, error) {
+	series, err := window("Delta", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	newest, err := series.Newest()
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	oldest, err := series.Oldest()
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	return newest.Sub(oldest), nil
+}
+
+// PctChange returns the fractional change across a history window,
+// (newest - oldest) / oldest. It is a fraction, not a percentage: 0.05 is a 5%
+// rise.
+func PctChange(x any) (decimal.Decimal, error) {
+	series, err := window("PctChange", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	newest, err := series.Newest()
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	oldest, err := series.Oldest()
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	if oldest.IsZero() {
+		return decimal.Decimal{}, fmt.Errorf("PctChange: oldest value is zero, relative change is undefined")
+	}
+	return divRound(newest.Sub(oldest), oldest, precision)
+}
+
+// Spread returns the range of a history window: maximum minus minimum.
+func Spread(x any) (decimal.Decimal, error) {
+	series, err := window("Spread", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	values := series.Values()
+	return decimal.Max(values[0], values[1:]...).Sub(decimal.Min(values[0], values[1:]...)), nil
+}

--- a/llo/protocol/calculated/functions_series_test.go
+++ b/llo/protocol/calculated/functions_series_test.go
@@ -1,0 +1,144 @@
+package calculated
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seriesOf builds a window from integer-valued strings, one second apart.
+func seriesOf(t *testing.T, values ...string) Series {
+	t.Helper()
+	decimals := make([]decimal.Decimal, 0, len(values))
+	timestamps := make([]uint64, 0, len(values))
+	for i, v := range values {
+		d, err := decimal.NewFromString(v)
+		require.NoError(t, err)
+		decimals = append(decimals, d)
+		timestamps = append(timestamps, uint64(i+1)*1_000_000_000)
+	}
+	s, err := NewSeries(decimals, timestamps)
+	require.NoError(t, err)
+	return s
+}
+
+func assertDecimal(t *testing.T, want string, got decimal.Decimal) {
+	t.Helper()
+	expected, err := decimal.NewFromString(want)
+	require.NoError(t, err)
+	assert.True(t, expected.Equal(got), "expected %s, got %s", want, got.String())
+}
+
+// TestSeriesFunctions_Golden pins each function against hand-computed values.
+func TestSeriesFunctions_Golden(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		fn     func(any) (decimal.Decimal, error)
+		values []string
+		want   string
+	}{
+		"Count":                {Count, []string{"1", "2", "3", "4"}, "4"},
+		"First":                {First, []string{"10", "20", "30"}, "10"},
+		"Last":                 {Last, []string{"10", "20", "30"}, "30"},
+		"Median odd":           {Median, []string{"30", "10", "20"}, "20"},
+		"Median even":          {Median, []string{"40", "10", "30", "20"}, "25"},
+		"Median single":        {Median, []string{"7"}, "7"},
+		"Median even fraction": {Median, []string{"1", "2"}, "1.5"},
+		"Delta":                {Delta, []string{"10", "50", "30"}, "20"},
+		"Delta negative":       {Delta, []string{"30", "10"}, "-20"},
+		"Spread":               {Spread, []string{"10", "50", "30"}, "40"},
+		"Spread flat":          {Spread, []string{"5", "5", "5"}, "0"},
+		"PctChange up":         {PctChange, []string{"100", "125"}, "0.25"},
+		"PctChange down":       {PctChange, []string{"100", "75"}, "-0.25"},
+		"Variance":             {Variance, []string{"2", "4", "4", "4", "5", "5", "7", "9"}, "4"},
+		"Variance flat":        {Variance, []string{"3", "3", "3"}, "0"},
+		"Stddev":               {Stddev, []string{"2", "4", "4", "4", "5", "5", "7", "9"}, "2"},
+		"Stddev single":        {Stddev, []string{"9"}, "0"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.fn(seriesOf(t, tc.values...))
+			require.NoError(t, err)
+			assertDecimal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSeriesFunctions_Errors(t *testing.T) {
+	t.Parallel()
+
+	windowOnly := map[string]func(any) (decimal.Decimal, error){
+		"Count": Count, "First": First, "Last": Last, "Median": Median,
+		"Variance": Variance, "Stddev": Stddev, "Delta": Delta,
+		"PctChange": PctChange, "Spread": Spread,
+	}
+	for name, fn := range windowOnly {
+		t.Run(name+" rejects a scalar", func(t *testing.T) {
+			t.Parallel()
+			_, err := fn(decimal.NewFromInt(1))
+			require.Error(t, err)
+		})
+		t.Run(name+" rejects an empty window", func(t *testing.T) {
+			t.Parallel()
+			_, err := fn(Series{})
+			require.Error(t, err)
+		})
+	}
+
+	t.Run("PctChange from zero is undefined", func(t *testing.T) {
+		t.Parallel()
+		_, err := PctChange(seriesOf(t, "0", "10"))
+		require.ErrorContains(t, err, "oldest value is zero")
+	})
+}
+
+// TestAggregateFunctions_AcceptWindowOrScalars covers the functions that take
+// either form, including that the two cannot be mixed.
+func TestAggregateFunctions_AcceptWindowOrScalars(t *testing.T) {
+	t.Parallel()
+
+	for name, fn := range map[string]func(...any) (decimal.Decimal, error){
+		"Avg": Avg, "Sum": Sum, "Min": Min, "Max": Max,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			fromWindow, err := fn(seriesOf(t, "10", "20", "30"))
+			require.NoError(t, err)
+			fromScalars, err := fn(10, 20, 30)
+			require.NoError(t, err)
+			assert.True(t, fromWindow.Equal(fromScalars),
+				"window and scalar forms must agree: %s vs %s", fromWindow, fromScalars)
+
+			// Mixing the forms is ambiguous: is the scalar another sample or a
+			// weight? Rejected rather than given a meaning.
+			_, err = fn(seriesOf(t, "10"), 20)
+			require.ErrorContains(t, err, "not both")
+
+			_, err = fn()
+			require.Error(t, err)
+
+			_, err = fn(Series{})
+			require.ErrorContains(t, err, "empty")
+		})
+	}
+
+	avg, err := Avg(seriesOf(t, "10", "20", "30"))
+	require.NoError(t, err)
+	assertDecimal(t, "20", avg)
+
+	sum, err := Sum(seriesOf(t, "10", "20", "30"))
+	require.NoError(t, err)
+	assertDecimal(t, "60", sum)
+
+	min, err := Min(seriesOf(t, "30", "10", "20"))
+	require.NoError(t, err)
+	assertDecimal(t, "10", min)
+
+	max, err := Max(seriesOf(t, "30", "10", "20"))
+	require.NoError(t, err)
+	assertDecimal(t, "30", max)
+}

--- a/llo/protocol/calculated/functions_twap.go
+++ b/llo/protocol/calculated/functions_twap.go
@@ -412,17 +412,22 @@ func twapWindowSeconds(raw any) (int64, error) {
 	}
 	// DivRound rather than Div: Div reads the mutable decimal.DivisionPrecision
 	// global. The division is exact here, but the rule holds everywhere.
-	seconds := nanoseconds.DivRound(perSecond, 0).IntPart()
-	if seconds < 1 {
-		return 0, fmt.Errorf("%w: window must be at least one second, got %d", ErrTWAPConfig, seconds)
+	// Compared and bounded as a decimal, before any narrowing; see decimalToInt.
+	// The upper bound also caps the per-evaluation work: the calculation
+	// allocates and fills one bucket per second of the window.
+	secondsDecimal := nanoseconds.DivRound(perSecond, 0)
+	if secondsDecimal.LessThan(decimal.NewFromInt(1)) {
+		return 0, fmt.Errorf("%w: window must be at least one second, got %s", ErrTWAPConfig, secondsDecimal)
 	}
-	if seconds > twapMaxWindowSeconds {
-		// Bounds the per-evaluation work: the calculation allocates and fills one
-		// bucket per second of the window.
-		return 0, fmt.Errorf("%w: window of %d seconds exceeds the maximum of %d",
-			ErrTWAPConfig, seconds, twapMaxWindowSeconds)
+	if secondsDecimal.GreaterThan(decimal.NewFromInt(twapMaxWindowSeconds)) {
+		return 0, fmt.Errorf("%w: window of %s seconds exceeds the maximum of %d",
+			ErrTWAPConfig, secondsDecimal, twapMaxWindowSeconds)
 	}
-	return seconds, nil
+	seconds, err := decimalToInt("window", secondsDecimal, 1, twapMaxWindowSeconds)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s", ErrTWAPConfig, err)
+	}
+	return int64(seconds), nil
 }
 
 // twapMaxWindowSeconds bounds the number of one-second buckets a single TWAP
@@ -439,12 +444,12 @@ func twapConfigInt(fields map[string]any, key string, minimum int) (int, error) 
 	if err != nil {
 		return 0, fmt.Errorf("%w: %s: %s", ErrTWAPConfig, key, err)
 	}
-	if !d.IsInteger() {
-		return 0, fmt.Errorf("%w: %s must be a whole number of seconds, got %s", ErrTWAPConfig, key, d)
-	}
-	value := int(d.IntPart())
-	if value < minimum {
-		return 0, fmt.Errorf("%w: %s must be at least %d, got %d", ErrTWAPConfig, key, minimum, value)
+	// Bounded as a decimal before narrowing; see decimalToInt. The upper bound
+	// is the window cap, since every one of these counts seconds or samples
+	// inside a window that cannot itself be longer than that.
+	value, err := decimalToInt(key, d, int64(minimum), twapMaxWindowSeconds)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s", ErrTWAPConfig, err)
 	}
 	return value, nil
 }

--- a/llo/protocol/calculated/functions_twap.go
+++ b/llo/protocol/calculated/functions_twap.go
@@ -1,0 +1,450 @@
+package calculated
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// TWAP is ported from the original spec (ADR 0013/0014/0015), semantics are unchanged.
+// It is a port rather than a reuse for two reasons: the source works from decoded
+// values and a clock, while here the input is an already-agreed history window;
+// and the source computes in float64, which is not guaranteed bit-identical
+// across architectures and so cannot appear in a consensus path. Every logarithm,
+// exponential and division below is decimal at a fixed precision.
+var (
+	// ErrTWAPRejected is what every rejection satisfies errors.Is against, so
+	// callers can detect a rejected window without inspecting the reasons.
+	ErrTWAPRejected = errors.New("TWAP window rejected by the acceptance rule")
+
+	// ErrTWAPConfig is returned for a malformed configuration. Configuration is
+	// static, so this is a deployment error rather than a data condition.
+	ErrTWAPConfig = errors.New("invalid TWAP configuration")
+)
+
+// TWAPRejectionReason enumerates why a window failed the acceptance rule. A
+// window can fail several checks at once.
+type TWAPRejectionReason string
+
+const (
+	// ReasonInsufficientSamples: M < minSamples, the coverage floor.
+	ReasonInsufficientSamples TWAPRejectionReason = "min_samples"
+	// ReasonHeadGapTooLong: Ghead > maxHeadGap, backfilled prefix too long.
+	ReasonHeadGapTooLong TWAPRejectionReason = "head_gap_too_long"
+	// ReasonInteriorGapTooLong: Gint > maxInteriorGap, longest both-sides-anchored gap too long.
+	ReasonInteriorGapTooLong TWAPRejectionReason = "interior_gap_too_long"
+	// ReasonTailGapTooLong: Gtail > maxTailGap, carry-forward suffix too long.
+	ReasonTailGapTooLong TWAPRejectionReason = "tail_gap_too_long"
+)
+
+// TWAPRejection carries the measured statistics alongside the thresholds they
+// failed, so an operator can tell a thin window from a stalled feed without
+// reproducing the calculation.
+type TWAPRejection struct {
+	Reasons                                            []TWAPRejectionReason
+	M, Ghead, Gint, Gtail                              int
+	MinSamples, MaxHeadGap, MaxInteriorGap, MaxTailGap int
+	WindowStartSeconds, WindowEndSeconds               int64
+	Records                                            int
+}
+
+func (e *TWAPRejection) Error() string {
+	reasons := make([]string, 0, len(e.Reasons))
+	for _, reason := range e.Reasons {
+		reasons = append(reasons, string(reason))
+	}
+	return fmt.Sprintf("TWAP: window [%d, %d) rejected (%s): M=%d/%d Ghead=%d/%d Gint=%d/%d Gtail=%d/%d from %d records",
+		e.WindowStartSeconds, e.WindowEndSeconds, strings.Join(reasons, ","),
+		e.M, e.MinSamples, e.Ghead, e.MaxHeadGap, e.Gint, e.MaxInteriorGap, e.Gtail, e.MaxTailGap, e.Records)
+}
+
+func (e *TWAPRejection) Is(target error) bool { return target == ErrTWAPRejected }
+
+// twapConfig is the acceptance rule for one window size. Every field is required:
+// a defaulted threshold would silently accept a window an operator never approved.
+type twapConfig struct {
+	windowSeconds  int64
+	minSamples     int
+	maxHeadGap     int
+	maxInteriorGap int
+	maxTailGap     int
+}
+
+// twapBucket is one second of the dense series the specification operates on.
+// price is only meaningful when observed is true.
+//
+// The specification is written in log-price space throughout: build X[i] = ln(P[i]),
+// fill gaps in that space, then average exp of the filled series. This stores the
+// price instead, and moves into log space only where filling actually requires it.
+//
+// That is not a shortcut, it is the same series. For an observed bucket the
+// specification computes exp(ln(P)) = P. For a head gap it backfills the first
+// observed log-price, and for a tail gap it carries the last, so exponentiating
+// those yields that same observed price. Only interior interpolation produces a
+// value that is not already a price.
+//
+// The reason it matters is cost. Filling in log space needs a logarithm per
+// observed bucket and an exponential per bucket in the window — about 600
+// operations for a five-minute window — and they all serialize on the
+// transcendental lock. Measured: 197ms per evaluation for a 300-second window,
+// and 7.2s for 32 such channels in one round, against a round budget on the
+// order of a second. Doing it this way, a fully covered window needs no
+// transcendental operations at all, and a window with gaps needs two logarithms
+// per gap plus one exponential per missing bucket.
+type twapBucket struct {
+	observed bool
+	price    decimal.Decimal
+}
+
+// twapFunc returns the TWAP function bound to a round's consensus observation
+// timestamp, which anchors the window.
+//
+// The anchor has to come from the round rather than from the data: taking it from
+// the newest record would silently shorten the window whenever a feed stalled,
+// which is exactly the condition the acceptance rule exists to catch.
+func twapFunc(observationTimestampNanoseconds uint64) func(any, any) (decimal.Decimal, error) {
+	return func(x any, rawConfig any) (decimal.Decimal, error) {
+		series, err := window("TWAP", x)
+		if err != nil {
+			return decimal.Decimal{}, err
+		}
+		cfg, err := parseTWAPConfig(rawConfig)
+		if err != nil {
+			return decimal.Decimal{}, err
+		}
+		// NOTE: whether the requested history depth can ever supply minSamples
+		// observations is a static property of the configuration, and is checked
+		// at configuration time rather than here. Checking it here would turn a
+		// specification-defined rejection (M < minSamples, a data condition with
+		// diagnostics) into a configuration error, losing the measured
+		// statistics an operator needs.
+		return twap(series, cfg, int64(observationTimestampNanoseconds/uint64(time.Second)))
+	}
+}
+
+// twapUnbound is the default TWAP binding. NewEnv replaces it with a function
+// bound to the round's observation timestamp; reaching this one means TWAP was
+// called against an environment that was not built by NewEnv.
+func twapUnbound(any, any) (decimal.Decimal, error) {
+	return decimal.Decimal{}, errors.New("TWAP has no observation timestamp bound; the environment was not created by NewEnv")
+}
+
+func twap(series Series, cfg twapConfig, anchorSeconds int64) (decimal.Decimal, error) {
+	windowStart := anchorSeconds - cfg.windowSeconds
+	buckets := make([]twapBucket, cfg.windowSeconds)
+
+	values, timestamps := series.Values(), series.Timestamps()
+	for i, ts := range timestamps {
+		seconds := int64(ts / uint64(time.Second))
+		if seconds < windowStart || seconds >= anchorSeconds {
+			continue // outside the half-open window (ADR 0013)
+		}
+		// The price must be positive: the filling rules are defined in log space,
+		// so a non-positive price has no representation there. Checked here for
+		// every observed bucket rather than only where a logarithm is taken, so
+		// acceptance does not depend on where the gaps happen to fall.
+		if !values[i].IsPositive() {
+			return decimal.Decimal{}, fmt.Errorf("TWAP: record %d: price %s must be positive", i, values[i])
+		}
+		// Timestamps are strictly increasing, so a later record legitimately
+		// overwrites an earlier one in the same bucket: newest wins.
+		buckets[seconds-windowStart] = twapBucket{observed: true, price: values[i]}
+	}
+
+	m, gHead, gInt, gTail := twapGapStats(buckets)
+
+	var reasons []TWAPRejectionReason
+	// A floor of 1 observation is required for head backfill to have an anchor.
+	// With a validated minSamples >= 1 this is redundant, but it keeps a
+	// misconfiguration from reaching an out-of-range index below.
+	minSamples := max(cfg.minSamples, 1)
+	if m < minSamples {
+		reasons = append(reasons, ReasonInsufficientSamples)
+	}
+	if gHead > cfg.maxHeadGap {
+		reasons = append(reasons, ReasonHeadGapTooLong)
+	}
+	if gInt > cfg.maxInteriorGap {
+		reasons = append(reasons, ReasonInteriorGapTooLong)
+	}
+	if gTail > cfg.maxTailGap {
+		reasons = append(reasons, ReasonTailGapTooLong)
+	}
+	if len(reasons) > 0 {
+		return decimal.Decimal{}, &TWAPRejection{
+			Reasons: reasons,
+			M:       m, Ghead: gHead, Gint: gInt, Gtail: gTail,
+			MinSamples: cfg.minSamples, MaxHeadGap: cfg.maxHeadGap,
+			MaxInteriorGap: cfg.maxInteriorGap, MaxTailGap: cfg.maxTailGap,
+			WindowStartSeconds: windowStart, WindowEndSeconds: anchorSeconds,
+			Records: series.Len(),
+		}
+	}
+
+	return twapFillThenAverage(buckets)
+}
+
+// twapGapStats measures M, Ghead, Gint and Gtail by classifying each missing run
+// by its position (spec §2, ADR 0015).
+//
+// Ghead and Gtail are kept separate from Gint deliberately: Gint is the
+// both-sides-anchored statistic, and a head or tail run has only one anchor. A
+// run spanning the whole window is classified as none of them because it has no
+// anchors at all; such a window is always rejected by the M check.
+func twapGapStats(buckets []twapBucket) (m, gHead, gInt, gTail int) {
+	n := len(buckets)
+	for i := 0; i < n; {
+		runStart := i
+		observed := buckets[i].observed
+		for i < n && buckets[i].observed == observed {
+			i++
+		}
+		runLen := i - runStart
+
+		if observed {
+			m += runLen
+			continue
+		}
+		switch {
+		case runStart == 0 && i == n:
+			// Entire window missing: no anchors, so not head, tail or interior.
+		case runStart == 0:
+			gHead = runLen
+		case i == n:
+			gTail = runLen
+		default:
+			gInt = max(gInt, runLen)
+		}
+	}
+	return m, gHead, gInt, gTail
+}
+
+// twapFillThenAverage fills every bucket per spec §4 and returns the mean price
+// over the full window.
+//
+// Callers must only reach this once the acceptance rule has passed, which
+// guarantees at least one observation.
+func twapFillThenAverage(buckets []twapBucket) (decimal.Decimal, error) {
+	n := len(buckets)
+	filled := make([]decimal.Decimal, n)
+
+	for i := 0; i < n; {
+		if buckets[i].observed {
+			filled[i] = buckets[i].price // spec §4.1: X[i] passes through
+			i++
+			continue
+		}
+		runStart := i
+		for i < n && !buckets[i].observed {
+			i++
+		}
+		switch {
+		case runStart == 0:
+			// Head gap: backfill the first observed price (ADR 0015).
+			// buckets[i] is observed, because a window with no observation at
+			// all was rejected above.
+			for k := 0; k < i; k++ {
+				filled[k] = buckets[i].price
+			}
+		case i == n:
+			// Tail gap: carry forward the last observed price (spec §4.3).
+			for k := runStart; k < n; k++ {
+				filled[k] = buckets[runStart-1].price
+			}
+		default:
+			// Interior gap: log-linear interpolation between the bracketing
+			// anchors at runStart-1 and i (spec §4.2). This is the only case
+			// that needs log space, so it is the only one that pays for it.
+			if err := twapInterpolate(buckets, filled, runStart, i); err != nil {
+				return decimal.Decimal{}, err
+			}
+		}
+	}
+
+	// TWAP = mean over N (spec §4-5, denominator N not M).
+	sum := decimal.Zero
+	for _, price := range filled {
+		sum = sum.Add(price)
+	}
+	return divRoundByInt(sum, n, precision)
+}
+
+// twapInterpolate fills the missing run [runStart, rightIdx) between its
+// bracketing anchors (spec §4.2).
+//
+// Linear interpolation in log space is geometric interpolation in price space: a
+// gap between 100 and 1600 fills as 200, 400, 800, not as evenly spaced prices.
+// So rather than exponentiating each interpolated log-price, this takes the
+// constant per-second ratio once and steps through the gap by multiplication:
+//
+//	ratio    = (right / left) ^ (1 / span)
+//	filled[k] = filled[k-1] * ratio
+//
+// One power per gap instead of two logarithms plus one exponential per missing
+// bucket. With the spec's example thresholds a window can be missing 60 buckets,
+// which cost ~73ms the other way and a fraction of that here. Exponentials are the
+// expensive operation (~0.5ms each) and reducing their precision only helps by
+// about a factor of two, so cutting their number is the only lever that matters.
+//
+// Determinism: the ratio is computed at a fixed precision and every step is
+// rounded, so the sequence is reproducible — the same requirement EMA has, for the
+// same reason.
+func twapInterpolate(buckets []twapBucket, filled []decimal.Decimal, runStart, rightIdx int) error {
+	leftIdx := runStart - 1
+	left, right := buckets[leftIdx].price, buckets[rightIdx].price
+
+	growth, err := divRound(right, left, doublePrecision)
+	if err != nil {
+		return fmt.Errorf("TWAP: bucket %d: %w", leftIdx, err)
+	}
+	exponent, err := divRoundByInt(decimal.NewFromInt(1), rightIdx-leftIdx, doublePrecision)
+	if err != nil {
+		return err
+	}
+	ratio, err := decimalPow(growth, exponent, doublePrecision)
+	if err != nil {
+		return fmt.Errorf("TWAP: interpolating buckets %d..%d: %w", runStart, rightIdx-1, err)
+	}
+
+	price := left
+	for k := runStart; k < rightIdx; k++ {
+		price = price.Mul(ratio).Round(doublePrecision)
+		filled[k] = price
+	}
+	return nil
+}
+
+// parseTWAPConfig decodes and validates the configuration map.
+//
+// Every key is required and no key is optional: a defaulted threshold would mean
+// accepting a window against a rule nobody wrote down. Unknown keys are rejected
+// too, so a typo fails loudly instead of leaving a threshold at its intended
+// value by accident.
+func parseTWAPConfig(raw any) (twapConfig, error) {
+	fields, ok := raw.(map[string]any)
+	if !ok {
+		return twapConfig{}, fmt.Errorf("%w: expected a configuration map, got %T", ErrTWAPConfig, raw)
+	}
+
+	const (
+		keyWindow         = "window"
+		keyMinSamples     = "minSamples"
+		keyMaxHeadGap     = "maxHeadGap"
+		keyMaxInteriorGap = "maxInteriorGap"
+		keyMaxTailGap     = "maxTailGap"
+	)
+	known := map[string]bool{
+		keyWindow: true, keyMinSamples: true, keyMaxHeadGap: true,
+		keyMaxInteriorGap: true, keyMaxTailGap: true,
+	}
+	unknown := make([]string, 0)
+	for key := range fields {
+		if !known[key] {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return twapConfig{}, fmt.Errorf("%w: unknown keys %s", ErrTWAPConfig, strings.Join(unknown, ", "))
+	}
+
+	windowSeconds, err := twapWindowSeconds(fields[keyWindow])
+	if err != nil {
+		return twapConfig{}, err
+	}
+	minSamples, err := twapConfigInt(fields, keyMinSamples, 1)
+	if err != nil {
+		return twapConfig{}, err
+	}
+	maxHeadGap, err := twapConfigInt(fields, keyMaxHeadGap, 0)
+	if err != nil {
+		return twapConfig{}, err
+	}
+	maxInteriorGap, err := twapConfigInt(fields, keyMaxInteriorGap, 0)
+	if err != nil {
+		return twapConfig{}, err
+	}
+	maxTailGap, err := twapConfigInt(fields, keyMaxTailGap, 0)
+	if err != nil {
+		return twapConfig{}, err
+	}
+
+	if int64(minSamples) > windowSeconds {
+		return twapConfig{}, fmt.Errorf("%w: minSamples %d exceeds the %d one-second buckets in the window",
+			ErrTWAPConfig, minSamples, windowSeconds)
+	}
+
+	return twapConfig{
+		windowSeconds:  windowSeconds,
+		minSamples:     minSamples,
+		maxHeadGap:     maxHeadGap,
+		maxInteriorGap: maxInteriorGap,
+		maxTailGap:     maxTailGap,
+	}, nil
+}
+
+// twapWindowSeconds resolves the window length, which must be a whole number of
+// seconds because the calculation is defined over one-second buckets.
+func twapWindowSeconds(raw any) (int64, error) {
+	if raw == nil {
+		return 0, fmt.Errorf("%w: window is required", ErrTWAPConfig)
+	}
+
+	var nanoseconds decimal.Decimal
+	switch v := raw.(type) {
+	case time.Duration:
+		nanoseconds = decimal.NewFromInt(int64(v))
+	default:
+		d, err := toDecimal(raw)
+		if err != nil {
+			return 0, fmt.Errorf("%w: window: %s", ErrTWAPConfig, err)
+		}
+		nanoseconds = d
+	}
+
+	perSecond := decimal.NewFromInt(int64(time.Second))
+	if !nanoseconds.Mod(perSecond).IsZero() {
+		return 0, fmt.Errorf("%w: window must be a whole number of seconds", ErrTWAPConfig)
+	}
+	// DivRound rather than Div: Div reads the mutable decimal.DivisionPrecision
+	// global. The division is exact here, but the rule holds everywhere.
+	seconds := nanoseconds.DivRound(perSecond, 0).IntPart()
+	if seconds < 1 {
+		return 0, fmt.Errorf("%w: window must be at least one second, got %d", ErrTWAPConfig, seconds)
+	}
+	if seconds > twapMaxWindowSeconds {
+		// Bounds the per-evaluation work: the calculation allocates and fills one
+		// bucket per second of the window.
+		return 0, fmt.Errorf("%w: window of %d seconds exceeds the maximum of %d",
+			ErrTWAPConfig, seconds, twapMaxWindowSeconds)
+	}
+	return seconds, nil
+}
+
+// twapMaxWindowSeconds bounds the number of one-second buckets a single TWAP
+// evaluation may allocate and fill. 24 hours is far beyond any settlement window
+// while keeping the per-round work bounded.
+const twapMaxWindowSeconds = 24 * 60 * 60
+
+func twapConfigInt(fields map[string]any, key string, minimum int) (int, error) {
+	raw, ok := fields[key]
+	if !ok || raw == nil {
+		return 0, fmt.Errorf("%w: %s is required", ErrTWAPConfig, key)
+	}
+	d, err := toDecimal(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s: %s", ErrTWAPConfig, key, err)
+	}
+	if !d.IsInteger() {
+		return 0, fmt.Errorf("%w: %s must be a whole number of seconds, got %s", ErrTWAPConfig, key, d)
+	}
+	value := int(d.IntPart())
+	if value < minimum {
+		return 0, fmt.Errorf("%w: %s must be at least %d, got %d", ErrTWAPConfig, key, minimum, value)
+	}
+	return value, nil
+}

--- a/llo/protocol/calculated/functions_twap_test.go
+++ b/llo/protocol/calculated/functions_twap_test.go
@@ -336,6 +336,29 @@ func TestTWAP_ConfigValidation(t *testing.T) {
 		require.ErrorContains(t, call(cfg), "exceeds the maximum")
 	})
 
+	t.Run("oversized configuration values are rejected, not wrapped", func(t *testing.T) {
+		t.Parallel()
+		// decimal.IntPart narrows through int64 and returns the low 64 bits of
+		// an oversized value, so 2^64+1 comes back as 1. Bounding after that
+		// would silently accept a one-second window or a minSamples of 1. TWAP
+		// configuration is not required to be literal (see checkTWAP), so these
+		// values can come from stream data, bounded only by MaxDecimalExponent.
+		wrapped := decimal.RequireFromString("18446744073709551617")
+
+		cfg := twapConfigMap(3, 1, 0, 0, 0)
+		// A whole number of seconds, so it clears the modulo check first.
+		cfg["window"] = wrapped.Mul(decimal.NewFromInt(int64(time.Second)))
+		require.ErrorContains(t, call(cfg), "exceeds the maximum")
+
+		for _, key := range []string{"minSamples", "maxHeadGap", "maxInteriorGap", "maxTailGap"} {
+			cfg := twapConfigMap(3, 1, 0, 0, 0)
+			cfg[key] = wrapped
+			err := call(cfg)
+			require.ErrorIs(t, err, ErrTWAPConfig, key)
+			require.ErrorContains(t, err, "at most", key)
+		}
+	})
+
 	t.Run("thresholds must be whole and non-negative", func(t *testing.T) {
 		t.Parallel()
 		cfg := twapConfigMap(3, 1, 0, 0, 0)

--- a/llo/protocol/calculated/functions_twap_test.go
+++ b/llo/protocol/calculated/functions_twap_test.go
@@ -1,0 +1,445 @@
+package calculated
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// twapWindowStartSeconds is the arbitrary window start the ported cases use.
+const twapWindowStartSeconds = 100
+
+// twapSeries builds a window from one price per bucket, 0 meaning "no observation
+// in that second". Buckets are one second apart starting at twapWindowStartSeconds.
+//
+// This mirrors the mercury calculator tests, where a report marks exactly one
+// bucket observed.
+func twapSeries(t *testing.T, prices []int64) Series {
+	t.Helper()
+	values := make([]decimal.Decimal, 0, len(prices))
+	timestamps := make([]uint64, 0, len(prices))
+	for i, price := range prices {
+		if price == 0 {
+			continue // missing observation
+		}
+		values = append(values, decimal.NewFromInt(price))
+		timestamps = append(timestamps, uint64(twapWindowStartSeconds+i)*uint64(time.Second))
+	}
+	s, err := NewSeries(values, timestamps)
+	require.NoError(t, err)
+	return s
+}
+
+// twapConfigMap is the configuration as an expression would supply it.
+func twapConfigMap(windowSeconds, minSamples, maxHeadGap, maxInteriorGap, maxTailGap int) map[string]any {
+	return map[string]any{
+		"window":         time.Duration(windowSeconds) * time.Second,
+		"minSamples":     minSamples,
+		"maxHeadGap":     maxHeadGap,
+		"maxInteriorGap": maxInteriorGap,
+		"maxTailGap":     maxTailGap,
+	}
+}
+
+// assertClose compares against a hand-computed value with a tolerance.
+//
+// Exactness is not available here and that is inherent to the algorithm, not a
+// shortcut: the specification fills gaps in log-price space, so every bucket goes
+// through exp(ln(price)). At any finite precision that round trip is not the
+// identity, so a whole-number expectation cannot be matched bit-for-bit. The
+// tolerance is many orders of magnitude tighter than any reporting precision.
+func assertClose(t *testing.T, want string, got decimal.Decimal) {
+	t.Helper()
+	expected, err := decimal.NewFromString(want)
+	require.NoError(t, err)
+
+	const tolerance = "0.000000000001" // 1e-12
+	limit, err := decimal.NewFromString(tolerance)
+	require.NoError(t, err)
+
+	diff := got.Sub(expected).Abs()
+	assert.True(t, diff.LessThanOrEqual(limit),
+		"expected %s (±%s), got %s (off by %s)", want, tolerance, got, diff)
+}
+
+// TestTWAP_FillThenAverage is the mercury TestCalculate_FillThenAverage suite,
+// ported case for case. The expected values are the same, which is the point: the
+// port changed the arithmetic from float64 to decimal, not the semantics.
+func TestTWAP_FillThenAverage(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		prices      []int64 // one entry per bucket; 0 = missing
+		minSamples  int
+		maxHead     int
+		maxInterior int
+		maxTail     int
+		want        string
+		wantReasons []TWAPRejectionReason
+	}{
+		{
+			name:       "no gaps: plain average over the full window",
+			prices:     []int64{100, 200, 300},
+			minSamples: 3,
+			want:       "200",
+		},
+		{
+			name:       "interior gap at the threshold: log-linear interpolated",
+			prices:     []int64{100, 0, 0, 0, 1600}, // Gint=3
+			minSamples: 2, maxInterior: 3,
+			// Interpolating in log space doubles each step: 100,200,400,800,1600.
+			want: "620",
+		},
+		{
+			name:       "interior gap one over the threshold: rejected",
+			prices:     []int64{100, 0, 0, 0, 1600},
+			minSamples: 2, maxInterior: 2,
+			wantReasons: []TWAPRejectionReason{ReasonInteriorGapTooLong},
+		},
+		{
+			name:       "tail gap at the threshold: carried forward from the last observed price",
+			prices:     []int64{100, 200, 300, 0, 0}, // Gtail=2
+			minSamples: 3, maxTail: 2,
+			want: "240",
+		},
+		{
+			name:       "tail gap one over the threshold: rejected",
+			prices:     []int64{100, 200, 300, 0, 0},
+			minSamples: 3, maxTail: 1,
+			wantReasons: []TWAPRejectionReason{ReasonTailGapTooLong},
+		},
+		{
+			name:       "insufficient samples: rejected even though every gap is within its threshold",
+			prices:     []int64{100, 0, 300, 0, 500}, // M=3, Gint=1
+			minSamples: 4, maxInterior: 5, maxTail: 5,
+			wantReasons: []TWAPRejectionReason{ReasonInsufficientSamples},
+		},
+		{
+			name:       "head gap at the threshold: backfilled from the first observed price",
+			prices:     []int64{0, 0, 200, 300, 400}, // Ghead=2
+			minSamples: 3, maxHead: 2,
+			want: "260",
+		},
+		{
+			name:       "head gap one over the threshold: rejected",
+			prices:     []int64{0, 0, 200, 300, 400},
+			minSamples: 3, maxHead: 1,
+			wantReasons: []TWAPRejectionReason{ReasonHeadGapTooLong},
+		},
+		{
+			// Gint is the both-sides-anchored statistic, so a head run must not
+			// count toward it. Ghead=2 while maxInterior is 1: if the head run
+			// leaked into Gint this would reject instead of producing a value.
+			name:       "head run is not counted toward the interior-gap threshold",
+			prices:     []int64{0, 0, 100, 0, 400}, // Ghead=2, Gint=1
+			minSamples: 2, maxHead: 2, maxInterior: 1,
+			want: "180",
+		},
+		{
+			name:       "head and tail gap in the same window, both at their thresholds",
+			prices:     []int64{0, 0, 100, 100, 0, 0}, // Ghead=2, Gtail=2
+			minSamples: 2, maxHead: 2, maxTail: 2,
+			want: "100",
+		},
+		{
+			name:       "multiple applicable reasons are all returned, not just the first",
+			prices:     []int64{100, 0, 0, 0, 0}, // M=1, Gtail=4
+			minSamples: 3, maxInterior: 5, maxTail: 2,
+			wantReasons: []TWAPRejectionReason{ReasonInsufficientSamples, ReasonTailGapTooLong},
+		},
+		{
+			name:       "head and tail reasons are reported alongside insufficient samples",
+			prices:     []int64{0, 0, 0, 100, 0}, // M=1, Ghead=3, Gtail=1
+			minSamples: 3, maxHead: 2,
+			wantReasons: []TWAPRejectionReason{ReasonInsufficientSamples, ReasonHeadGapTooLong, ReasonTailGapTooLong},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			windowSeconds := len(tc.prices)
+			series := twapSeries(t, tc.prices)
+			cfg := twapConfigMap(windowSeconds, tc.minSamples, tc.maxHead, tc.maxInterior, tc.maxTail)
+
+			// The anchor is the exclusive end of the window.
+			anchorNs := uint64(twapWindowStartSeconds+windowSeconds) * uint64(time.Second)
+			got, err := twapFunc(anchorNs)(series, cfg)
+
+			if tc.wantReasons != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrTWAPRejected)
+				var rejection *TWAPRejection
+				require.ErrorAs(t, err, &rejection)
+				assert.Equal(t, tc.wantReasons, rejection.Reasons)
+				return
+			}
+			require.NoError(t, err)
+			assertClose(t, tc.want, got)
+		})
+	}
+}
+
+// TestTWAP_GapStats ports the mercury gap-classification cases. These are the
+// statistics the acceptance rule is written in terms of, so they are worth
+// pinning independently of the averaging.
+func TestTWAP_GapStats(t *testing.T) {
+	t.Parallel()
+
+	// o marks an observed bucket, x a missing one.
+	const o, x = true, false
+
+	for _, tc := range []struct {
+		name                               string
+		observed                           []bool
+		wantM, wantHead, wantInt, wantTail int
+	}{
+		{"all observed", []bool{o, o, o}, 3, 0, 0, 0},
+		{"head gap only", []bool{x, x, o, o, o}, 3, 2, 0, 0},
+		{"tail gap only", []bool{o, o, o, x, x}, 3, 0, 0, 2},
+		{"single interior gap", []bool{o, x, o}, 2, 0, 1, 0},
+		{"head and tail gaps", []bool{x, x, o, x, x}, 1, 2, 0, 2},
+		{"head and interior gaps", []bool{x, o, x, x, o}, 2, 1, 2, 0},
+		{"interior and tail gaps", []bool{o, x, x, x, x}, 1, 0, 0, 4},
+		// No anchors at all, so no run is classified; the M check rejects it.
+		{"no observations", []bool{x, x, x, x, x}, 0, 0, 0, 0},
+		{"single observed bucket", []bool{o}, 1, 0, 0, 0},
+		{"single missing bucket", []bool{x}, 0, 0, 0, 0},
+		{"alternating", []bool{o, x, o, x, o}, 3, 0, 1, 0},
+		{"two interior gaps takes the longest", []bool{o, x, o, x, x, o}, 3, 0, 2, 0},
+		{"three interior gaps increasing", []bool{o, x, o, x, x, o, x, x, x, o}, 4, 0, 3, 0},
+		{"gaps not in order", []bool{o, x, x, x, o, x, o, x, x, o}, 4, 0, 3, 0},
+		{"long head gap", []bool{x, x, x, x, x, o, o}, 2, 5, 0, 0},
+		{"long tail gap", []bool{o, o, x, x, x, x, x}, 2, 0, 0, 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			buckets := make([]twapBucket, len(tc.observed))
+			for i, observed := range tc.observed {
+				buckets[i] = twapBucket{observed: observed, price: decimal.NewFromInt(1)}
+			}
+			m, head, interior, tail := twapGapStats(buckets)
+			assert.Equal(t, tc.wantM, m, "M")
+			assert.Equal(t, tc.wantHead, head, "Ghead")
+			assert.Equal(t, tc.wantInt, interior, "Gint")
+			assert.Equal(t, tc.wantTail, tail, "Gtail")
+		})
+	}
+}
+
+// TestTWAP_HalfOpenWindow covers ADR 0013: the anchor second belongs to the next
+// window, and observations before the window start are dropped.
+func TestTWAP_HalfOpenWindow(t *testing.T) {
+	t.Parallel()
+
+	const windowSeconds = 3
+	anchorSeconds := uint64(twapWindowStartSeconds + windowSeconds)
+	cfg := twapConfigMap(windowSeconds, 1, windowSeconds, windowSeconds, windowSeconds)
+
+	// An observation exactly at the anchor is excluded, leaving the window empty.
+	series, err := NewSeries(
+		[]decimal.Decimal{decimal.NewFromInt(100)},
+		[]uint64{anchorSeconds * uint64(time.Second)},
+	)
+	require.NoError(t, err)
+	_, err = twapFunc(anchorSeconds*uint64(time.Second))(series, cfg)
+	require.ErrorIs(t, err, ErrTWAPRejected, "the anchor second belongs to the next window")
+
+	// One second earlier is inside the window.
+	series, err = NewSeries(
+		[]decimal.Decimal{decimal.NewFromInt(100)},
+		[]uint64{(anchorSeconds - 1) * uint64(time.Second)},
+	)
+	require.NoError(t, err)
+	got, err := twapFunc(anchorSeconds*uint64(time.Second))(series, cfg)
+	require.NoError(t, err)
+	assertClose(t, "100", got)
+
+	// An observation before the window start is dropped, so only the in-window
+	// one counts.
+	series, err = NewSeries(
+		[]decimal.Decimal{decimal.NewFromInt(999), decimal.NewFromInt(100)},
+		[]uint64{(twapWindowStartSeconds - 5) * uint64(time.Second), (anchorSeconds - 1) * uint64(time.Second)},
+	)
+	require.NoError(t, err)
+	got, err = twapFunc(anchorSeconds*uint64(time.Second))(series, cfg)
+	require.NoError(t, err)
+	assertClose(t, "100", got)
+}
+
+// TestTWAP_Deterministic is the property that makes TWAP usable in a consensus
+// path: identical inputs give an identical result, with no float64 anywhere.
+func TestTWAP_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	prices := []int64{1234, 0, 1240, 1250, 0, 0, 1300, 1310}
+	series := twapSeries(t, prices)
+	cfg := twapConfigMap(len(prices), 3, 2, 2, 2)
+	anchorNs := uint64(twapWindowStartSeconds+len(prices)) * uint64(time.Second)
+
+	first, err := twapFunc(anchorNs)(series, cfg)
+	require.NoError(t, err)
+	for range 30 {
+		again, err := twapFunc(anchorNs)(series, cfg)
+		require.NoError(t, err)
+		require.True(t, first.Equal(again), "TWAP drifted: %s vs %s", first, again)
+	}
+}
+
+func TestTWAP_ConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	series := twapSeries(t, []int64{100, 200, 300})
+	anchorNs := uint64(twapWindowStartSeconds+3) * uint64(time.Second)
+	call := func(cfg any) error {
+		_, err := twapFunc(anchorNs)(series, cfg)
+		return err
+	}
+
+	t.Run("every key is required", func(t *testing.T) {
+		t.Parallel()
+		// A defaulted threshold would mean accepting a window against a rule
+		// nobody wrote down.
+		for _, missing := range []string{"window", "minSamples", "maxHeadGap", "maxInteriorGap", "maxTailGap"} {
+			cfg := twapConfigMap(3, 1, 0, 0, 0)
+			delete(cfg, missing)
+			err := call(cfg)
+			require.ErrorIs(t, err, ErrTWAPConfig, "missing %s", missing)
+			require.ErrorContains(t, err, missing)
+		}
+	})
+
+	t.Run("unknown keys are rejected", func(t *testing.T) {
+		t.Parallel()
+		cfg := twapConfigMap(3, 1, 0, 0, 0)
+		cfg["maxHeadGapp"] = 1
+		err := call(cfg)
+		require.ErrorIs(t, err, ErrTWAPConfig)
+		require.ErrorContains(t, err, "maxHeadGapp")
+	})
+
+	t.Run("window must be whole seconds and positive", func(t *testing.T) {
+		t.Parallel()
+		cfg := twapConfigMap(3, 1, 0, 0, 0)
+		cfg["window"] = 1500 * time.Millisecond
+		require.ErrorContains(t, call(cfg), "whole number of seconds")
+
+		cfg["window"] = time.Duration(0)
+		require.ErrorContains(t, call(cfg), "at least one second")
+
+		cfg["window"] = 48 * time.Hour
+		require.ErrorContains(t, call(cfg), "exceeds the maximum")
+	})
+
+	t.Run("thresholds must be whole and non-negative", func(t *testing.T) {
+		t.Parallel()
+		cfg := twapConfigMap(3, 1, 0, 0, 0)
+		cfg["maxHeadGap"] = -1
+		require.ErrorContains(t, call(cfg), "at least 0")
+
+		cfg = twapConfigMap(3, 1, 0, 0, 0)
+		cfg["minSamples"] = 0
+		require.ErrorContains(t, call(cfg), "at least 1")
+
+		cfg = twapConfigMap(3, 1, 0, 0, 0)
+		cfg["maxTailGap"] = 1.5
+		require.ErrorContains(t, call(cfg), "whole number")
+	})
+
+	t.Run("minSamples cannot exceed the window", func(t *testing.T) {
+		t.Parallel()
+		require.ErrorContains(t, call(twapConfigMap(3, 4, 0, 0, 0)), "exceeds the")
+	})
+
+	t.Run("a window too thin to satisfy minSamples is a rejection, not a config error", func(t *testing.T) {
+		t.Parallel()
+		// Whether the requested depth can ever supply minSamples is a static
+		// property checked at configuration time. At runtime a thin window is a
+		// data condition, and must come back with the measured statistics.
+		shallow := twapSeries(t, []int64{100})
+		_, err := twapFunc(anchorNs)(shallow, twapConfigMap(3, 3, 0, 2, 2))
+		require.ErrorIs(t, err, ErrTWAPRejected)
+		var rejection *TWAPRejection
+		require.ErrorAs(t, err, &rejection)
+		assert.Equal(t, []TWAPRejectionReason{ReasonInsufficientSamples}, rejection.Reasons)
+	})
+
+	t.Run("not a configuration map", func(t *testing.T) {
+		t.Parallel()
+		require.ErrorIs(t, call(42), ErrTWAPConfig)
+	})
+
+	t.Run("not a window", func(t *testing.T) {
+		t.Parallel()
+		_, err := twapFunc(anchorNs)(decimal.NewFromInt(1), twapConfigMap(3, 1, 0, 0, 0))
+		require.ErrorContains(t, err, "expects a history window")
+	})
+}
+
+// TestTWAP_NonPositivePriceRejected covers the log-space requirement: a
+// non-positive price has no logarithm, so the window cannot be filled.
+func TestTWAP_NonPositivePriceRejected(t *testing.T) {
+	t.Parallel()
+
+	series, err := NewSeries(
+		[]decimal.Decimal{decimal.NewFromInt(100), decimal.Zero},
+		[]uint64{twapWindowStartSeconds * uint64(time.Second), (twapWindowStartSeconds + 1) * uint64(time.Second)},
+	)
+	require.NoError(t, err)
+
+	anchorNs := uint64(twapWindowStartSeconds+3) * uint64(time.Second)
+	_, err = twapFunc(anchorNs)(series, twapConfigMap(3, 1, 2, 2, 2))
+	require.ErrorContains(t, err, "must be positive")
+}
+
+// TestTWAP_Unbound covers the patch-bypass equivalent for TWAP: without a round
+// to anchor the window, it must refuse rather than invent one.
+func TestTWAP_Unbound(t *testing.T) {
+	t.Parallel()
+
+	_, err := twapUnbound(nil, nil)
+	require.ErrorContains(t, err, "no observation timestamp bound")
+
+	// A pooled environment always carries a bound TWAP; release restores the
+	// unbound default.
+	env := NewEnv(uint64(5 * time.Second))
+	bound, ok := env["TWAP"].(func(any, any) (decimal.Decimal, error))
+	require.True(t, ok, "NewEnv must bind TWAP to the round")
+	env.release()
+
+	series := twapSeries(t, []int64{100, 200, 300})
+	_, err = bound(series, twapConfigMap(3, 1, 0, 0, 0))
+	require.Error(t, err, "the round anchor is 5s, so the window is far from these observations")
+}
+
+// TestTWAP_RejectionMessage checks an operator can tell what failed without
+// reproducing the calculation.
+func TestTWAP_RejectionMessage(t *testing.T) {
+	t.Parallel()
+
+	prices := []int64{100, 0, 0, 0, 0}
+	series := twapSeries(t, prices)
+	anchorNs := uint64(twapWindowStartSeconds+len(prices)) * uint64(time.Second)
+
+	_, err := twapFunc(anchorNs)(series, twapConfigMap(len(prices), 3, 0, 5, 2))
+	require.Error(t, err)
+
+	var rejection *TWAPRejection
+	require.ErrorAs(t, err, &rejection)
+	assert.Equal(t, 1, rejection.M)
+	assert.Equal(t, 4, rejection.Gtail)
+	assert.Equal(t, 3, rejection.MinSamples)
+	assert.Equal(t, 2, rejection.MaxTailGap)
+
+	message := err.Error()
+	for _, want := range []string{"min_samples", "tail_gap_too_long", "M=1/3", "Gtail=4/2"} {
+		assert.Contains(t, message, want)
+	}
+	assert.True(t, errors.Is(err, ErrTWAPRejected))
+	assert.Contains(t, fmt.Sprint(err), "rejected")
+}

--- a/llo/protocol/calculated/history_ast.go
+++ b/llo/protocol/calculated/history_ast.go
@@ -1,0 +1,476 @@
+package calculated
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+
+	"github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/parser"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+// HistoryFunctionName is the DSL form that declares and reads a window of a
+// stream's past agreed values:
+//
+//	History(s10001, 600)
+//
+// It is a compile-time form, not a runtime function. The AST is rewritten so
+// each call becomes a plain identifier bound to the loaded window, for two
+// reasons:
+//
+//  1. The requested depth must be known before evaluation, because it is what
+//     tells the plugin how much history to keep. A depth discovered at run time
+//     is discovered a round too late.
+//  2. A stream identifier passed as an argument would resolve through the
+//     environment to a scalar, so the function body would receive a single
+//     number rather than a reference to the stream.
+//
+// Both arguments must therefore be literal: a bare stream identifier and an
+// integer.
+const HistoryFunctionName = "History"
+
+// twapFunctionName is the DSL name TWAP is registered under, shared with the
+// static analysis that validates its configuration.
+const twapFunctionName = "TWAP"
+
+// Field selects which part of a stored stream value a window projects. One
+// stored window serves every field, so History(s1, 10), History(s1_bid, 10) and
+// History(s1_ask, 10) share a single series in state and differ only here.
+//
+// NOTE: Field lives in this file rather than with Series because the AST pass is
+// what parses field suffixes and it must not depend on the evaluation types.
+type Field uint8
+
+const (
+	FieldValue Field = iota
+	FieldBid
+	FieldAsk
+	FieldBenchmark
+)
+
+// suffix returns the stream identifier suffix that selects this field.
+func (f Field) suffix() string {
+	switch f {
+	case FieldBid:
+		return "_bid"
+	case FieldAsk:
+		return "_ask"
+	case FieldBenchmark:
+		return "_benchmark"
+	default:
+		return ""
+	}
+}
+
+func (f Field) String() string {
+	if s := f.suffix(); s != "" {
+		return s[1:]
+	}
+	return "value"
+}
+
+func fieldFromSuffix(suffix string) (Field, bool) {
+	switch suffix {
+	case "":
+		return FieldValue, true
+	case "bid":
+		return FieldBid, true
+	case "ask":
+		return FieldAsk, true
+	case "benchmark":
+		return FieldBenchmark, true
+	default:
+		return FieldValue, false
+	}
+}
+
+// HistoryRef is one History call recovered from an expression: which stream and
+// field it reads, and how deep. It is both the read and the declaration — the
+// plugin derives the depth it must persist per stream from these.
+type HistoryRef struct {
+	StreamID llotypes.StreamID
+	Field    Field
+	Count    uint32
+}
+
+// envName is the identifier a History call is rewritten to. The name is
+// generated from the recovered reference so the declaration and the binding
+// cannot drift apart.
+func (r HistoryRef) envName() string {
+	return fmt.Sprintf("s%d%s__h%d", r.StreamID, r.Field.suffix(), r.Count)
+}
+
+func (r HistoryRef) String() string {
+	return fmt.Sprintf("History(s%d%s, %d)", r.StreamID, r.Field.suffix(), r.Count)
+}
+
+var (
+	// historyStreamArg matches the first argument of a History call. It is
+	// anchored, unlike streamMatch, because here the whole argument must be a
+	// stream identifier and nothing else.
+	historyStreamArg = regexp.MustCompile(`^s(\d+)(?:_(bid|ask|benchmark|timestamp))?$`)
+
+	// reservedHistoryName matches the identifier namespace this pass generates.
+	// Expressions may not use it directly: allowing that would let a source
+	// identifier impersonate a window binding that was never declared, and so
+	// never persisted.
+	reservedHistoryName = regexp.MustCompile(`__h\d+$`)
+
+	// rangeAcceptingFunctions are the functions a window may be passed to.
+	// Anything else — arithmetic, comparisons — takes scalars, so passing a
+	// window to one is a mistake worth catching at compile time rather than at
+	// evaluation.
+	//
+	// Some of these are implemented in a later phase; naming them here is
+	// deliberate, since an unimplemented function fails loudly at compile time
+	// with "unknown name" rather than silently accepting a window.
+	rangeAcceptingFunctions = map[string]bool{
+		"Avg":       true,
+		"Sum":       true,
+		"Min":       true,
+		"Max":       true,
+		"Count":     true,
+		"First":     true,
+		"Last":      true,
+		"Median":    true,
+		"Variance":  true,
+		"Stddev":    true,
+		"Delta":     true,
+		"PctChange": true,
+		"Spread":    true,
+		"SMA":       true,
+		"WMA":       true,
+		"EMA":       true,
+		"TWAP":      true,
+	}
+)
+
+// ErrHistoryExpression is returned for any expression that misuses History. It
+// is a static error: the expression is rejected at configuration time and at
+// compile time, never accepted and left to fail during evaluation.
+var ErrHistoryExpression = errors.New("invalid History expression")
+
+// historyPatcher rewrites History calls into window identifiers, recording what
+// it found. It satisfies ast.Visitor so it can be used both standalone, to
+// analyze an expression without compiling it, and as an expr.Patch option during
+// compilation. Using one implementation for both means the depth the plugin
+// persists and the identifier the program reads can never disagree.
+//
+// A patcher is single-use and not safe for concurrent use: it accumulates state
+// for one expression.
+type historyPatcher struct {
+	refs []HistoryRef
+	errs []error
+
+	// generated holds the identifier nodes this pass created, so position
+	// validation can recognise them by identity rather than by name. Identity
+	// matters because the same window may legitimately appear more than once in
+	// an expression, and each occurrence must be checked on its own.
+	generated map[ast.Node]bool
+	// approved holds the generated nodes found in a valid position.
+	approved map[ast.Node]bool
+	// refByNode maps each generated identifier back to what it was generated
+	// from, so a consuming call can be checked against the depth it will get.
+	refByNode map[ast.Node]HistoryRef
+
+	fanOut uint64
+}
+
+func newHistoryPatcher() *historyPatcher {
+	return &historyPatcher{
+		generated: map[ast.Node]bool{},
+		approved:  map[ast.Node]bool{},
+		refByNode: map[ast.Node]HistoryRef{},
+	}
+}
+
+// Visit implements ast.Visitor.
+//
+// ast.Walk is post-order, so a node's children are visited before the node
+// itself. Two consequences the logic here depends on:
+//
+//   - By the time a call is visited, any History calls among its arguments have
+//     already been rewritten into identifiers. Position checking therefore looks
+//     for generated identifiers, not for nested calls.
+//   - Nodes this pass creates are never visited, so every identifier reaching
+//     Visit came from the source. That is what makes the reserved-namespace
+//     check meaningful.
+func (p *historyPatcher) Visit(node *ast.Node) {
+	switch n := (*node).(type) {
+	case *ast.IdentifierNode:
+		if reservedHistoryName.MatchString(n.Value) {
+			p.errorf("identifier %q uses the reserved history namespace (__h<N>); use %s(s<streamID>, <N>) instead", n.Value, HistoryFunctionName)
+		}
+
+	case *ast.CallNode:
+		callee, ok := n.Callee.(*ast.IdentifierNode)
+		if !ok {
+			return
+		}
+		if callee.Value == HistoryFunctionName {
+			p.rewrite(node, n)
+			return
+		}
+		if rangeAcceptingFunctions[callee.Value] {
+			for _, arg := range n.Arguments {
+				if p.generated[arg] {
+					p.approved[arg] = true
+				}
+			}
+			if callee.Value == twapFunctionName {
+				p.checkTWAP(n)
+			}
+		}
+	}
+}
+
+// rewrite validates one History call and replaces it with its window
+// identifier. On any validation failure the node is left untouched so the error
+// is reported rather than a bad binding being introduced.
+func (p *historyPatcher) rewrite(node *ast.Node, call *ast.CallNode) {
+	if len(call.Arguments) != 2 {
+		p.errorf("%s takes exactly 2 arguments (stream identifier, depth), got %d", HistoryFunctionName, len(call.Arguments))
+		return
+	}
+
+	streamArg, ok := call.Arguments[0].(*ast.IdentifierNode)
+	if !ok {
+		p.errorf("%s: first argument must be a stream identifier such as s10001, got %s", HistoryFunctionName, describeNode(call.Arguments[0]))
+		return
+	}
+	match := historyStreamArg.FindStringSubmatch(streamArg.Value)
+	if match == nil {
+		p.errorf("%s: first argument %q is not a stream identifier", HistoryFunctionName, streamArg.Value)
+		return
+	}
+	if match[2] == "timestamp" {
+		p.errorf("%s: _timestamp is not available as a window; timestamps travel inside the window itself", HistoryFunctionName)
+		return
+	}
+	field, ok := fieldFromSuffix(match[2])
+	if !ok {
+		p.errorf("%s: unsupported stream field %q", HistoryFunctionName, match[2])
+		return
+	}
+	streamID, err := strconv.ParseUint(match[1], 10, 32)
+	if err != nil {
+		p.errorf("%s: stream ID %q is out of range: %s", HistoryFunctionName, match[1], err)
+		return
+	}
+
+	depthArg, ok := call.Arguments[1].(*ast.IntegerNode)
+	if !ok {
+		// Anything computed is rejected: the depth has to be known before
+		// evaluation, so it cannot depend on a value.
+		p.errorf("%s: depth must be an integer literal, got %s", HistoryFunctionName, describeNode(call.Arguments[1]))
+		return
+	}
+	if depthArg.Value < 1 {
+		p.errorf("%s: depth must be at least 1, got %d", HistoryFunctionName, depthArg.Value)
+		return
+	}
+	if depthArg.Value > protocol.MaxHistoryRecordsPerPair {
+		p.errorf("%s: depth %d exceeds the maximum of %d", HistoryFunctionName, depthArg.Value, protocol.MaxHistoryRecordsPerPair)
+		return
+	}
+
+	p.fanOut += uint64(depthArg.Value)
+	if p.fanOut > protocol.MaxHistoryRecordsPerExpression {
+		p.errorf("total history depth %d across the expression exceeds the maximum of %d", p.fanOut, protocol.MaxHistoryRecordsPerExpression)
+		return
+	}
+
+	ref := HistoryRef{
+		StreamID: llotypes.StreamID(streamID),
+		Field:    field,
+		Count:    uint32(depthArg.Value),
+	}
+	p.refs = append(p.refs, ref)
+
+	generated := &ast.IdentifierNode{Value: ref.envName()}
+	ast.Patch(node, generated)
+	p.generated[*node] = true
+	p.refByNode[*node] = ref
+}
+
+// checkTWAP validates a TWAP call against the depth of the window it reads.
+//
+// This is the static half of TWAP validation: whether a configuration can ever be
+// satisfied is a property of the expression, so it belongs here rather than at
+// evaluation time, where the same condition would surface as a per-round
+// rejection and look like a data problem instead of a deployment mistake.
+//
+// Only literal configuration can be checked. A configuration built at runtime is
+// left to the runtime validation in functions_twap.go, which is stricter but
+// later.
+func (p *historyPatcher) checkTWAP(call *ast.CallNode) {
+	if len(call.Arguments) != 2 {
+		p.errorf("%s takes exactly 2 arguments (history window, configuration), got %d", twapFunctionName, len(call.Arguments))
+		return
+	}
+	ref, ok := p.refByNode[call.Arguments[0]]
+	if !ok {
+		// Not reading a window at all; the position rule reports that.
+		return
+	}
+	config, ok := call.Arguments[1].(*ast.MapNode)
+	if !ok {
+		return // not a literal configuration
+	}
+
+	minSamples, found := twapConfigLiteral(config, "minSamples")
+	if !found {
+		return
+	}
+	if uint32(minSamples) > ref.Count {
+		p.errorf("%s requires at least %d observations but %s only keeps %d records; increase the history depth or lower minSamples",
+			twapFunctionName, minSamples, ref, ref.Count)
+	}
+}
+
+// twapConfigLiteral reads an integer-literal value out of a configuration map
+// literal, reporting whether it was present and literal.
+func twapConfigLiteral(config *ast.MapNode, key string) (int64, bool) {
+	for _, pair := range config.Pairs {
+		kv, ok := pair.(*ast.PairNode)
+		if !ok {
+			continue
+		}
+		name, ok := kv.Key.(*ast.StringNode)
+		if !ok || name.Value != key {
+			continue
+		}
+		value, ok := kv.Value.(*ast.IntegerNode)
+		if !ok {
+			return 0, false
+		}
+		return int64(value.Value), true
+	}
+	return 0, false
+}
+
+// err reports every problem found, including windows left in a position that
+// cannot consume them.
+//
+// The position rule is what turns a confusing evaluation-time failure into a
+// configuration-time one: Add(History(s101, 10), 2) is meaningless, and saying
+// so at compile time is far better than letting it reach a node and fail inside
+// scalar conversion.
+func (p *historyPatcher) err() error {
+	errs := p.errs
+	for node := range p.generated {
+		if p.approved[node] {
+			continue
+		}
+		name := "window"
+		if id, ok := node.(*ast.IdentifierNode); ok {
+			name = id.Value
+		}
+		errs = append(errs, fmt.Errorf("%s must be passed directly to one of %v; %s cannot be used as a scalar",
+			HistoryFunctionName, sortedRangeAcceptingFunctions(), name))
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	// Sorted so the same expression always produces the same message: these
+	// errors reach configuration tooling, and unstable ordering there is noise.
+	msgs := make([]string, 0, len(errs))
+	for _, err := range errs {
+		msgs = append(msgs, err.Error())
+	}
+	sort.Strings(msgs)
+	joined := make([]error, 0, len(msgs))
+	for _, msg := range msgs {
+		joined = append(joined, errors.New(msg))
+	}
+	return fmt.Errorf("%w: %w", ErrHistoryExpression, errors.Join(joined...))
+}
+
+func (p *historyPatcher) errorf(format string, args ...any) {
+	p.errs = append(p.errs, fmt.Errorf(format, args...))
+}
+
+// sortedRefs returns the recovered references deduplicated and in a
+// deterministic order, so callers deriving persisted state from them agree
+// across nodes.
+func (p *historyPatcher) sortedRefs() []HistoryRef {
+	if len(p.refs) == 0 {
+		return nil
+	}
+	seen := make(map[HistoryRef]bool, len(p.refs))
+	refs := make([]HistoryRef, 0, len(p.refs))
+	for _, ref := range p.refs {
+		if seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		refs = append(refs, ref)
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].StreamID != refs[j].StreamID {
+			return refs[i].StreamID < refs[j].StreamID
+		}
+		if refs[i].Field != refs[j].Field {
+			return refs[i].Field < refs[j].Field
+		}
+		return refs[i].Count < refs[j].Count
+	})
+	return refs
+}
+
+// analyzeHistoryExpression parses an expression and recovers its History
+// references without compiling it. It is a pure function of the expression
+// string, which is what lets every node derive the same required depths from
+// replicated channel definitions.
+//
+// An expression with no History calls returns no references and no error.
+func analyzeHistoryExpression(expression string) ([]HistoryRef, error) {
+	tree, err := parser.Parse(expression)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to parse expression: %s", ErrHistoryExpression, err)
+	}
+
+	p := newHistoryPatcher()
+	ast.Walk(&tree.Node, p)
+	if err := p.err(); err != nil {
+		return nil, err
+	}
+	return p.sortedRefs(), nil
+}
+
+func describeNode(node ast.Node) string {
+	switch n := node.(type) {
+	case *ast.IdentifierNode:
+		return fmt.Sprintf("identifier %q", n.Value)
+	case *ast.CallNode:
+		if callee, ok := n.Callee.(*ast.IdentifierNode); ok {
+			return fmt.Sprintf("call to %s", callee.Value)
+		}
+		return "call"
+	case *ast.StringNode:
+		return fmt.Sprintf("string %q", n.Value)
+	case *ast.FloatNode:
+		return fmt.Sprintf("float %v", n.Value)
+	case *ast.BinaryNode:
+		return fmt.Sprintf("expression %q", n.String())
+	case nil:
+		return "nothing"
+	default:
+		return fmt.Sprintf("%s", node.String())
+	}
+}
+
+func sortedRangeAcceptingFunctions() []string {
+	names := make([]string, 0, len(rangeAcceptingFunctions))
+	for name := range rangeAcceptingFunctions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/llo/protocol/calculated/history_ast.go
+++ b/llo/protocol/calculated/history_ast.go
@@ -328,7 +328,16 @@ func (p *historyPatcher) checkTWAP(call *ast.CallNode) {
 	if !found {
 		return
 	}
-	if uint32(minSamples) > ref.Count {
+	// Compared as int64: minSamples is a literal and can be any integer the
+	// parser accepted, so narrowing it to the width of ref.Count would let a
+	// value above 2^32 wrap into a small one and pass. The runtime validation
+	// still rejects it, but the diagnostic this check exists to give would be
+	// lost.
+	if minSamples < 1 {
+		p.errorf("%s requires minSamples to be at least 1, got %d", twapFunctionName, minSamples)
+		return
+	}
+	if minSamples > int64(ref.Count) {
 		p.errorf("%s requires at least %d observations but %s only keeps %d records; increase the history depth or lower minSamples",
 			twapFunctionName, minSamples, ref, ref.Count)
 	}

--- a/llo/protocol/calculated/history_ast_test.go
+++ b/llo/protocol/calculated/history_ast_test.go
@@ -484,3 +484,14 @@ func TestFieldFromSuffix(t *testing.T) {
 	_, ok := fieldFromSuffix("timestamp")
 	assert.False(t, ok, "timestamp must not map to a field")
 }
+
+// TestRangeAcceptingFunctionsAreRegistered keeps the static-analysis list and the
+// environment in agreement. A name in one and not the other means an expression
+// either fails to compile or is rejected as misusing a window.
+func TestRangeAcceptingFunctionsAreRegistered(t *testing.T) {
+	t.Parallel()
+
+	for name := range rangeAcceptingFunctions {
+		assert.Contains(t, defaultEnv, name, "%s accepts a window but is not registered", name)
+	}
+}

--- a/llo/protocol/calculated/history_ast_test.go
+++ b/llo/protocol/calculated/history_ast_test.go
@@ -1,0 +1,486 @@
+package calculated
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/parser"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+func TestHistoryRef_EnvName(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		ref  HistoryRef
+		want string
+	}{
+		{HistoryRef{StreamID: 10001, Field: FieldValue, Count: 10}, "s10001__h10"},
+		{HistoryRef{StreamID: 10001, Field: FieldBid, Count: 300}, "s10001_bid__h300"},
+		{HistoryRef{StreamID: 1, Field: FieldAsk, Count: 1}, "s1_ask__h1"},
+		{HistoryRef{StreamID: 7, Field: FieldBenchmark, Count: 1024}, "s7_benchmark__h1024"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.ref.envName())
+			// Every generated name must land in the reserved namespace, or the
+			// spoofing check would not cover it.
+			assert.Regexp(t, reservedHistoryName, tc.ref.envName())
+		})
+	}
+}
+
+func TestAnalyzeHistoryExpression_Accepts(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		expression string
+		want       []HistoryRef
+	}{
+		"no history at all": {
+			expression: "Add(s1, s2)",
+			want:       nil,
+		},
+		"single window": {
+			expression: "Avg(History(s10001, 10))",
+			want:       []HistoryRef{{StreamID: 10001, Field: FieldValue, Count: 10}},
+		},
+		"bid field": {
+			expression: "Avg(History(s10001_bid, 300))",
+			want:       []HistoryRef{{StreamID: 10001, Field: FieldBid, Count: 300}},
+		},
+		"ask field": {
+			expression: "Avg(History(s10001_ask, 5))",
+			want:       []HistoryRef{{StreamID: 10001, Field: FieldAsk, Count: 5}},
+		},
+		"benchmark field": {
+			expression: "Avg(History(s10001_benchmark, 5))",
+			want:       []HistoryRef{{StreamID: 10001, Field: FieldBenchmark, Count: 5}},
+		},
+		"mixed with scalars": {
+			expression: "Div(Avg(History(s1, 10)), s2)",
+			want:       []HistoryRef{{StreamID: 1, Field: FieldValue, Count: 10}},
+		},
+		"deduplicated and sorted": {
+			expression: "Add(Avg(History(s7, 10)), Add(Avg(History(s1, 20)), Avg(History(s7, 10))))",
+			want: []HistoryRef{
+				{StreamID: 1, Field: FieldValue, Count: 20},
+				{StreamID: 7, Field: FieldValue, Count: 10},
+			},
+		},
+		"same stream different depths": {
+			expression: "Add(Avg(History(s1, 10)), Avg(History(s1, 20)))",
+			want: []HistoryRef{
+				{StreamID: 1, Field: FieldValue, Count: 10},
+				{StreamID: 1, Field: FieldValue, Count: 20},
+			},
+		},
+		"same stream different fields": {
+			expression: "Add(Avg(History(s1_ask, 10)), Avg(History(s1_bid, 10)))",
+			want: []HistoryRef{
+				{StreamID: 1, Field: FieldBid, Count: 10},
+				{StreamID: 1, Field: FieldAsk, Count: 10},
+			},
+		},
+		"depth at the cap": {
+			expression: fmt.Sprintf("Avg(History(s1, %d))", protocol.MaxHistoryRecordsPerPair),
+			want:       []HistoryRef{{StreamID: 1, Field: FieldValue, Count: protocol.MaxHistoryRecordsPerPair}},
+		},
+		"minimum depth": {
+			expression: "Avg(History(s1, 1))",
+			want:       []HistoryRef{{StreamID: 1, Field: FieldValue, Count: 1}},
+		},
+		// The case a text-level rewriter gets wrong: only the parser knows this
+		// is a string, not a call.
+		"history inside a string literal is not a call": {
+			expression: `Duration('History(s1, 10)')`,
+			want:       nil,
+		},
+		"scalar stream sharing the ranged stream id": {
+			expression: "Div(Avg(History(s1, 10)), s1)",
+			want:       []HistoryRef{{StreamID: 1, Field: FieldValue, Count: 10}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			refs, err := analyzeHistoryExpression(tc.expression)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, refs)
+		})
+	}
+}
+
+func TestAnalyzeHistoryExpression_Rejects(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		expression string
+		wantErr    string
+	}{
+		"depth is an identifier": {
+			expression: "Avg(History(s1, n))",
+			wantErr:    "depth must be an integer literal",
+		},
+		"depth is computed": {
+			expression: "Avg(History(s1, 10 + 2))",
+			wantErr:    "depth must be an integer literal",
+		},
+		"depth is a float": {
+			expression: "Avg(History(s1, 10.5))",
+			wantErr:    "depth must be an integer literal",
+		},
+		"depth is a string": {
+			expression: `Avg(History(s1, '10'))`,
+			wantErr:    "depth must be an integer literal",
+		},
+		"depth is zero": {
+			expression: "Avg(History(s1, 0))",
+			wantErr:    "depth must be at least 1",
+		},
+		"depth is negative": {
+			// Parsed as a unary minus over an integer, so it is not an integer
+			// literal node at all.
+			expression: "Avg(History(s1, -5))",
+			wantErr:    "depth must be an integer literal",
+		},
+		"depth over the cap": {
+			expression: fmt.Sprintf("Avg(History(s1, %d))", protocol.MaxHistoryRecordsPerPair+1),
+			wantErr:    "exceeds the maximum",
+		},
+		"stream argument is a call": {
+			expression: "Avg(History(Avg(s1, s2), 10))",
+			wantErr:    "first argument must be a stream identifier",
+		},
+		"stream argument is an expression": {
+			expression: "Avg(History(s1 + s2, 10))",
+			wantErr:    "first argument must be a stream identifier",
+		},
+		"stream argument is a string": {
+			expression: `Avg(History('s1', 10))`,
+			wantErr:    "first argument must be a stream identifier",
+		},
+		"stream argument is not a stream": {
+			expression: "Avg(History(notAStream, 10))",
+			wantErr:    "is not a stream identifier",
+		},
+		"timestamp field is not rangeable": {
+			expression: "Avg(History(s1_timestamp, 10))",
+			wantErr:    "_timestamp is not available as a window",
+		},
+		"too few arguments": {
+			expression: "Avg(History(s1))",
+			wantErr:    "takes exactly 2 arguments",
+		},
+		"too many arguments": {
+			expression: "Avg(History(s1, 10, 20))",
+			wantErr:    "takes exactly 2 arguments",
+		},
+		"no arguments": {
+			expression: "Avg(History())",
+			wantErr:    "takes exactly 2 arguments",
+		},
+		// The inner call is rewritten first (ast.Walk is post-order), so the
+		// outer call sees a window identifier where it requires a stream.
+		"nested history": {
+			expression: "Avg(History(History(s1, 10), 10))",
+			wantErr:    "is not a stream identifier",
+		},
+		"scalar position": {
+			expression: "Add(History(s1, 10), 2)",
+			wantErr:    "must be passed directly to one of",
+		},
+		"bare top level history": {
+			expression: "History(s1, 10)",
+			wantErr:    "must be passed directly to one of",
+		},
+		"window in an arithmetic operator": {
+			expression: "History(s1, 10) + 2",
+			wantErr:    "must be passed directly to one of",
+		},
+		"window in a comparison": {
+			expression: "GT(History(s1, 10), 2)",
+			wantErr:    "must be passed directly to one of",
+		},
+		"reserved namespace spoofing": {
+			expression: "Avg(s1__h10)",
+			wantErr:    "reserved history namespace",
+		},
+		"reserved namespace spoofing with field": {
+			expression: "Add(s1_bid__h300, 1)",
+			wantErr:    "reserved history namespace",
+		},
+		"parse error": {
+			expression: "Avg(History(s1, 10)",
+			wantErr:    "failed to parse expression",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			refs, err := analyzeHistoryExpression(tc.expression)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrHistoryExpression)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			assert.Nil(t, refs, "a rejected expression must not yield references")
+		})
+	}
+}
+
+// TestAnalyzeHistoryExpression_FanOut covers the per-expression bound: each
+// depth is legal on its own, but their sum is work done every round.
+func TestAnalyzeHistoryExpression_FanOut(t *testing.T) {
+	t.Parallel()
+
+	perCall := protocol.MaxHistoryRecordsPerPair
+	calls := protocol.MaxHistoryRecordsPerExpression / perCall
+
+	within := make([]string, 0, calls)
+	for i := range calls {
+		within = append(within, fmt.Sprintf("Avg(History(s%d, %d))", i+1, perCall))
+	}
+	refs, err := analyzeHistoryExpression(strings.Join(within, " + "))
+	require.NoError(t, err)
+	assert.Len(t, refs, calls)
+
+	over := append(within, fmt.Sprintf("Avg(History(s%d, 1))", calls+1))
+	_, err = analyzeHistoryExpression(strings.Join(over, " + "))
+	require.ErrorIs(t, err, ErrHistoryExpression)
+	assert.Contains(t, err.Error(), "total history depth")
+}
+
+// TestAnalyzeHistoryExpression_ReportsEveryProblem checks that a single pass
+// surfaces all the problems rather than one at a time, since these errors are
+// read by configuration tooling.
+func TestAnalyzeHistoryExpression_ReportsEveryProblem(t *testing.T) {
+	t.Parallel()
+
+	_, err := analyzeHistoryExpression("Add(History(s1, 0), History(s2, x))")
+	require.ErrorIs(t, err, ErrHistoryExpression)
+	assert.Contains(t, err.Error(), "depth must be at least 1")
+	assert.Contains(t, err.Error(), "depth must be an integer literal")
+}
+
+// TestAnalyzeHistoryExpression_Deterministic guards the property the plugin
+// depends on: analysis is a pure function of the expression string, so every
+// node derives the same required depths.
+func TestAnalyzeHistoryExpression_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	expression := "Add(Avg(History(s7_bid, 10)), Add(Avg(History(s1, 300)), Avg(History(s7, 10))))"
+	first, err := analyzeHistoryExpression(expression)
+	require.NoError(t, err)
+	for range 20 {
+		again, err := analyzeHistoryExpression(expression)
+		require.NoError(t, err)
+		require.Equal(t, first, again)
+	}
+
+	errFirst := func() string {
+		_, err := analyzeHistoryExpression("Add(History(s1, 0), History(s2, x))")
+		return err.Error()
+	}()
+	for range 20 {
+		_, err := analyzeHistoryExpression("Add(History(s1, 0), History(s2, x))")
+		require.Equal(t, errFirst, err.Error(), "error text must be stable")
+	}
+}
+
+// TestHistoryPatcher_RewritesTree checks the tree the compiler will actually see.
+func TestHistoryPatcher_RewritesTree(t *testing.T) {
+	t.Parallel()
+
+	tree, err := parser.Parse("Avg(History(s10001_bid, 300))")
+	require.NoError(t, err)
+
+	p := newHistoryPatcher()
+	ast.Walk(&tree.Node, p)
+	require.NoError(t, p.err())
+
+	call, ok := tree.Node.(*ast.CallNode)
+	require.True(t, ok)
+	require.Len(t, call.Arguments, 1)
+	// The History call is gone: what remains is a plain identifier the compiler
+	// resolves from the environment.
+	id, ok := call.Arguments[0].(*ast.IdentifierNode)
+	require.True(t, ok, "expected the History call to be replaced by an identifier, got %T", call.Arguments[0])
+	assert.Equal(t, "s10001_bid__h300", id.Value)
+}
+
+// TestHistoryPatcher_AsCompileOption exercises the patcher through the same
+// expr.Patch hook the evaluator will use, so the analysis path and the
+// compilation path cannot diverge.
+func TestHistoryPatcher_AsCompileOption(t *testing.T) {
+	t.Parallel()
+
+	env := NewEnv(uint64(1750169759775700000))
+	defer env.release()
+	// Phase 3 binds a real window here; for compilation only the name has to
+	// resolve.
+	env["s10001__h10"] = struct{}{}
+
+	p := newHistoryPatcher()
+	program, err := expr.Compile(
+		"Avg(History(s10001, 10))",
+		expr.Env(env),
+		expr.DisableAllBuiltins(),
+		expr.Patch(p),
+	)
+	require.NoError(t, err)
+	require.NoError(t, p.err())
+	require.NotNil(t, program)
+	assert.Equal(t, []HistoryRef{{StreamID: 10001, Field: FieldValue, Count: 10}}, p.sortedRefs())
+}
+
+// TestHistoryPatcher_UnboundWindowFailsAtEvaluation pins where an unbound window
+// is caught.
+//
+// With a map environment, expr resolves unknown identifiers dynamically, so a
+// missing window binding does NOT fail compilation — only an unknown *callee*
+// does. The window therefore reads as nil and the failure surfaces when a
+// function tries to use it. That is still fail-closed (an error, so no
+// aggregate is produced), but callers must not rely on compilation to detect
+// insufficient or unbound history.
+func TestHistoryPatcher_UnboundWindowFailsAtEvaluation(t *testing.T) {
+	t.Parallel()
+
+	env := NewEnv(uint64(1750169759775700000))
+	defer env.release()
+
+	p := newHistoryPatcher()
+	program, err := expr.Compile(
+		"Avg(History(s10001, 10))",
+		expr.Env(env),
+		expr.DisableAllBuiltins(),
+		expr.Patch(p),
+	)
+	require.NoError(t, err, "an unbound window does not fail compilation")
+	require.NoError(t, p.err())
+
+	_, err = expr.Run(program, env)
+	require.Error(t, err, "an unbound window must fail evaluation")
+}
+
+// TestHistoryStubFailsClosed covers the patch-bypass guard: History resolving at
+// evaluation time means compilation did not rewrite it, and that must fail
+// loudly rather than produce a value.
+//
+// evalDecimal always applies the patcher, so a bypass can only come from code
+// that compiles without expr.Patch — which is what this constructs.
+func TestHistoryStubFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, defaultEnv, HistoryFunctionName, "History must be registered so a bypass cannot hit an undefined identifier")
+
+	env := NewEnv(uint64(1750169759775700000))
+	defer env.release()
+	env["s1"] = decimal.NewFromInt(1)
+
+	program, err := expr.Compile("History(s1, 10)", expr.Env(map[string]any(env)), expr.DisableAllBuiltins())
+	require.NoError(t, err, "the stub keeps History a known name")
+
+	_, err = expr.Run(program, map[string]any(env))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "was not resolved at compile time")
+}
+
+// TestEvalDecimalPatchesHistory confirms the normal evaluation path rewrites
+// History rather than calling the stub, so the stub really is unreachable in
+// practice.
+func TestEvalDecimalPatchesHistory(t *testing.T) {
+	t.Parallel()
+
+	env := NewEnv(uint64(1750169759775700000))
+	defer env.release()
+
+	// With the window unbound, the rewrite still happens: the call reaches
+	// Count with a nil window rather than reaching the History stub. This is
+	// also why bindHistory has to gate evaluation — an unbound or too-short
+	// window is not a compile error, it is a nil that arrives at a function.
+	_, err := evalDecimal("Count(History(s1, 10))", env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Count expects a history window")
+	assert.NotContains(t, err.Error(), "was not resolved at compile time")
+}
+
+// TestHistoryPatcher_SingleUse documents that a patcher accumulates state for one
+// expression and must not be reused.
+func TestHistoryPatcher_SingleUse(t *testing.T) {
+	t.Parallel()
+
+	p := newHistoryPatcher()
+	for _, expression := range []string{"Avg(History(s1, 10))", "Avg(History(s2, 20))"} {
+		tree, err := parser.Parse(expression)
+		require.NoError(t, err)
+		ast.Walk(&tree.Node, p)
+	}
+	// Both are recorded, which is why a fresh patcher is required per
+	// expression.
+	assert.Len(t, p.sortedRefs(), 2)
+}
+
+// FuzzAnalyzeHistoryExpression checks that arbitrary expression text cannot
+// panic the analysis pass, and that anything it accepts respects the depth
+// bounds. Expressions come from channel definitions, which are replicated state:
+// a panic here would take the node down, and an out-of-bounds depth accepted
+// here would become persisted state.
+func FuzzAnalyzeHistoryExpression(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"s1",
+		"Avg(History(s1, 10))",
+		"History(s1, 10)",
+		"Avg(History(s1_bid, 1024))",
+		"Avg(History(s1, 0))",
+		"Avg(History(s1, x))",
+		"Avg(History(History(s1, 2), 2))",
+		"Avg(s1__h10)",
+		`Duration('History(s1, 10)')`,
+		"Avg(History(s99999999999999999999, 10))",
+		"((((",
+		"History",
+		"History()",
+		"Avg(History(s1, 10)) + Avg(History(s2, 20))",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, expression string) {
+		refs, err := analyzeHistoryExpression(expression)
+		if err != nil {
+			require.Nil(t, refs, "a rejected expression must not yield references")
+			return
+		}
+		seen := map[HistoryRef]bool{}
+		for _, ref := range refs {
+			require.GreaterOrEqual(t, ref.Count, uint32(1))
+			require.LessOrEqual(t, ref.Count, uint32(protocol.MaxHistoryRecordsPerPair))
+			require.Regexp(t, reservedHistoryName, ref.envName())
+			require.False(t, seen[ref], "references must be deduplicated")
+			seen[ref] = true
+		}
+	})
+}
+
+func TestFieldFromSuffix(t *testing.T) {
+	t.Parallel()
+
+	for suffix, want := range map[string]Field{
+		"":          FieldValue,
+		"bid":       FieldBid,
+		"ask":       FieldAsk,
+		"benchmark": FieldBenchmark,
+	} {
+		got, ok := fieldFromSuffix(suffix)
+		require.True(t, ok, "suffix %q", suffix)
+		assert.Equal(t, want, got)
+	}
+
+	_, ok := fieldFromSuffix("timestamp")
+	assert.False(t, ok, "timestamp must not map to a field")
+}

--- a/llo/protocol/calculated/history_ast_test.go
+++ b/llo/protocol/calculated/history_ast_test.go
@@ -400,7 +400,7 @@ func TestEvalDecimalPatchesHistory(t *testing.T) {
 
 	// With the window unbound, the rewrite still happens: the call reaches
 	// Count with a nil window rather than reaching the History stub. This is
-	// also why bindHistory has to gate evaluation — an unbound or too-short
+	// also why history binding has to gate evaluation — an unbound or too-short
 	// window is not a compile error, it is a nil that arrives at a function.
 	_, err := evalDecimal("Count(History(s1, 10))", env)
 	require.Error(t, err)

--- a/llo/protocol/calculated/process_fuzz_test.go
+++ b/llo/protocol/calculated/process_fuzz_test.go
@@ -108,9 +108,14 @@ func runFuzzRound(t *testing.T, expression string, reader HistoryReader) map[str
 	t.Helper()
 
 	defs, aggregates := fuzzRound(expression)
+	before := fmt.Sprint(defs)
 	// Nop rather than Test: a round of unevaluable expressions logs one error per
 	// channel, and the fuzzer runs a great many rounds.
 	ProcessCalculatedStreams(logger.Nop(), defs, aggregates, fuzzAnchorNs, protocol.NewOptsCache(), reader)
+
+	// Evaluation contributes to the aggregates and nothing else. Whatever the
+	// expression does, the definitions it ran against come out untouched.
+	require.Equal(t, before, fmt.Sprint(defs), "channel definitions were mutated by evaluation")
 
 	out := make(map[string]string, len(aggregates)+len(defs))
 	for sid, byAggregator := range aggregates {

--- a/llo/protocol/calculated/process_fuzz_test.go
+++ b/llo/protocol/calculated/process_fuzz_test.go
@@ -1,0 +1,130 @@
+package calculated
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+// fuzzAnchorNs anchors the round. It matches the anchor FuzzEvaluateExpression
+// uses so the two fuzzers see windows positioned the same way.
+const fuzzAnchorNs = 1_000 * uint64(1_000_000_000)
+
+// fuzzStreamValue is the observed value every stream carries. The values are not
+// what is under test here — the round is — so one fixed, well behaved number
+// keeps the fuzzer spending its budget on expression text.
+var fuzzStreamValue = decimal.NewFromInt(3)
+
+// fuzzRoundChannels is wide enough to put the worker pool to work and to place
+// several channels on each worker.
+const fuzzRoundChannels = 16
+
+// fuzzRound builds a round of channels that all evaluate the same expression.
+// The expression is the fuzzed input; the shape around it is fixed, because what
+// is under test is the round, not the channel definition decoder.
+func fuzzRound(expression string) (llotypes.ChannelDefinitions, protocol.StreamAggregates) {
+	defs := llotypes.ChannelDefinitions{}
+	for c := range fuzzRoundChannels {
+		defs[llotypes.ChannelID(c+1)] = llotypes.ChannelDefinition{
+			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+			Streams:      medianStreams(1, 2),
+			Opts: fmt.Appendf(nil,
+				`{"abi":[{"type":"int256","expression":%q,"expressionStreamID":%d}]}`,
+				expression, 1000+c),
+		}
+	}
+	return defs, protocol.StreamAggregates{
+		1: {llotypes.AggregatorMedian: protocol.ToDecimal(fuzzStreamValue)},
+		2: {llotypes.AggregatorMedian: protocol.ToDecimal(fuzzStreamValue)},
+	}
+}
+
+// FuzzProcessCalculatedStreams fuzzes a whole round rather than one expression:
+// preparation, concurrent evaluation and the sequential apply that commits the
+// results.
+//
+// FuzzEvaluateExpression covers what one expression does to the function
+// library. This covers what a round of them does to the shared structures around
+// it — the environment pool, the analysis and program caches, the aggregates map
+// every channel writes into — none of which the single-expression path touches
+// under concurrency.
+//
+// Two properties are asserted. Nothing panics: a panic in an oracle's state
+// transition takes the node down, and an expression arrives from replicated
+// channel definitions, so it is not trusted to be sensible. And the round is
+// deterministic: evaluating the same input twice must produce the same
+// aggregates, whatever order the workers finished in. A result that depended on
+// scheduling would diverge between oracles and stall the protocol, which is a
+// far worse failure than an expression that simply cannot be evaluated.
+func FuzzProcessCalculatedStreams(f *testing.F) {
+	for _, expression := range []string{
+		"Add(s1, s2)",
+		"Div(s1, s2)",
+		"Pow(s1, s2)",
+		"Ln(s1)",
+		"Avg(History(s1, 3))",
+		"EMA(History(s1, 3), 2)",
+		"SMA(History(s1, 3), 2)",
+		"Stddev(History(s1, 3))",
+		`TWAP(History(s1, 3), {window: Duration("3s"), minSamples: 1, maxHeadGap: 3, maxInteriorGap: 3, maxTailGap: 3})`,
+		// Deeper than the reader serves: the whole round takes the warmup gate.
+		"Avg(History(s1, 64))",
+		// Two windows in one expression, so binding order is exercised.
+		"Add(Avg(History(s1, 2)), Avg(History(s2, 2)))",
+		"",
+		"((((",
+	} {
+		// withHistory false covers the v30 shape, where the reader is nil and
+		// any expression using History must fail closed rather than evaluate.
+		f.Add(expression, true)
+		f.Add(expression, false)
+	}
+
+	f.Fuzz(func(t *testing.T, expression string, withHistory bool) {
+		var reader HistoryReader
+		if withHistory {
+			// Typed nil would defeat the nil check in resolveHistory, so the
+			// reader is only assigned when one is wanted.
+			reader = fuzzHistoryReader{seed: 3, scale: 0}
+		}
+
+		first := runFuzzRound(t, expression, reader)
+		second := runFuzzRound(t, expression, reader)
+		require.Equal(t, first, second, "round was not deterministic for %q", expression)
+	})
+}
+
+// runFuzzRound evaluates one round and returns what it committed: the calculated
+// aggregates, and the streams each channel definition ended up carrying. Both are
+// outcome state, so both must be identical across runs.
+func runFuzzRound(t *testing.T, expression string, reader HistoryReader) map[string]string {
+	t.Helper()
+
+	defs, aggregates := fuzzRound(expression)
+	// Nop rather than Test: a round of unevaluable expressions logs one error per
+	// channel, and the fuzzer runs a great many rounds.
+	ProcessCalculatedStreams(logger.Nop(), defs, aggregates, fuzzAnchorNs, protocol.NewOptsCache(), reader)
+
+	out := make(map[string]string, len(aggregates)+len(defs))
+	for sid, byAggregator := range aggregates {
+		for aggregator, value := range byAggregator {
+			// Assert rather than format: %v on a StreamValue prints a pointer,
+			// which differs between runs and would pass this test for the wrong
+			// reason.
+			d, ok := value.(*protocol.Decimal)
+			require.True(t, ok, "unexpected stream value type %T", value)
+			out[fmt.Sprintf("aggregate/%d/%d", sid, aggregator)] = d.Decimal().String()
+		}
+	}
+	for cid, cd := range defs {
+		out[fmt.Sprintf("streams/%d", cid)] = fmt.Sprint(cd.Streams)
+	}
+	return out
+}

--- a/llo/protocol/calculated/program.go
+++ b/llo/protocol/calculated/program.go
@@ -1,0 +1,201 @@
+package calculated
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/expr-lang/expr/vm"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+// maxAnalysisCacheEntries bounds the expression analysis cache. Channel
+// definitions can churn, so the cache must not grow with the number of distinct
+// expressions ever seen; a few hundred live expressions is already far more than
+// any real configuration.
+const maxAnalysisCacheEntries = 1024
+
+// analysisCache memoizes expression analysis, keyed by the raw expression
+// string.
+//
+// Analysis parses the expression and walks its AST, which previously happened
+// on every round for every expression. It is a pure function of the expression
+// string, so the result is identical on every node and safe to memoize
+// node-locally — the same reasoning that makes the opts cache safe. Nothing
+// about consensus depends on whether a given node hits the cache.
+//
+// Both hits and failures are cached: a rejected expression stays rejected until
+// its text changes, and re-deriving the same error every round is wasted work.
+type analysisCache struct {
+	mu      sync.Mutex
+	entries map[string]*list.Element
+	order   *list.List // front is most recently used
+	max     int
+}
+
+type analysisEntry struct {
+	expression string
+	refs       []HistoryRef
+	err        error
+
+	// program is the compiled expression, filled in on first successful
+	// compilation. Compilation is deferred because it needs an environment,
+	// while analysis does not.
+	//
+	// A program is safe to share across channels even though it was compiled
+	// against one channel's environment: identifier reads compile to dynamic
+	// map fetches, so the program resolves names from whatever environment it
+	// is run with. Only compile failures are environment-dependent, and those
+	// are deliberately not cached.
+	program *vm.Program
+}
+
+func newAnalysisCache(max int) *analysisCache {
+	return &analysisCache{
+		entries: make(map[string]*list.Element, max),
+		order:   list.New(),
+		max:     max,
+	}
+}
+
+// historyAnalysisCache is the process-wide analysis cache.
+var historyAnalysisCache = newAnalysisCache(maxAnalysisCacheEntries)
+
+// AnalyzeExpressionHistory returns the History references an expression
+// declares: which stream and field each reads, and how deep.
+//
+// This is the declaration side of the DSL. Callers use it to derive how much
+// history to persist per stream, so it must stay a pure function of the
+// expression string. An expression using no History returns no references and
+// no error; an expression misusing History returns ErrHistoryExpression and no
+// references, and must not be evaluated.
+//
+// The returned slice is deduplicated, ordered by (streamID, field, depth), and
+// shared with the cache: callers must not modify it.
+func AnalyzeExpressionHistory(expression string) ([]HistoryRef, error) {
+	return historyAnalysisCache.analyze(expression)
+}
+
+// ValidateExpression reports whether an expression is statically well formed.
+//
+// It is the check to run before a channel definition reaches consensus: it
+// parses, rewrites History calls, and applies every static rule (argument
+// shapes, depth caps, per-expression fan-out, window positions, reserved names,
+// TWAP configuration satisfiability). It does not evaluate, so it needs no
+// stream values and no persisted state, and it is a pure function of the
+// expression string.
+//
+// A statically invalid expression can never produce a value, so accepting one
+// into a channel definition means accepting a channel that will never report.
+func ValidateExpression(expression string) error {
+	if expression == "" {
+		return fmt.Errorf("%w: expression is empty", ErrHistoryExpression)
+	}
+	_, err := AnalyzeExpressionHistory(expression)
+	return err
+}
+
+// ValidateChannelExpressions validates every expression a channel's opts declare.
+// Errors are joined so one pass reports all of them.
+func ValidateChannelExpressions(optsCache *protocol.OptsCache, cd llotypes.ChannelDefinition, cid llotypes.ChannelID) error {
+	expressions, err := Expressions(optsCache, cd, cid)
+	if err != nil {
+		return err
+	}
+
+	// The aggregator a History call resolves to comes from the channel's
+	// streams, so an ambiguous channel cannot be validated — or evaluated.
+	if _, err := AggregatorByStream(cd); err != nil {
+		return fmt.Errorf("channel %d: %w", cid, err)
+	}
+
+	var errs []error
+	for _, expression := range expressions {
+		if err := ValidateExpression(expression); err != nil {
+			errs = append(errs, fmt.Errorf("expression %q: %w", expression, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (c *analysisCache) analyze(expression string) ([]HistoryRef, error) {
+	if entry, ok := c.get(expression); ok {
+		return entry.refs, entry.err
+	}
+
+	refs, err := analyzeHistoryExpression(expression)
+	c.put(&analysisEntry{expression: expression, refs: refs, err: err})
+	return refs, err
+}
+
+func (c *analysisCache) get(expression string) (*analysisEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	element, ok := c.entries[expression]
+	if !ok {
+		return nil, false
+	}
+	c.order.MoveToFront(element)
+	return element.Value.(*analysisEntry), true
+}
+
+func (c *analysisCache) put(entry *analysisEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if element, ok := c.entries[entry.expression]; ok {
+		element.Value = entry
+		c.order.MoveToFront(element)
+		return
+	}
+
+	c.entries[entry.expression] = c.order.PushFront(entry)
+	for c.order.Len() > c.max {
+		oldest := c.order.Back()
+		if oldest == nil {
+			return
+		}
+		c.order.Remove(oldest)
+		delete(c.entries, oldest.Value.(*analysisEntry).expression)
+	}
+}
+
+// program returns the cached compiled program for an expression, or nil if it
+// has not been compiled yet.
+func (c *analysisCache) program(expression string) *vm.Program {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	element, ok := c.entries[expression]
+	if !ok {
+		return nil
+	}
+	c.order.MoveToFront(element)
+	return element.Value.(*analysisEntry).program
+}
+
+// storeProgram attaches a compiled program to an existing entry. It is a no-op
+// if the entry was evicted in between, in which case the next round simply
+// compiles again.
+func (c *analysisCache) storeProgram(expression string, program *vm.Program) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	element, ok := c.entries[expression]
+	if !ok {
+		return
+	}
+	element.Value.(*analysisEntry).program = program
+	c.order.MoveToFront(element)
+}
+
+func (c *analysisCache) len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.order.Len()
+}

--- a/llo/protocol/calculated/program.go
+++ b/llo/protocol/calculated/program.go
@@ -109,14 +109,35 @@ func ValidateChannelExpressions(optsCache *protocol.OptsCache, cd llotypes.Chann
 
 	// The aggregator a History call resolves to comes from the channel's
 	// streams, so an ambiguous channel cannot be validated — or evaluated.
-	if _, err := AggregatorByStream(cd); err != nil {
+	aggByStream, err := AggregatorByStream(cd)
+	if err != nil {
 		return fmt.Errorf("channel %d: %w", cid, err)
 	}
 
 	var errs []error
 	for _, expression := range expressions {
-		if err := ValidateExpression(expression); err != nil {
+		if expression == "" {
+			errs = append(errs, fmt.Errorf("%w: expression is empty", ErrHistoryExpression))
+			continue
+		}
+		refs, err := AnalyzeExpressionHistory(expression)
+		if err != nil {
 			errs = append(errs, fmt.Errorf("expression %q: %w", expression, err))
+			continue
+		}
+		// A History call may only read a stream the channel observes. The DSL
+		// names a stream, and the channel definition is what says which
+		// aggregation of it is meant, so a reference to a stream that is not
+		// there cannot be resolved. Both consumers already refuse it — history
+		// requirements skip the reference, and evaluation fails on it — so
+		// admitting such a definition installs a channel that reserves no
+		// history and never reports. Reporting it here is the whole point of
+		// validating the definition.
+		for _, ref := range refs {
+			if _, ok := aggByStream[ref.StreamID]; !ok {
+				errs = append(errs, fmt.Errorf("expression %q: %w: %s references stream %d, which the channel does not observe",
+					expression, ErrHistoryExpression, HistoryFunctionName, ref.StreamID))
+			}
 		}
 	}
 	return errors.Join(errs...)

--- a/llo/protocol/calculated/program_test.go
+++ b/llo/protocol/calculated/program_test.go
@@ -1,0 +1,129 @@
+package calculated
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalysisCache_HitReturnsSameResult(t *testing.T) {
+	t.Parallel()
+
+	c := newAnalysisCache(8)
+	const expression = "Avg(History(s10001, 10))"
+
+	first, err := c.analyze(expression)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	assert.Equal(t, 1, c.len())
+
+	second, err := c.analyze(expression)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, c.len(), "a repeated expression must not add an entry")
+}
+
+// TestAnalysisCache_CachesRejections keeps a bad expression from being
+// re-analyzed every round for as long as it stays in the configuration.
+func TestAnalysisCache_CachesRejections(t *testing.T) {
+	t.Parallel()
+
+	c := newAnalysisCache(8)
+	const expression = "Add(History(s1, 10), 2)"
+
+	refs, err := c.analyze(expression)
+	require.ErrorIs(t, err, ErrHistoryExpression)
+	assert.Nil(t, refs)
+	assert.Equal(t, 1, c.len())
+
+	refs, again := c.analyze(expression)
+	require.ErrorIs(t, again, ErrHistoryExpression)
+	assert.Nil(t, refs)
+	assert.Equal(t, err.Error(), again.Error())
+	assert.Equal(t, 1, c.len())
+}
+
+// TestAnalysisCache_BoundedByEviction is the property that matters
+// operationally: channel churn must not grow the cache without limit.
+func TestAnalysisCache_BoundedByEviction(t *testing.T) {
+	t.Parallel()
+
+	const max = 4
+	c := newAnalysisCache(max)
+
+	for i := range 100 {
+		_, err := c.analyze(fmt.Sprintf("Avg(History(s%d, 10))", i+1))
+		require.NoError(t, err)
+		assert.LessOrEqual(t, c.len(), max)
+	}
+	assert.Equal(t, max, c.len())
+}
+
+func TestAnalysisCache_EvictsLeastRecentlyUsed(t *testing.T) {
+	t.Parallel()
+
+	c := newAnalysisCache(2)
+	a := "Avg(History(s1, 10))"
+	b := "Avg(History(s2, 10))"
+	d := "Avg(History(s3, 10))"
+
+	_, err := c.analyze(a)
+	require.NoError(t, err)
+	_, err = c.analyze(b)
+	require.NoError(t, err)
+
+	// Touch a so b becomes the least recently used.
+	_, err = c.analyze(a)
+	require.NoError(t, err)
+
+	_, err = c.analyze(d)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, c.len())
+	_, ok := c.get(a)
+	assert.True(t, ok, "recently used entry must survive")
+	_, ok = c.get(b)
+	assert.False(t, ok, "least recently used entry must be evicted")
+	_, ok = c.get(d)
+	assert.True(t, ok)
+}
+
+// TestAnalysisCache_Concurrent checks the cache is safe under concurrent use;
+// the plugin and configuration tooling can both reach it.
+func TestAnalysisCache_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	c := newAnalysisCache(16)
+	var wg sync.WaitGroup
+	for i := range 64 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			expression := fmt.Sprintf("Avg(History(s%d, 10))", i%8+1)
+			refs, err := c.analyze(expression)
+			assert.NoError(t, err)
+			assert.Len(t, refs, 1)
+		}()
+	}
+	wg.Wait()
+	assert.LessOrEqual(t, c.len(), 16)
+}
+
+func TestAnalyzeExpressionHistory(t *testing.T) {
+	t.Parallel()
+
+	refs, err := AnalyzeExpressionHistory("Avg(History(s424242, 7))")
+	require.NoError(t, err)
+	assert.Equal(t, []HistoryRef{{StreamID: 424242, Field: FieldValue, Count: 7}}, refs)
+
+	// Cached results are shared, so repeated calls agree exactly.
+	again, err := AnalyzeExpressionHistory("Avg(History(s424242, 7))")
+	require.NoError(t, err)
+	assert.Equal(t, refs, again)
+
+	_, err = AnalyzeExpressionHistory("Add(History(s424243, 7), 1)")
+	require.ErrorIs(t, err, ErrHistoryExpression)
+}

--- a/llo/protocol/calculated/series.go
+++ b/llo/protocol/calculated/series.go
@@ -147,17 +147,15 @@ func windowSize(name string, series Series, x any) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("%s: %w", name, err)
 	}
-	if !d.IsInteger() {
-		return 0, fmt.Errorf("%s: sample count must be a whole number, got %s", name, d)
+	// Compared as a decimal, before any narrowing: silently averaging over fewer
+	// samples than asked for would change the meaning of the result, and an
+	// oversized value narrowed first would wrap into the accepted range.
+	if d.GreaterThan(decimal.NewFromInt(int64(series.Len()))) {
+		return 0, fmt.Errorf("%s: sample count %s exceeds the window length %d", name, d, series.Len())
 	}
-	n := int(d.IntPart())
-	if n < 1 {
-		return 0, fmt.Errorf("%s: sample count must be at least 1, got %d", name, n)
-	}
-	if n > series.Len() {
-		// Silently averaging over fewer samples than asked for would change the
-		// meaning of the result.
-		return 0, fmt.Errorf("%s: sample count %d exceeds the window length %d", name, n, series.Len())
+	n, err := decimalToInt("sample count", d, 1, int64(series.Len()))
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", name, err)
 	}
 	return n, nil
 }

--- a/llo/protocol/calculated/series.go
+++ b/llo/protocol/calculated/series.go
@@ -97,6 +97,38 @@ func Count(x any) (decimal.Decimal, error) {
 	return decimal.NewFromInt(int64(series.Len())), nil
 }
 
+// scalarsOrWindow resolves the arguments of a function that accepts either a
+// single history window or a list of scalars.
+//
+// The two forms are deliberately not mixed: Avg(History(s1, 10), s2) would be
+// ambiguous about whether the scalar is one more sample or a weight, so it is
+// rejected rather than given a meaning.
+func scalarsOrWindow(name string, args []any) ([]decimal.Decimal, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("%s requires at least one argument", name)
+	}
+
+	if series, ok := args[0].(Series); ok {
+		if len(args) > 1 {
+			return nil, fmt.Errorf("%s takes either a single history window or a list of scalars, not both", name)
+		}
+		if series.Len() == 0 {
+			return nil, fmt.Errorf("%s: history window is empty", name)
+		}
+		return series.Values(), nil
+	}
+
+	values := make([]decimal.Decimal, 0, len(args))
+	for _, arg := range args {
+		value, err := toDecimal(arg)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
 // window resolves the single history window argument of a window-only function.
 func window(name string, x any) (Series, error) {
 	series, ok := x.(Series)

--- a/llo/protocol/calculated/series.go
+++ b/llo/protocol/calculated/series.go
@@ -1,0 +1,243 @@
+package calculated
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/shopspring/decimal"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+// ErrInsufficientHistory is returned when a window holds fewer records than the
+// expression asked for. It means "not yet evaluable" — during warmup, after a
+// depth increase, or after corrupt state was discarded — and must never be
+// treated as zero or silently substituted with a shorter window.
+var ErrInsufficientHistory = protocol.ErrInsufficientStreamHistory
+
+// ErrSeriesAsScalar is returned when a window reaches a function that takes
+// scalars. Static analysis rejects this at configuration time (history_ast.go),
+// so reaching it means the analysis was bypassed; it exists so the failure is
+// loud rather than a silently coerced value.
+var ErrSeriesAsScalar = errors.New("history window cannot be used as a scalar")
+
+// Series is an immutable window of a stream's past agreed values, oldest first,
+// with the timestamp each value was observed at.
+//
+// Timestamps travel with the values rather than being derived from position:
+// rounds are not evenly spaced (stalls, leader changes, minimum report
+// intervals), so any time-weighted function or gap check needs the real
+// observation times. This is also why _timestamp is not a rangeable field —
+// the timestamps are already here.
+type Series struct {
+	values     []decimal.Decimal
+	timestamps []uint64
+}
+
+// NewSeries builds a series from parallel value and timestamp slices. It is
+// exported for tests and for history readers outside this package.
+func NewSeries(values []decimal.Decimal, timestamps []uint64) (Series, error) {
+	if len(values) != len(timestamps) {
+		return Series{}, fmt.Errorf("series has %d values but %d timestamps", len(values), len(timestamps))
+	}
+	for i := 1; i < len(timestamps); i++ {
+		if timestamps[i] <= timestamps[i-1] {
+			return Series{}, fmt.Errorf("series timestamps must be strictly increasing: index %d (%d) is not after index %d (%d)",
+				i, timestamps[i], i-1, timestamps[i-1])
+		}
+	}
+	return Series{values: values, timestamps: timestamps}, nil
+}
+
+// Len is the number of values in the window.
+func (s Series) Len() int { return len(s.values) }
+
+// Values returns the window's values, oldest first. The slice must be treated
+// as read-only.
+func (s Series) Values() []decimal.Decimal { return s.values }
+
+// Timestamps returns the observation time of each value in nanoseconds,
+// parallel to Values and strictly increasing. The slice must be treated as
+// read-only.
+func (s Series) Timestamps() []uint64 { return s.timestamps }
+
+// Newest returns the most recent value.
+func (s Series) Newest() (decimal.Decimal, error) {
+	if len(s.values) == 0 {
+		return decimal.Decimal{}, fmt.Errorf("%w: window is empty", ErrInsufficientHistory)
+	}
+	return s.values[len(s.values)-1], nil
+}
+
+// Oldest returns the least recent value.
+func (s Series) Oldest() (decimal.Decimal, error) {
+	if len(s.values) == 0 {
+		return decimal.Decimal{}, fmt.Errorf("%w: window is empty", ErrInsufficientHistory)
+	}
+	return s.values[0], nil
+}
+
+func (s Series) String() string {
+	return fmt.Sprintf("Series(len=%d)", len(s.values))
+}
+
+// Count returns the number of values in a history window.
+//
+// An empty window is an error rather than a count of zero, matching every other
+// window function: a window is only bound once it holds exactly the requested
+// depth, so an empty one means something upstream went wrong, and a zero
+// flowing into a stream value would hide that.
+func Count(x any) (decimal.Decimal, error) {
+	series, err := window("Count", x)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	return decimal.NewFromInt(int64(series.Len())), nil
+}
+
+// window resolves the single history window argument of a window-only function.
+func window(name string, x any) (Series, error) {
+	series, ok := x.(Series)
+	if !ok {
+		return Series{}, fmt.Errorf("%s expects a history window, got %T", name, x)
+	}
+	if series.Len() == 0 {
+		return Series{}, fmt.Errorf("%s: history window is empty", name)
+	}
+	return series, nil
+}
+
+// windowSize resolves a function's sample-count argument against a window.
+func windowSize(name string, series Series, x any) (int, error) {
+	d, err := toDecimal(x)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", name, err)
+	}
+	if !d.IsInteger() {
+		return 0, fmt.Errorf("%s: sample count must be a whole number, got %s", name, d)
+	}
+	n := int(d.IntPart())
+	if n < 1 {
+		return 0, fmt.Errorf("%s: sample count must be at least 1, got %d", name, n)
+	}
+	if n > series.Len() {
+		// Silently averaging over fewer samples than asked for would change the
+		// meaning of the result.
+		return 0, fmt.Errorf("%s: sample count %d exceeds the window length %d", name, n, series.Len())
+	}
+	return n, nil
+}
+
+// HistoryReader is the read side of persisted stream history.
+//
+// Implementations must be memoized: one underlying state read per
+// (streamID, aggregator) pair per round no matter how many channels or
+// expressions ask, since that is what keeps history within the per-round state
+// budget. Projection to a field and to a depth is cheap and happens per call.
+//
+// A nil HistoryReader means history is unavailable (the v30 plugin has no
+// replicated key-value state), and expressions using History must then fail
+// closed rather than evaluate against an empty window.
+type HistoryReader interface {
+	// Series returns the newest count records of a pair, projected to a field.
+	// It must return ErrInsufficientHistory when fewer than count records are
+	// stored.
+	Series(streamID llotypes.StreamID, aggregator llotypes.Aggregator, count uint32, field Field) (Series, error)
+}
+
+// syntheticHistoryReader satisfies every window request with a deterministic
+// generated series. It exists so expressions using History can be validated
+// offline, where no persisted state exists — the shape of the expression is what
+// is being checked, not the values.
+//
+// It always returns exactly the requested depth, so validation exercises the
+// evaluable path rather than the warmup gate.
+type syntheticHistoryReader struct {
+	// endNanoseconds is the exclusive upper bound of the synthesized
+	// timestamps, which must be the round's observation timestamp: functions
+	// that place records into a window relative to it (TWAP) would otherwise see
+	// every record fall outside the window.
+	endNanoseconds uint64
+	// intervalNanoseconds is the spacing between synthesized records.
+	intervalNanoseconds uint64
+}
+
+func (r syntheticHistoryReader) Series(streamID llotypes.StreamID, _ llotypes.Aggregator, count uint32, _ Field) (Series, error) {
+	values := make([]decimal.Decimal, 0, count)
+	timestamps := make([]uint64, 0, count)
+
+	// The newest record sits one interval before the anchor, so the whole window
+	// lands inside a window measured backwards from it.
+	oldest := r.endNanoseconds - uint64(count)*r.intervalNanoseconds
+	for i := range count {
+		// Values vary per record and per stream so that a validated expression
+		// cannot accidentally depend on them being equal or zero.
+		values = append(values, decimal.New(int64(1_000_000+uint64(streamID)+uint64(i)), -3))
+		timestamps = append(timestamps, oldest+uint64(i)*r.intervalNanoseconds)
+	}
+	return NewSeries(values, timestamps)
+}
+
+// SeriesFromRecords projects stored history records onto a single field. One
+// stored window serves every field, so this is where History(s1, N),
+// History(s1_bid, N) and History(s1_ask, N) diverge.
+//
+// It is exported so history readers in other packages (the v31 plugin) can
+// build a Series without duplicating the field and type handling.
+func SeriesFromRecords(records []protocol.StreamHistoryRecord, field Field) (Series, error) {
+	values := make([]decimal.Decimal, 0, len(records))
+	timestamps := make([]uint64, 0, len(records))
+	for i, record := range records {
+		value, err := projectStreamValue(record.Value, field)
+		if err != nil {
+			return Series{}, fmt.Errorf("history record %d: %w", i, err)
+		}
+		values = append(values, value)
+		timestamps = append(timestamps, record.ObservedAtNanoseconds)
+	}
+	return NewSeries(values, timestamps)
+}
+
+// projectStreamValue extracts one field from a stored stream value.
+//
+// Field selection mirrors how scalar stream values are bound into the
+// environment: a quote exposes _bid/_benchmark/_ask and no bare value, so
+// asking for the bare value of a quote is an error rather than a silent choice
+// of one of the three.
+func projectStreamValue(value protocol.StreamValue, field Field) (decimal.Decimal, error) {
+	switch v := value.(type) {
+	case *protocol.Decimal:
+		if field != FieldValue {
+			return decimal.Decimal{}, fmt.Errorf("stream value is a decimal and has no %s field", field)
+		}
+		return v.Decimal(), nil
+
+	case *protocol.Quote:
+		switch field {
+		case FieldBid:
+			return v.Bid, nil
+		case FieldAsk:
+			return v.Ask, nil
+		case FieldBenchmark:
+			return v.Benchmark, nil
+		default:
+			return decimal.Decimal{}, errors.New("stream value is a quote; use the _bid, _ask or _benchmark field")
+		}
+
+	case *protocol.TimestampedStreamValue:
+		// The timestamp is already carried per record, so only the wrapped
+		// value is projected.
+		if v.StreamValue == nil {
+			return decimal.Decimal{}, protocol.ErrNilStreamValue
+		}
+		return projectStreamValue(v.StreamValue, field)
+
+	case nil:
+		return decimal.Decimal{}, protocol.ErrNilStreamValue
+
+	default:
+		return decimal.Decimal{}, fmt.Errorf("unsupported stream value type %T in history", value)
+	}
+}

--- a/llo/protocol/calculated/series_test.go
+++ b/llo/protocol/calculated/series_test.go
@@ -1,0 +1,483 @@
+package calculated
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+// --- test doubles ---
+
+// stubHistoryReader serves fixed windows and counts reads, so tests can assert
+// both the values an expression saw and that a shared window is not read twice.
+type stubHistoryReader struct {
+	windows map[histRequest]Series
+	err     map[histRequest]error
+	reads   map[histRequest]int
+}
+
+type histRequest struct {
+	streamID   llotypes.StreamID
+	aggregator llotypes.Aggregator
+	count      uint32
+	field      Field
+}
+
+func newStubHistoryReader() *stubHistoryReader {
+	return &stubHistoryReader{
+		windows: map[histRequest]Series{},
+		err:     map[histRequest]error{},
+		reads:   map[histRequest]int{},
+	}
+}
+
+func (r *stubHistoryReader) set(streamID llotypes.StreamID, aggregator llotypes.Aggregator, count uint32, field Field, values ...int64) {
+	decimals := make([]decimal.Decimal, 0, len(values))
+	timestamps := make([]uint64, 0, len(values))
+	for i, v := range values {
+		decimals = append(decimals, decimal.NewFromInt(v))
+		timestamps = append(timestamps, uint64(i+1)*1_000)
+	}
+	series, err := NewSeries(decimals, timestamps)
+	if err != nil {
+		panic(err)
+	}
+	r.windows[histRequest{streamID, aggregator, count, field}] = series
+}
+
+func (r *stubHistoryReader) setErr(streamID llotypes.StreamID, aggregator llotypes.Aggregator, count uint32, field Field, err error) {
+	r.err[histRequest{streamID, aggregator, count, field}] = err
+}
+
+func (r *stubHistoryReader) Series(streamID llotypes.StreamID, aggregator llotypes.Aggregator, count uint32, field Field) (Series, error) {
+	key := histRequest{streamID, aggregator, count, field}
+	r.reads[key]++
+	if err, ok := r.err[key]; ok {
+		return Series{}, err
+	}
+	series, ok := r.windows[key]
+	if !ok {
+		return Series{}, fmt.Errorf("%w: no window for stream %d aggregator %d depth %d field %s",
+			ErrInsufficientHistory, streamID, aggregator, count, field)
+	}
+	return series, nil
+}
+
+var _ HistoryReader = (*stubHistoryReader)(nil)
+
+// --- Series ---
+
+func TestNewSeries(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewSeries(
+		[]decimal.Decimal{decimal.NewFromInt(1), decimal.NewFromInt(2)},
+		[]uint64{10, 20},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, s.Len())
+
+	newest, err := s.Newest()
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(2).Equal(newest))
+
+	oldest, err := s.Oldest()
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(1).Equal(oldest))
+
+	_, err = NewSeries([]decimal.Decimal{decimal.NewFromInt(1)}, []uint64{1, 2})
+	require.ErrorContains(t, err, "1 values but 2 timestamps")
+
+	// Timestamps must be strictly increasing: a duplicate would mean two values
+	// observed at the same instant, which the append rule makes impossible.
+	_, err = NewSeries(
+		[]decimal.Decimal{decimal.NewFromInt(1), decimal.NewFromInt(2)},
+		[]uint64{10, 10},
+	)
+	require.ErrorContains(t, err, "strictly increasing")
+
+	_, err = NewSeries(
+		[]decimal.Decimal{decimal.NewFromInt(1), decimal.NewFromInt(2)},
+		[]uint64{20, 10},
+	)
+	require.ErrorContains(t, err, "strictly increasing")
+}
+
+func TestSeries_EmptyAccessors(t *testing.T) {
+	t.Parallel()
+
+	var s Series
+	assert.Equal(t, 0, s.Len())
+	_, err := s.Newest()
+	require.ErrorIs(t, err, ErrInsufficientHistory)
+	_, err = s.Oldest()
+	require.ErrorIs(t, err, ErrInsufficientHistory)
+}
+
+func TestSeriesFromRecords(t *testing.T) {
+	t.Parallel()
+
+	quote := &protocol.Quote{
+		Bid:       decimal.NewFromInt(10),
+		Benchmark: decimal.NewFromInt(11),
+		Ask:       decimal.NewFromInt(12),
+	}
+	quoteRecords := []protocol.StreamHistoryRecord{
+		{ObservedAtNanoseconds: 1_000, Value: quote},
+		{ObservedAtNanoseconds: 2_000, Value: quote},
+	}
+
+	// One stored window serves every field.
+	for field, want := range map[Field]int64{
+		FieldBid:       10,
+		FieldBenchmark: 11,
+		FieldAsk:       12,
+	} {
+		s, err := SeriesFromRecords(quoteRecords, field)
+		require.NoError(t, err, "field %s", field)
+		require.Equal(t, 2, s.Len())
+		assert.True(t, decimal.NewFromInt(want).Equal(s.Values()[0]), "field %s", field)
+		assert.Equal(t, []uint64{1_000, 2_000}, s.Timestamps())
+	}
+
+	// A quote has no bare value: picking one of the three silently would be
+	// worse than refusing.
+	_, err := SeriesFromRecords(quoteRecords, FieldValue)
+	require.ErrorContains(t, err, "use the _bid, _ask or _benchmark field")
+
+	decimalRecords := []protocol.StreamHistoryRecord{
+		{ObservedAtNanoseconds: 1_000, Value: protocol.ToDecimal(decimal.NewFromInt(7))},
+	}
+	s, err := SeriesFromRecords(decimalRecords, FieldValue)
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(7).Equal(s.Values()[0]))
+
+	_, err = SeriesFromRecords(decimalRecords, FieldBid)
+	require.ErrorContains(t, err, "has no bid field")
+
+	// A timestamped value is unwrapped: the timestamp is already carried per
+	// record.
+	timestampedRecords := []protocol.StreamHistoryRecord{
+		{ObservedAtNanoseconds: 5_000, Value: &protocol.TimestampedStreamValue{
+			ObservedAtNanoseconds: 4_999,
+			StreamValue:           protocol.ToDecimal(decimal.NewFromInt(3)),
+		}},
+	}
+	s, err = SeriesFromRecords(timestampedRecords, FieldValue)
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(3).Equal(s.Values()[0]))
+	assert.Equal(t, []uint64{5_000}, s.Timestamps(), "the record timestamp wins, not the wrapped one")
+
+	_, err = SeriesFromRecords([]protocol.StreamHistoryRecord{{ObservedAtNanoseconds: 1, Value: nil}}, FieldValue)
+	require.ErrorIs(t, err, protocol.ErrNilStreamValue)
+
+	empty, err := SeriesFromRecords(nil, FieldValue)
+	require.NoError(t, err)
+	assert.Equal(t, 0, empty.Len())
+}
+
+func TestCount(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewSeries(
+		[]decimal.Decimal{decimal.NewFromInt(1), decimal.NewFromInt(2), decimal.NewFromInt(3)},
+		[]uint64{1, 2, 3},
+	)
+	require.NoError(t, err)
+
+	got, err := Count(s)
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(3).Equal(got))
+
+	_, err = Count(decimal.NewFromInt(1))
+	require.ErrorContains(t, err, "expects a history window")
+}
+
+// TestToDecimalRejectsSeries is the backstop for a bypassed static check: a
+// window must never be coerced into a number.
+func TestToDecimalRejectsSeries(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewSeries([]decimal.Decimal{decimal.NewFromInt(5)}, []uint64{1})
+	require.NoError(t, err)
+
+	_, err = toDecimal(s)
+	require.ErrorIs(t, err, ErrSeriesAsScalar)
+	assert.Contains(t, err.Error(), "length 1")
+}
+
+// --- ProcessCalculatedStreams with history ---
+
+func historyChannel(streams []llotypes.Stream, expression string) llotypes.ChannelDefinition {
+	return llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+		Streams:      streams,
+		Opts:         []byte(fmt.Sprintf(`{"abi":[{"type":"int256","expression":%q,"expressionStreamID":999}]}`, expression)),
+	}
+}
+
+func medianStreams(ids ...llotypes.StreamID) []llotypes.Stream {
+	streams := make([]llotypes.Stream, 0, len(ids))
+	for _, id := range ids {
+		streams = append(streams, llotypes.Stream{StreamID: id, Aggregator: llotypes.AggregatorMedian})
+	}
+	return streams
+}
+
+func TestProcessCalculatedStreams_History(t *testing.T) {
+	t.Parallel()
+
+	t.Run("evaluates against a bound window", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel(medianStreams(1), "Count(History(s1, 3))"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(5))},
+		}
+		reader := newStubHistoryReader()
+		reader.set(1, llotypes.AggregatorMedian, 3, FieldValue, 10, 20, 30)
+
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), reader)
+
+		got := aggregates[999][llotypes.AggregatorCalculated]
+		require.NotNil(t, got, "expected a calculated aggregate")
+		value, ok := got.(*protocol.Decimal)
+		require.True(t, ok)
+		assert.True(t, decimal.NewFromInt(3).Equal(value.Decimal()), "got %s", value.Decimal())
+	})
+
+	t.Run("insufficient history leaves no aggregate", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel(medianStreams(1), "Count(History(s1, 300))"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(5))},
+		}
+		reader := newStubHistoryReader()
+		reader.setErr(1, llotypes.AggregatorMedian, 300, FieldValue, ErrInsufficientHistory)
+
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), reader)
+
+		assert.Empty(t, aggregates[999], "warmup must not write an aggregate")
+	})
+
+	t.Run("nil reader fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel(medianStreams(1), "Count(History(s1, 3))"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(5))},
+		}
+
+		// This is the v30 path: no replicated state, so no history.
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), nil)
+
+		assert.Empty(t, aggregates[999], "history must not be evaluated when unavailable")
+	})
+
+	t.Run("history-free expressions are unaffected by a nil reader", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel(medianStreams(1, 2), "Add(s1, s2)"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(3))},
+			2: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(4))},
+		}
+
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), nil)
+
+		value, ok := aggregates[999][llotypes.AggregatorCalculated].(*protocol.Decimal)
+		require.True(t, ok)
+		assert.True(t, decimal.NewFromInt(7).Equal(value.Decimal()))
+	})
+
+	t.Run("reads the aggregator the channel declares", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel([]llotypes.Stream{{StreamID: 1, Aggregator: llotypes.AggregatorMode}}, "Count(History(s1, 2))"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {llotypes.AggregatorMode: protocol.ToDecimal(decimal.NewFromInt(5))},
+		}
+		reader := newStubHistoryReader()
+		// Only the mode window exists; a median read would miss.
+		reader.set(1, llotypes.AggregatorMode, 2, FieldValue, 1, 2)
+
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), reader)
+
+		require.NotEmpty(t, aggregates[999])
+		assert.Equal(t, 1, reader.reads[histRequest{1, llotypes.AggregatorMode, 2, FieldValue}])
+		assert.Zero(t, reader.reads[histRequest{1, llotypes.AggregatorMedian, 2, FieldValue}])
+	})
+
+	t.Run("quote field is projected", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel(medianStreams(1), "Count(History(s1_bid, 2))"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {llotypes.AggregatorMedian: &protocol.Quote{
+				Bid:       decimal.NewFromInt(1),
+				Benchmark: decimal.NewFromInt(2),
+				Ask:       decimal.NewFromInt(3),
+			}},
+		}
+		reader := newStubHistoryReader()
+		reader.set(1, llotypes.AggregatorMedian, 2, FieldBid, 7, 8)
+
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), reader)
+
+		require.NotEmpty(t, aggregates[999])
+		assert.Equal(t, 1, reader.reads[histRequest{1, llotypes.AggregatorMedian, 2, FieldBid}])
+	})
+
+	t.Run("a repeated window is read once per expression", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel(medianStreams(1), "Add(Count(History(s1, 2)), Count(History(s1, 2)))"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(5))},
+		}
+		reader := newStubHistoryReader()
+		reader.set(1, llotypes.AggregatorMedian, 2, FieldValue, 1, 2)
+
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), reader)
+
+		value, ok := aggregates[999][llotypes.AggregatorCalculated].(*protocol.Decimal)
+		require.True(t, ok)
+		assert.True(t, decimal.NewFromInt(4).Equal(value.Decimal()))
+		assert.Equal(t, 1, reader.reads[histRequest{1, llotypes.AggregatorMedian, 2, FieldValue}],
+			"duplicate references are deduplicated by analysis")
+	})
+
+	t.Run("window on a stream the channel does not observe", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel(medianStreams(1), "Count(History(s2, 2))"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(5))},
+		}
+		reader := newStubHistoryReader()
+		reader.set(2, llotypes.AggregatorMedian, 2, FieldValue, 1, 2)
+
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), reader)
+
+		assert.Empty(t, aggregates[999], "the channel must declare the stream it reads history for")
+	})
+
+	t.Run("ambiguous aggregator skips the channel", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel([]llotypes.Stream{
+				{StreamID: 1, Aggregator: llotypes.AggregatorMedian},
+				{StreamID: 1, Aggregator: llotypes.AggregatorMode},
+			}, "Count(History(s1, 2))"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {
+				llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(5)),
+				llotypes.AggregatorMode:   protocol.ToDecimal(decimal.NewFromInt(6)),
+			},
+		}
+		reader := newStubHistoryReader()
+		reader.set(1, llotypes.AggregatorMedian, 2, FieldValue, 1, 2)
+		reader.set(1, llotypes.AggregatorMode, 2, FieldValue, 3, 4)
+
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), reader)
+
+		assert.Empty(t, aggregates[999], "ambiguous aggregation must not be guessed at")
+		assert.Empty(t, reader.reads, "an ambiguous channel must not read history at all")
+	})
+
+	t.Run("a short window from the reader is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel(medianStreams(1), "Count(History(s1, 5))"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(5))},
+		}
+		reader := newStubHistoryReader()
+		// Reader misbehaves and returns fewer records than asked for.
+		reader.set(1, llotypes.AggregatorMedian, 5, FieldValue, 1, 2)
+
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), reader)
+
+		assert.Empty(t, aggregates[999], "a differently sized window would change the result")
+	})
+
+	t.Run("a statically invalid expression is not evaluated", func(t *testing.T) {
+		t.Parallel()
+
+		defs := llotypes.ChannelDefinitions{
+			1: historyChannel(medianStreams(1), "Add(History(s1, 2), 1)"),
+		}
+		aggregates := protocol.StreamAggregates{
+			1: {llotypes.AggregatorMedian: protocol.ToDecimal(decimal.NewFromInt(5))},
+		}
+		reader := newStubHistoryReader()
+		reader.set(1, llotypes.AggregatorMedian, 2, FieldValue, 1, 2)
+
+		ProcessCalculatedStreams(logger.Test(t), defs, aggregates, 1_000, protocol.NewOptsCache(), reader)
+
+		assert.Empty(t, aggregates[999])
+		assert.Empty(t, reader.reads, "analysis rejects before any state is read")
+	})
+}
+
+// TestProcessCalculatedStreams_ReleaseStripsWindows checks the pooled
+// environment does not leak a window into a later round, where it would be a
+// stale value bound under a name the expression trusts.
+func TestProcessCalculatedStreams_ReleaseStripsWindows(t *testing.T) {
+	t.Parallel()
+
+	env := NewEnv(1_000)
+	s, err := NewSeries([]decimal.Decimal{decimal.NewFromInt(1)}, []uint64{1})
+	require.NoError(t, err)
+	env["s1__h1"] = s
+	env.release()
+
+	next := NewEnv(1_000)
+	defer next.release()
+	assert.NotContains(t, next, "s1__h1")
+}
+
+// TestProcessCalculatedStreamsDryRun_History checks History expressions can be
+// validated offline, where no persisted state exists.
+func TestProcessCalculatedStreamsDryRun_History(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ProcessCalculatedStreamsDryRun("Count(History(s1, 10))"))
+	require.NoError(t, ProcessCalculatedStreamsDryRun("Count(History(s1_bid, 10))"))
+	require.NoError(t, ProcessCalculatedStreamsDryRun("Add(Count(History(s1, 3)), Count(History(s2, 4)))"))
+
+	// Static rejections still apply offline.
+	require.Error(t, ProcessCalculatedStreamsDryRun("Add(History(s1, 10), 1)"))
+	require.Error(t, ProcessCalculatedStreamsDryRun("Count(History(s1, 0))"))
+	require.Error(t, ProcessCalculatedStreamsDryRun("Count(History(s1_timestamp, 10))"))
+	require.Error(t, ProcessCalculatedStreamsDryRun(fmt.Sprintf("Count(History(s1, %d))", protocol.MaxHistoryRecordsPerPair+1)))
+}

--- a/llo/protocol/calculated/testdata/fuzz/FuzzEvaluateExpression/c26395cd6007cb8c
+++ b/llo/protocol/calculated/testdata/fuzz/FuzzEvaluateExpression/c26395cd6007cb8c
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("Pow(s1, s2)")
+int64(26)
+rune('\x1e')

--- a/llo/protocol/calculated/validation_test.go
+++ b/llo/protocol/calculated/validation_test.go
@@ -106,6 +106,22 @@ func TestValidateChannelExpressions(t *testing.T) {
 	assert.Contains(t, err.Error(), "must be passed directly")
 	assert.Contains(t, err.Error(), "at least 1")
 
+	// A History call may only read a stream the channel observes. Requirements
+	// skip such a reference and evaluation fails on it, so admitting this would
+	// install a channel that reserves no history and never reports.
+	err = ValidateChannelExpressions(nil,
+		channel([]llotypes.Stream{median(1)}, "Count(History(s2, 10))"), 1)
+	require.ErrorContains(t, err, "which the channel does not observe")
+	assert.Contains(t, err.Error(), "stream 2")
+
+	// Calculated streams are not observed, so an expression cannot read the
+	// history of one.
+	err = ValidateChannelExpressions(nil, channel([]llotypes.Stream{
+		median(1),
+		{StreamID: 900, Aggregator: llotypes.AggregatorCalculated},
+	}, "Count(History(s900, 10))"), 1)
+	require.ErrorContains(t, err, "which the channel does not observe")
+
 	// A channel aggregating one stream two ways cannot be validated, because
 	// which aggregation a History call means is undecidable.
 	err = ValidateChannelExpressions(nil, channel([]llotypes.Stream{

--- a/llo/protocol/calculated/validation_test.go
+++ b/llo/protocol/calculated/validation_test.go
@@ -1,0 +1,155 @@
+package calculated
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+func TestValidateExpression(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accepts", func(t *testing.T) {
+		t.Parallel()
+		for _, expression := range []string{
+			"Add(s1, s2)",
+			"Count(History(s1, 10))",
+			"Avg(History(s1_bid, 300))",
+			"Div(Avg(History(s1, 10)), s2)",
+			"EMA(History(s1, 50), 20)",
+			`TWAP(History(s1, 600), {window: Duration("5m"), minSamples: 240, maxHeadGap: 30, maxInteriorGap: 10, maxTailGap: 30})`,
+		} {
+			assert.NoError(t, ValidateExpression(expression), "expression %q", expression)
+		}
+	})
+
+	t.Run("rejects", func(t *testing.T) {
+		t.Parallel()
+		for _, expression := range []string{
+			"",
+			"Add(History(s1, 10), 1)",
+			"Count(History(s1, 0))",
+			"Count(History(s1_timestamp, 10))",
+			"Count(History(s1, x))",
+			"Avg(s1__h10)",
+			"Count(History(s1, 10)",
+			fmt.Sprintf("Count(History(s1, %d))", protocol.MaxHistoryRecordsPerPair+1),
+		} {
+			assert.Error(t, ValidateExpression(expression), "expression %q", expression)
+		}
+	})
+}
+
+// TestValidateExpression_TWAPSatisfiability covers the static half of TWAP
+// validation: a configuration that can never be satisfied is a deployment
+// mistake, and saying so here beats letting every round reject the window and
+// look like a data problem.
+func TestValidateExpression_TWAPSatisfiability(t *testing.T) {
+	t.Parallel()
+
+	// 600 records can supply 240 observations.
+	require.NoError(t, ValidateExpression(
+		`TWAP(History(s1, 600), {window: Duration("5m"), minSamples: 240, maxHeadGap: 30, maxInteriorGap: 10, maxTailGap: 30})`))
+
+	// 100 records can never supply 240.
+	err := ValidateExpression(
+		`TWAP(History(s1, 100), {window: Duration("5m"), minSamples: 240, maxHeadGap: 30, maxInteriorGap: 10, maxTailGap: 30})`)
+	require.ErrorIs(t, err, ErrHistoryExpression)
+	assert.Contains(t, err.Error(), "only keeps 100 records")
+
+	// Exactly enough is fine.
+	require.NoError(t, ValidateExpression(
+		`TWAP(History(s1, 240), {window: Duration("4m"), minSamples: 240, maxHeadGap: 30, maxInteriorGap: 10, maxTailGap: 30})`))
+
+	// A non-literal configuration cannot be checked statically; runtime
+	// validation still applies.
+	require.NoError(t, ValidateExpression("TWAP(History(s1, 10), cfg)"))
+
+	// Wrong arity is caught.
+	require.Error(t, ValidateExpression("TWAP(History(s1, 10))"))
+}
+
+func TestValidateChannelExpressions(t *testing.T) {
+	t.Parallel()
+
+	channel := func(streams []llotypes.Stream, expressions ...string) llotypes.ChannelDefinition {
+		abi := ""
+		for i, expression := range expressions {
+			if i > 0 {
+				abi += ","
+			}
+			abi += fmt.Sprintf(`{"type":"int256","expression":%q,"expressionStreamID":%d}`, expression, 900+i)
+		}
+		return llotypes.ChannelDefinition{
+			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+			Streams:      streams,
+			Opts:         []byte(fmt.Sprintf(`{"abi":[%s]}`, abi)),
+		}
+	}
+	median := func(id llotypes.StreamID) llotypes.Stream {
+		return llotypes.Stream{StreamID: id, Aggregator: llotypes.AggregatorMedian}
+	}
+
+	require.NoError(t, ValidateChannelExpressions(nil,
+		channel([]llotypes.Stream{median(1)}, "Count(History(s1, 10))"), 1))
+
+	// Every problem is reported in one pass, not one at a time.
+	err := ValidateChannelExpressions(nil,
+		channel([]llotypes.Stream{median(1)}, "Add(History(s1, 10), 1)", "Count(History(s1, 0))"), 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be passed directly")
+	assert.Contains(t, err.Error(), "at least 1")
+
+	// A channel aggregating one stream two ways cannot be validated, because
+	// which aggregation a History call means is undecidable.
+	err = ValidateChannelExpressions(nil, channel([]llotypes.Stream{
+		median(1),
+		{StreamID: 1, Aggregator: llotypes.AggregatorMode},
+	}, "Count(History(s1, 10))"), 1)
+	require.ErrorContains(t, err, "aggregators")
+
+	// Undecodable opts.
+	cd := channel([]llotypes.Stream{median(1)}, "Count(History(s1, 10))")
+	cd.Opts = []byte(`{"abi":`)
+	require.Error(t, ValidateChannelExpressions(nil, cd, 1))
+
+	// An ABI entry with no expression names a calculated stream nothing can
+	// produce, so the channel could never report. Rejected at validation rather
+	// than left to fail every round.
+	cd = llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+		Streams:      []llotypes.Stream{median(1)},
+		Opts:         []byte(`{"abi":[{"type":"int192"}]}`),
+	}
+	require.ErrorContains(t, ValidateChannelExpressions(nil, cd, 1), "expression is empty")
+
+	// Including when only one of several entries is missing one.
+	cd = llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+		Streams:      []llotypes.Stream{median(1)},
+		Opts:         []byte(`{"abi":[{"type":"int192","expression":"Add(s1, 1)","expressionStreamID":900},{"type":"int192"}]}`),
+	}
+	err = ValidateChannelExpressions(nil, cd, 1)
+	require.ErrorContains(t, err, "expression is empty")
+	assert.Contains(t, err.Error(), "abi index: 1")
+}
+
+// TestProcessCalculatedStreamsDryRun_Satisfiability checks the offline path
+// rejects the same configurations the static analysis does.
+func TestProcessCalculatedStreamsDryRun_Satisfiability(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ProcessCalculatedStreamsDryRun(
+		`TWAP(History(s1, 300), {window: Duration("5m"), minSamples: 240, maxHeadGap: 30, maxInteriorGap: 10, maxTailGap: 30})`))
+
+	err := ProcessCalculatedStreamsDryRun(
+		`TWAP(History(s1, 10), {window: Duration("5m"), minSamples: 240, maxHeadGap: 30, maxInteriorGap: 10, maxTailGap: 30})`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only keeps 10 records")
+}

--- a/llo/protocol/calculated/validation_test.go
+++ b/llo/protocol/calculated/validation_test.go
@@ -67,6 +67,20 @@ func TestValidateExpression_TWAPSatisfiability(t *testing.T) {
 	require.NoError(t, ValidateExpression(
 		`TWAP(History(s1, 240), {window: Duration("4m"), minSamples: 240, maxHeadGap: 30, maxInteriorGap: 10, maxTailGap: 30})`))
 
+	// A minSamples above the width of the record count must not wrap into a
+	// small value and pass. 2^32+5 would narrow to 5.
+	err = ValidateExpression(
+		`TWAP(History(s1, 100), {window: Duration("5m"), minSamples: 4294967301, maxHeadGap: 30, maxInteriorGap: 10, maxTailGap: 30})`)
+	require.ErrorIs(t, err, ErrHistoryExpression)
+	assert.Contains(t, err.Error(), "only keeps 100 records")
+
+	// A non-positive minSamples is reported as such rather than as a depth
+	// problem, which would read as "requires at least 0 observations".
+	err = ValidateExpression(
+		`TWAP(History(s1, 100), {window: Duration("5m"), minSamples: 0, maxHeadGap: 30, maxInteriorGap: 10, maxTailGap: 30})`)
+	require.ErrorIs(t, err, ErrHistoryExpression)
+	assert.Contains(t, err.Error(), "requires minSamples to be at least 1")
+
 	// A non-literal configuration cannot be checked statically; runtime
 	// validation still applies.
 	require.NoError(t, ValidateExpression("TWAP(History(s1, 10), cfg)"))

--- a/llo/protocol/calculated_streams.go
+++ b/llo/protocol/calculated_streams.go
@@ -1,0 +1,134 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+)
+
+// CalculatedStreamOpts is the shape of the channel opts that declare calculated
+// (expression) streams. It is the single decode of that shape: expression
+// evaluation, channel definition verification and stream derivation all read it,
+// so they cannot drift apart.
+//
+// It lives here rather than in llo/protocol/calculated because that package
+// depends on this one, and this package needs the shape in order to derive a
+// channel's effective streams.
+type CalculatedStreamOpts struct {
+	ABI []CalculatedStreamABI `json:"abi"`
+}
+
+// CalculatedStreamABI is one declared calculated stream: the expression that
+// produces it and the stream ID it is published under.
+type CalculatedStreamABI struct {
+	Type               string            `json:"type"`
+	Expression         string            `json:"expression"`
+	ExpressionStreamID llotypes.StreamID `json:"expressionStreamID"`
+}
+
+// DecodeCalculatedStreamOpts decodes a channel definition's calculated stream
+// opts, preferring the (node-local) decode cache and falling back to decoding
+// the definition's raw opts on a cache miss. The fallback keeps the result
+// identical across oracles even when the cache has not been populated (e.g.
+// after a restart, or in stages that never reset it).
+//
+// Returns an error if the opts cannot be decoded or declare no expressions.
+// The error does not name the channel: every caller already has the channel ID
+// in hand and wraps with it, and naming it here produced it twice.
+func DecodeCalculatedStreamOpts(optsCache *OptsCache, cd llotypes.ChannelDefinition, cid llotypes.ChannelID) (CalculatedStreamOpts, error) {
+	var o CalculatedStreamOpts
+	var err error
+	if optsCache != nil {
+		o, err = GetOpts[CalculatedStreamOpts](optsCache, cid)
+	}
+	if optsCache == nil || err != nil {
+		o = CalculatedStreamOpts{}
+		if uerr := json.Unmarshal(cd.Opts, &o); uerr != nil {
+			return o, fmt.Errorf("failed to decode calculated stream opts: %w", uerr)
+		}
+	}
+	if len(o.ABI) == 0 {
+		return o, errors.New("no expressions found in channel definition")
+	}
+	return o, nil
+}
+
+// HasCalculatedStreams reports whether a channel definition's report format
+// declares calculated streams. It is the definition's format, not its stream
+// list, that answers this: calculated streams are derived from the opts and are
+// not required to be present on the definition.
+func HasCalculatedStreams(cd llotypes.ChannelDefinition) bool {
+	return cd.ReportFormat == llotypes.ReportFormatEVMABIEncodeUnpackedExpr
+}
+
+// EffectiveStreams returns the streams a channel actually reports: the streams
+// its definition observes, followed by one calculated stream per expression its
+// opts declare, in declaration order.
+//
+// This is a pure function of (definition, opts), which is the point. Calculated
+// streams are derived, never stored: a definition is exactly what was voted on,
+// and every node derives the same effective list from it without the derivation
+// having to be replicated. Callers that need to know which streams a report
+// carries — report value assembly above all — must go through here rather than
+// reading cd.Streams directly.
+//
+// The trailing position of the calculated streams is a contract, not an
+// accident: ReportCodecEVMABIEncodeUnpackedExpr encodes the last len(opts.ABI)
+// report values as its payload.
+//
+// Inline llotypes.AggregatorCalculated entries on the definition are dropped
+// before the derived ones are appended. Definitions written by older code
+// carried the calculated streams inline, so filtering makes the result identical
+// whether or not the stored definition was mutated, and makes the function
+// idempotent under repeated application.
+func EffectiveStreams(optsCache *OptsCache, cd llotypes.ChannelDefinition, cid llotypes.ChannelID) ([]llotypes.Stream, error) {
+	if !HasCalculatedStreams(cd) {
+		return cd.Streams, nil
+	}
+
+	o, err := DecodeCalculatedStreamOpts(optsCache, cd, cid)
+	if err != nil {
+		return nil, fmt.Errorf("cannot derive effective streams for channel %d: %w", cid, err)
+	}
+
+	streams := make([]llotypes.Stream, 0, len(cd.Streams)+len(o.ABI))
+	for _, strm := range cd.Streams {
+		if strm.Aggregator == llotypes.AggregatorCalculated {
+			continue
+		}
+		streams = append(streams, strm)
+	}
+	for i, abi := range o.ABI {
+		if abi.ExpressionStreamID == 0 {
+			return nil, fmt.Errorf("cannot derive effective streams for channel %d: expression stream ID is 0, abi index: %d", cid, i)
+		}
+		streams = append(streams, llotypes.Stream{
+			StreamID:   abi.ExpressionStreamID,
+			Aggregator: llotypes.AggregatorCalculated,
+		})
+	}
+	return streams, nil
+}
+
+// CalculatedStreamIDs returns the calculated stream IDs a channel's opts
+// declare, in declaration order. It is the source of truth for which calculated
+// streams a channel is expected to produce.
+//
+// Returns an error if the opts cannot be resolved, declare no expressions, or
+// declare a zero expression stream ID.
+func CalculatedStreamIDs(optsCache *OptsCache, cd llotypes.ChannelDefinition, cid llotypes.ChannelID) ([]llotypes.StreamID, error) {
+	o, err := DecodeCalculatedStreamOpts(optsCache, cd, cid)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]llotypes.StreamID, 0, len(o.ABI))
+	for i, abi := range o.ABI {
+		if abi.ExpressionStreamID == 0 {
+			return ids, fmt.Errorf("expression stream ID is 0, abi index: %d", i)
+		}
+		ids = append(ids, abi.ExpressionStreamID)
+	}
+	return ids, nil
+}

--- a/llo/protocol/calculated_streams_test.go
+++ b/llo/protocol/calculated_streams_test.go
@@ -1,0 +1,171 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+)
+
+const twoExpressionOpts = `{"abi":[
+	{"type":"int256","expression":"Add(s1, s2)","expressionStreamID":998},
+	{"type":"int256","expression":"Sub(s1, s2)","expressionStreamID":999}
+]}`
+
+func observedStreams() []llotypes.Stream {
+	return []llotypes.Stream{
+		{StreamID: 1, Aggregator: llotypes.AggregatorMedian},
+		{StreamID: 2, Aggregator: llotypes.AggregatorMedian},
+	}
+}
+
+func exprChannel(opts string, streams []llotypes.Stream) llotypes.ChannelDefinition {
+	return llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+		Opts:         []byte(opts),
+		Streams:      streams,
+	}
+}
+
+func TestEffectiveStreams(t *testing.T) {
+	t.Run("non-expression channel is returned unchanged", func(t *testing.T) {
+		cd := llotypes.ChannelDefinition{
+			ReportFormat: llotypes.ReportFormatEVMPremiumLegacy,
+			Streams:      observedStreams(),
+		}
+		got, err := EffectiveStreams(nil, cd, 1)
+		require.NoError(t, err)
+		require.Equal(t, cd.Streams, got)
+	})
+
+	t.Run("appends declared calculated streams in declaration order", func(t *testing.T) {
+		got, err := EffectiveStreams(nil, exprChannel(twoExpressionOpts, observedStreams()), 1)
+		require.NoError(t, err)
+		require.Equal(t, []llotypes.Stream{
+			{StreamID: 1, Aggregator: llotypes.AggregatorMedian},
+			{StreamID: 2, Aggregator: llotypes.AggregatorMedian},
+			{StreamID: 998, Aggregator: llotypes.AggregatorCalculated},
+			{StreamID: 999, Aggregator: llotypes.AggregatorCalculated},
+		}, got)
+	})
+
+	t.Run("a definition carrying the streams inline derives identically", func(t *testing.T) {
+		// The shape written by the v3.0 append, which v3.1 must tolerate reading.
+		inline := append(observedStreams(),
+			llotypes.Stream{StreamID: 998, Aggregator: llotypes.AggregatorCalculated},
+			llotypes.Stream{StreamID: 999, Aggregator: llotypes.AggregatorCalculated},
+		)
+		fromInline, err := EffectiveStreams(nil, exprChannel(twoExpressionOpts, inline), 1)
+		require.NoError(t, err)
+		fromClean, err := EffectiveStreams(nil, exprChannel(twoExpressionOpts, observedStreams()), 1)
+		require.NoError(t, err)
+		require.Equal(t, fromClean, fromInline)
+	})
+
+	t.Run("is idempotent under repeated application", func(t *testing.T) {
+		cd := exprChannel(twoExpressionOpts, observedStreams())
+		once, err := EffectiveStreams(nil, cd, 1)
+		require.NoError(t, err)
+		cd.Streams = once
+		twice, err := EffectiveStreams(nil, cd, 1)
+		require.NoError(t, err)
+		require.Equal(t, once, twice)
+	})
+
+	t.Run("stale inline streams do not survive an opts change", func(t *testing.T) {
+		// A channel whose expressions were re-voted: the definition still lists
+		// the old calculated stream, but only the newly declared one is derived.
+		stale := append(observedStreams(),
+			llotypes.Stream{StreamID: 111, Aggregator: llotypes.AggregatorCalculated},
+		)
+		cd := exprChannel(`{"abi":[{"type":"int256","expression":"Add(s1, s2)","expressionStreamID":222}]}`, stale)
+		got, err := EffectiveStreams(nil, cd, 1)
+		require.NoError(t, err)
+		require.Equal(t, []llotypes.Stream{
+			{StreamID: 1, Aggregator: llotypes.AggregatorMedian},
+			{StreamID: 2, Aggregator: llotypes.AggregatorMedian},
+			{StreamID: 222, Aggregator: llotypes.AggregatorCalculated},
+		}, got)
+	})
+
+	t.Run("the opts cache and the raw opts agree", func(t *testing.T) {
+		cd := exprChannel(twoExpressionOpts, observedStreams())
+		cache := NewOptsCache()
+		cache.ResetTo(llotypes.ChannelDefinitions{1: cd})
+
+		cached, err := EffectiveStreams(cache, cd, 1)
+		require.NoError(t, err)
+		raw, err := EffectiveStreams(nil, cd, 1)
+		require.NoError(t, err)
+		require.Equal(t, raw, cached)
+	})
+
+	t.Run("falls back to the raw opts on a cache miss", func(t *testing.T) {
+		cd := exprChannel(twoExpressionOpts, observedStreams())
+		got, err := EffectiveStreams(NewOptsCache(), cd, 1)
+		require.NoError(t, err)
+		require.Len(t, got, 4)
+	})
+
+	t.Run("rejects undecodable opts", func(t *testing.T) {
+		_, err := EffectiveStreams(nil, exprChannel(`not json`, observedStreams()), 7)
+		require.ErrorContains(t, err, "channel 7")
+		require.ErrorContains(t, err, "failed to decode calculated stream opts")
+	})
+
+	t.Run("rejects opts declaring no expressions", func(t *testing.T) {
+		_, err := EffectiveStreams(nil, exprChannel(`{"abi":[]}`, observedStreams()), 7)
+		require.ErrorContains(t, err, "no expressions found in channel definition")
+	})
+
+	t.Run("rejects a zero expression stream ID", func(t *testing.T) {
+		cd := exprChannel(`{"abi":[{"type":"int256","expression":"s1","expressionStreamID":0}]}`, observedStreams())
+		_, err := EffectiveStreams(nil, cd, 7)
+		require.ErrorContains(t, err, "expression stream ID is 0")
+	})
+}
+
+func TestCalculatedStreamIDs(t *testing.T) {
+	t.Run("returns the declared IDs in order", func(t *testing.T) {
+		ids, err := CalculatedStreamIDs(nil, exprChannel(twoExpressionOpts, observedStreams()), 1)
+		require.NoError(t, err)
+		require.Equal(t, []llotypes.StreamID{998, 999}, ids)
+	})
+
+	t.Run("returns the IDs decoded before a zero ID alongside the error", func(t *testing.T) {
+		cd := exprChannel(`{"abi":[
+			{"type":"int256","expression":"s1","expressionStreamID":998},
+			{"type":"int256","expression":"s2","expressionStreamID":0}
+		]}`, observedStreams())
+		ids, err := CalculatedStreamIDs(nil, cd, 1)
+		require.ErrorContains(t, err, "expression stream ID is 0")
+		require.Equal(t, []llotypes.StreamID{998}, ids)
+	})
+
+	t.Run("agrees with EffectiveStreams", func(t *testing.T) {
+		cd := exprChannel(twoExpressionOpts, observedStreams())
+		ids, err := CalculatedStreamIDs(nil, cd, 1)
+		require.NoError(t, err)
+		streams, err := EffectiveStreams(nil, cd, 1)
+		require.NoError(t, err)
+
+		derived := make([]llotypes.StreamID, 0, len(ids))
+		for _, strm := range streams {
+			if strm.Aggregator == llotypes.AggregatorCalculated {
+				derived = append(derived, strm.StreamID)
+			}
+		}
+		require.Equal(t, ids, derived)
+	})
+}
+
+func TestHasCalculatedStreams(t *testing.T) {
+	require.True(t, HasCalculatedStreams(llotypes.ChannelDefinition{ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr}))
+	require.False(t, HasCalculatedStreams(llotypes.ChannelDefinition{ReportFormat: llotypes.ReportFormatEVMPremiumLegacy}))
+	// The stream list does not answer the question; the report format does.
+	require.False(t, HasCalculatedStreams(llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatEVMPremiumLegacy,
+		Streams:      []llotypes.Stream{{StreamID: 1, Aggregator: llotypes.AggregatorCalculated}},
+	}))
+}

--- a/llo/protocol/channel_definitions.go
+++ b/llo/protocol/channel_definitions.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -12,8 +13,29 @@ func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, chan
 	if len(channelDefs) > MaxOutcomeChannelDefinitionsLength {
 		return fmt.Errorf("too many channels, got: %d/%d", len(channelDefs), MaxOutcomeChannelDefinitionsLength)
 	}
+
+	// Verify in ascending channel ID order so that the errors a rejected
+	// definitions file produces are the same on every oracle.
+	channelIDs := make([]llotypes.ChannelID, 0, len(channelDefs))
+	for channelID := range channelDefs {
+		channelIDs = append(channelIDs, channelID)
+	}
+	sort.Slice(channelIDs, func(i, j int) bool { return channelIDs[i] < channelIDs[j] })
+
 	uniqueStreamIDs := make(map[llotypes.StreamID]struct{}, len(channelDefs))
-	for channelID, cd := range channelDefs {
+	// Owners of every stream ID that will hold an aggregate: observed streams
+	// come from the definitions, calculated streams from the expressions their
+	// channel's opts declare. Both are collected here so that the uniqueness
+	// check below can run once over the whole set.
+	observedBy := make(map[llotypes.StreamID]llotypes.ChannelID, len(channelDefs))
+	calculatedBy := make(map[llotypes.StreamID]llotypes.ChannelID)
+	// Owners of every feed ID the definitions publish under. Two channels
+	// sharing one publish conflicting reports for the same on-chain feed, so the
+	// second is rejected.
+	feedIDBy := make(map[[32]byte]llotypes.ChannelID)
+
+	for _, channelID := range channelIDs {
+		cd := channelDefs[channelID]
 		if cd.Tombstone {
 			continue
 		}
@@ -32,12 +54,50 @@ func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, chan
 				continue
 			}
 			uniqueStreamIDs[strm.StreamID] = struct{}{}
+			// Calculated streams are appended to the definition by expression
+			// evaluation, so they are recorded from the opts that declare them
+			// rather than from here: a definition inherited from a previous
+			// outcome already carries its channel's own calculated streams, and
+			// treating those as observed would report every such channel as
+			// colliding with itself.
+			if strm.Aggregator != llotypes.AggregatorCalculated {
+				if _, ok := observedBy[strm.StreamID]; !ok {
+					observedBy[strm.StreamID] = channelID
+				}
+			}
+		}
+		if cd.ReportFormat == llotypes.ReportFormatEVMABIEncodeUnpackedExpr {
+			ids, err := expressionStreamIDs(cd)
+			if err != nil {
+				merr = errors.Join(merr, fmt.Errorf("invalid ChannelDefinition with ID %d: %w", channelID, err))
+			}
+			for _, streamID := range ids {
+				if owner, ok := calculatedBy[streamID]; ok {
+					merr = errors.Join(merr, fmt.Errorf("ChannelDefinition with ID %d declares calculated stream %d already declared by channel %d", channelID, streamID, owner))
+					continue
+				}
+				calculatedBy[streamID] = channelID
+			}
 		}
 		var verifyErr error
 		if codec, ok := codecs[cd.ReportFormat]; ok {
 			verifyErr = codec.Verify(cd)
 			if verifyErr != nil {
 				merr = errors.Join(merr, fmt.Errorf("invalid ChannelDefinition with ID %d: %w", channelID, verifyErr))
+			}
+		}
+		if feedIDer, ok := codecs[cd.ReportFormat].(FeedIDer); ok && verifyErr == nil {
+			feedID, hasFeedID, err := feedIDer.FeedID(cd)
+			switch {
+			case err != nil:
+				merr = errors.Join(merr, fmt.Errorf("invalid ChannelDefinition with ID %d: failed to resolve feed ID: %w", channelID, err))
+			case !hasFeedID:
+			default:
+				if owner, ok := feedIDBy[feedID]; ok {
+					merr = errors.Join(merr, fmt.Errorf("ChannelDefinition with ID %d has feed ID 0x%x already used by channel %d", channelID, feedID, owner))
+				} else {
+					feedIDBy[feedID] = channelID
+				}
 			}
 		}
 		if cd.ReportFormat == llotypes.ReportFormatHistoryBackfill {
@@ -49,6 +109,19 @@ func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, chan
 			continue
 		}
 	}
+
+	// A calculated stream that shares its ID with an observed stream would write
+	// over an aggregate that is not its own. Evaluation refuses to do that, so
+	// such a channel can never report, and the ID it clashes with is only
+	// visible across the whole definition set -- which is why it is checked
+	// here, once, rather than per channel. Only observed streams need a second
+	// pass: calculated collisions are caught as they are collected above.
+	for _, streamID := range sortedStreamIDs(calculatedBy) {
+		if owner, ok := observedBy[streamID]; ok {
+			merr = errors.Join(merr, fmt.Errorf("ChannelDefinition with ID %d declares calculated stream %d, which channel %d observes", calculatedBy[streamID], streamID, owner))
+		}
+	}
+
 	if merr != nil {
 		return merr
 	}
@@ -56,6 +129,44 @@ func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, chan
 		return fmt.Errorf("too many unique stream IDs, got: %d/%d", len(uniqueStreamIDs), MaxObservationStreamValuesLength)
 	}
 	return nil
+}
+
+func sortedStreamIDs(m map[llotypes.StreamID]llotypes.ChannelID) []llotypes.StreamID {
+	ids := make([]llotypes.StreamID, 0, len(m))
+	for id := range m {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// expressionStreamIDs decodes the calculated stream IDs an expression channel's
+// opts declare. It duplicates the shape of the calculated package's opts rather
+// than calling into it because that package depends on this one; only the field
+// this check needs is decoded, so the shapes cannot drift in a way that matters.
+//
+// Returns the IDs decoded so far along with the first error, so a definition
+// with a bad entry still contributes its good ones to the uniqueness check.
+func expressionStreamIDs(cd llotypes.ChannelDefinition) ([]llotypes.StreamID, error) {
+	var opts struct {
+		ABI []struct {
+			ExpressionStreamID llotypes.StreamID `json:"expressionStreamID"`
+		} `json:"abi"`
+	}
+	if err := json.Unmarshal(cd.Opts, &opts); err != nil {
+		return nil, fmt.Errorf("failed to decode calculated stream opts: %w", err)
+	}
+	if len(opts.ABI) == 0 {
+		return nil, errors.New("no expressions found in channel definition")
+	}
+	ids := make([]llotypes.StreamID, 0, len(opts.ABI))
+	for i, abi := range opts.ABI {
+		if abi.ExpressionStreamID == 0 {
+			return ids, fmt.Errorf("expression stream ID is 0, abi index: %d", i)
+		}
+		ids = append(ids, abi.ExpressionStreamID)
+	}
+	return ids, nil
 }
 
 func SubtractChannelDefinitions(minuend llotypes.ChannelDefinitions, subtrahend llotypes.ChannelDefinitions, limit int) llotypes.ChannelDefinitions {

--- a/llo/protocol/channel_definitions.go
+++ b/llo/protocol/channel_definitions.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -54,20 +53,19 @@ func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, chan
 				continue
 			}
 			uniqueStreamIDs[strm.StreamID] = struct{}{}
-			// Calculated streams are appended to the definition by expression
-			// evaluation, so they are recorded from the opts that declare them
-			// rather than from here: a definition inherited from a previous
-			// outcome already carries its channel's own calculated streams, and
-			// treating those as observed would report every such channel as
-			// colliding with itself.
+			// Calculated streams are derived from the opts that declare them and
+			// are not stored on the definition, so anything listed here is
+			// observed. Definitions written by older code may still carry their
+			// calculated streams inline; those are skipped so that such a
+			// channel is not reported as colliding with itself.
 			if strm.Aggregator != llotypes.AggregatorCalculated {
 				if _, ok := observedBy[strm.StreamID]; !ok {
 					observedBy[strm.StreamID] = channelID
 				}
 			}
 		}
-		if cd.ReportFormat == llotypes.ReportFormatEVMABIEncodeUnpackedExpr {
-			ids, err := expressionStreamIDs(cd)
+		if HasCalculatedStreams(cd) {
+			ids, err := CalculatedStreamIDs(nil, cd, channelID)
 			if err != nil {
 				merr = errors.Join(merr, fmt.Errorf("invalid ChannelDefinition with ID %d: %w", channelID, err))
 			}
@@ -138,35 +136,6 @@ func sortedStreamIDs(m map[llotypes.StreamID]llotypes.ChannelID) []llotypes.Stre
 	}
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	return ids
-}
-
-// expressionStreamIDs decodes the calculated stream IDs an expression channel's
-// opts declare. It duplicates the shape of the calculated package's opts rather
-// than calling into it because that package depends on this one; only the field
-// this check needs is decoded, so the shapes cannot drift in a way that matters.
-//
-// Returns the IDs decoded so far along with the first error, so a definition
-// with a bad entry still contributes its good ones to the uniqueness check.
-func expressionStreamIDs(cd llotypes.ChannelDefinition) ([]llotypes.StreamID, error) {
-	var opts struct {
-		ABI []struct {
-			ExpressionStreamID llotypes.StreamID `json:"expressionStreamID"`
-		} `json:"abi"`
-	}
-	if err := json.Unmarshal(cd.Opts, &opts); err != nil {
-		return nil, fmt.Errorf("failed to decode calculated stream opts: %w", err)
-	}
-	if len(opts.ABI) == 0 {
-		return nil, errors.New("no expressions found in channel definition")
-	}
-	ids := make([]llotypes.StreamID, 0, len(opts.ABI))
-	for i, abi := range opts.ABI {
-		if abi.ExpressionStreamID == 0 {
-			return ids, fmt.Errorf("expression stream ID is 0, abi index: %d", i)
-		}
-		ids = append(ids, abi.ExpressionStreamID)
-	}
-	return ids, nil
 }
 
 func SubtractChannelDefinitions(minuend llotypes.ChannelDefinitions, subtrahend llotypes.ChannelDefinitions, limit int) llotypes.ChannelDefinitions {

--- a/llo/protocol/channel_definitions.go
+++ b/llo/protocol/channel_definitions.go
@@ -175,6 +175,9 @@ func verifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, chan
 			if err := ValidateHistoryBackfillAgainstDefinitions(cd, channelDefs, 0); err != nil {
 				merr = errors.Join(merr, fmt.Errorf("invalid history backfill channel %d: %w", channelID, err))
 			}
+			if err := ValidateHistoryBackfillTarget(cd, channelDefs); err != nil {
+				admit(fmt.Errorf("invalid history backfill channel %d: %w", channelID, err), channelID)
+			}
 		}
 		if verifyErr != nil {
 			continue

--- a/llo/protocol/channel_definitions.go
+++ b/llo/protocol/channel_definitions.go
@@ -8,7 +8,66 @@ import (
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 )
 
-func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, channelDefs llotypes.ChannelDefinitions) (merr error) {
+// VerifyChannelDefinitions applies the checks that any definition set must
+// satisfy, whether it is being admitted or has already been committed.
+func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, channelDefs llotypes.ChannelDefinitions) error {
+	return verifyChannelDefinitions(codecs, channelDefs, nil)
+}
+
+// VerifyChannelDefinitionsForAdmission additionally applies the admission-only
+// checks, restricted to admitting -- the channels being added or changed.
+//
+// The admission-only checks are the ones that reject a definition outright
+// rather than merely stopping it from reporting: static expression analysis
+// (ReportCodec implementations of AdmissionVerifier), calculated stream ID
+// collisions, and feed ID uniqueness. Applying them to already-committed
+// definitions would mean one grandfathered channel makes verification fail on
+// every node, every round, which halts the protocol. Restricting them to
+// admitting keeps the gate closed for anything new or changed while leaving
+// what is already installed alone.
+//
+// A cross-definition check involves two channels and is reported against
+// whichever of them is seen second, so such a finding is kept when either
+// channel is in admitting.
+//
+// This is a local decision -- an oracle deciding what it is willing to vote for
+// -- not a consensus-critical one, so oracles running different versions of the
+// admission-only checks disagree only about what they vote for.
+func VerifyChannelDefinitionsForAdmission(codecs map[llotypes.ReportFormat]ReportCodec, channelDefs llotypes.ChannelDefinitions, admitting map[llotypes.ChannelID]struct{}) error {
+	return verifyChannelDefinitions(codecs, channelDefs, admitting)
+}
+
+// ChangedChannelIDs returns the IDs of the channels desired holds that current
+// does not hold identically: the set being added or changed, which is the
+// admitting set to verify against.
+func ChangedChannelIDs(current, desired llotypes.ChannelDefinitions) map[llotypes.ChannelID]struct{} {
+	changed := make(map[llotypes.ChannelID]struct{})
+	for channelID, cd := range desired {
+		if prev, exists := current[channelID]; exists && prev.Equals(cd) {
+			continue
+		}
+		changed[channelID] = struct{}{}
+	}
+	return changed
+}
+
+// admissionFinding is an admission-only check failure, together with every
+// channel it implicates, so that it can be filtered by the admitting set.
+type admissionFinding struct {
+	channels []llotypes.ChannelID
+	err      error
+}
+
+func (f admissionFinding) appliesTo(admitting map[llotypes.ChannelID]struct{}) bool {
+	for _, channelID := range f.channels {
+		if _, ok := admitting[channelID]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func verifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, channelDefs llotypes.ChannelDefinitions, admitting map[llotypes.ChannelID]struct{}) (merr error) {
 	if len(channelDefs) > MaxOutcomeChannelDefinitionsLength {
 		return fmt.Errorf("too many channels, got: %d/%d", len(channelDefs), MaxOutcomeChannelDefinitionsLength)
 	}
@@ -20,6 +79,15 @@ func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, chan
 		channelIDs = append(channelIDs, channelID)
 	}
 	sort.Slice(channelIDs, func(i, j int) bool { return channelIDs[i] < channelIDs[j] })
+
+	// Admission-only findings are collected as they are discovered and filtered
+	// against admitting once at the end. The bookkeeping the cross-definition
+	// checks rely on is built for the whole set either way, so that a finding
+	// does not depend on which channels are being admitted.
+	var admissionFindings []admissionFinding
+	admit := func(err error, channels ...llotypes.ChannelID) {
+		admissionFindings = append(admissionFindings, admissionFinding{channels: channels, err: err})
+	}
 
 	uniqueStreamIDs := make(map[llotypes.StreamID]struct{}, len(channelDefs))
 	// Owners of every stream ID that will hold an aggregate: observed streams
@@ -67,11 +135,11 @@ func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, chan
 		if HasCalculatedStreams(cd) {
 			ids, err := CalculatedStreamIDs(nil, cd, channelID)
 			if err != nil {
-				merr = errors.Join(merr, fmt.Errorf("invalid ChannelDefinition with ID %d: %w", channelID, err))
+				admit(fmt.Errorf("invalid ChannelDefinition with ID %d: %w", channelID, err), channelID)
 			}
 			for _, streamID := range ids {
 				if owner, ok := calculatedBy[streamID]; ok {
-					merr = errors.Join(merr, fmt.Errorf("ChannelDefinition with ID %d declares calculated stream %d already declared by channel %d", channelID, streamID, owner))
+					admit(fmt.Errorf("ChannelDefinition with ID %d declares calculated stream %d already declared by channel %d", channelID, streamID, owner), channelID, owner)
 					continue
 				}
 				calculatedBy[streamID] = channelID
@@ -83,16 +151,21 @@ func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, chan
 			if verifyErr != nil {
 				merr = errors.Join(merr, fmt.Errorf("invalid ChannelDefinition with ID %d: %w", channelID, verifyErr))
 			}
+			if av, ok := codec.(AdmissionVerifier); ok && verifyErr == nil {
+				if err := av.VerifyForAdmission(cd); err != nil {
+					admit(fmt.Errorf("invalid ChannelDefinition with ID %d: %w", channelID, err), channelID)
+				}
+			}
 		}
 		if feedIDer, ok := codecs[cd.ReportFormat].(FeedIDer); ok && verifyErr == nil {
 			feedID, hasFeedID, err := feedIDer.FeedID(cd)
 			switch {
 			case err != nil:
-				merr = errors.Join(merr, fmt.Errorf("invalid ChannelDefinition with ID %d: failed to resolve feed ID: %w", channelID, err))
+				admit(fmt.Errorf("invalid ChannelDefinition with ID %d: failed to resolve feed ID: %w", channelID, err), channelID)
 			case !hasFeedID:
 			default:
 				if owner, ok := feedIDBy[feedID]; ok {
-					merr = errors.Join(merr, fmt.Errorf("ChannelDefinition with ID %d has feed ID 0x%x already used by channel %d", channelID, feedID, owner))
+					admit(fmt.Errorf("ChannelDefinition with ID %d has feed ID 0x%x already used by channel %d", channelID, feedID, owner), channelID, owner)
 				} else {
 					feedIDBy[feedID] = channelID
 				}
@@ -116,7 +189,13 @@ func VerifyChannelDefinitions(codecs map[llotypes.ReportFormat]ReportCodec, chan
 	// pass: calculated collisions are caught as they are collected above.
 	for _, streamID := range sortedStreamIDs(calculatedBy) {
 		if owner, ok := observedBy[streamID]; ok {
-			merr = errors.Join(merr, fmt.Errorf("ChannelDefinition with ID %d declares calculated stream %d, which channel %d observes", calculatedBy[streamID], streamID, owner))
+			admit(fmt.Errorf("ChannelDefinition with ID %d declares calculated stream %d, which channel %d observes", calculatedBy[streamID], streamID, owner), calculatedBy[streamID], owner)
+		}
+	}
+
+	for _, finding := range admissionFindings {
+		if finding.appliesTo(admitting) {
+			merr = errors.Join(merr, finding.err)
 		}
 	}
 

--- a/llo/protocol/channel_definitions_test.go
+++ b/llo/protocol/channel_definitions_test.go
@@ -169,3 +169,137 @@ func (stubReportCodec) Encode(Report, llotypes.ChannelDefinition, *OptsCache) ([
 	return nil, nil
 }
 func (stubReportCodec) Verify(llotypes.ChannelDefinition) error { return nil }
+
+func Test_VerifyChannelDefinitions_CalculatedStreamCollisions(t *testing.T) {
+	codecs := make(map[llotypes.ReportFormat]ReportCodec)
+
+	exprChannel := func(observed llotypes.StreamID, opts string, calculated ...llotypes.StreamID) llotypes.ChannelDefinition {
+		streams := []llotypes.Stream{{StreamID: observed, Aggregator: llotypes.AggregatorMedian}}
+		for _, sid := range calculated {
+			streams = append(streams, llotypes.Stream{StreamID: sid, Aggregator: llotypes.AggregatorCalculated})
+		}
+		return llotypes.ChannelDefinition{
+			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+			Streams:      streams,
+			Opts:         llotypes.ChannelOpts(opts),
+		}
+	}
+
+	t.Run("accepts distinct calculated stream IDs", func(t *testing.T) {
+		channelDefs := llotypes.ChannelDefinitions{
+			1: exprChannel(10, `{"abi":[{"expressionStreamID":100}]}`, 100),
+			2: exprChannel(11, `{"abi":[{"expressionStreamID":101}]}`, 101),
+		}
+		require.NoError(t, VerifyChannelDefinitions(codecs, channelDefs))
+	})
+	t.Run("fails when two channels declare the same calculated stream", func(t *testing.T) {
+		channelDefs := llotypes.ChannelDefinitions{
+			1: exprChannel(10, `{"abi":[{"expressionStreamID":100}]}`, 100),
+			2: exprChannel(11, `{"abi":[{"expressionStreamID":100}]}`, 100),
+		}
+		err := VerifyChannelDefinitions(codecs, channelDefs)
+		require.EqualError(t, err, "ChannelDefinition with ID 2 declares calculated stream 100 already declared by channel 1")
+	})
+	t.Run("fails when a channel declares the same calculated stream twice", func(t *testing.T) {
+		channelDefs := llotypes.ChannelDefinitions{
+			1: exprChannel(10, `{"abi":[{"expressionStreamID":100},{"expressionStreamID":100}]}`, 100),
+		}
+		err := VerifyChannelDefinitions(codecs, channelDefs)
+		require.EqualError(t, err, "ChannelDefinition with ID 1 declares calculated stream 100 already declared by channel 1")
+	})
+	t.Run("fails when a calculated stream collides with an observed stream", func(t *testing.T) {
+		channelDefs := llotypes.ChannelDefinitions{
+			1: exprChannel(10, `{"abi":[{"expressionStreamID":100}]}`, 100),
+			2: {
+				Streams: []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}},
+			},
+		}
+		err := VerifyChannelDefinitions(codecs, channelDefs)
+		require.EqualError(t, err, "ChannelDefinition with ID 1 declares calculated stream 100, which channel 2 observes")
+	})
+	t.Run("fails when a calculated stream collides with its own channel's observed stream", func(t *testing.T) {
+		channelDefs := llotypes.ChannelDefinitions{
+			1: exprChannel(100, `{"abi":[{"expressionStreamID":100}]}`),
+		}
+		err := VerifyChannelDefinitions(codecs, channelDefs)
+		require.EqualError(t, err, "ChannelDefinition with ID 1 declares calculated stream 100, which channel 1 observes")
+	})
+	t.Run("fails for undecodable, empty, and zero-ID expression opts", func(t *testing.T) {
+		for opts, want := range map[string]string{
+			`not json`:                           "invalid ChannelDefinition with ID 1: failed to decode calculated stream opts: invalid character 'o' in literal null (expecting 'u')",
+			`{}`:                                 "invalid ChannelDefinition with ID 1: no expressions found in channel definition",
+			`{"abi":[{"expressionStreamID":0}]}`: "invalid ChannelDefinition with ID 1: expression stream ID is 0, abi index: 0",
+		} {
+			channelDefs := llotypes.ChannelDefinitions{1: exprChannel(10, opts)}
+			require.EqualError(t, VerifyChannelDefinitions(codecs, channelDefs), want)
+		}
+	})
+	t.Run("ignores tombstoned channels", func(t *testing.T) {
+		tombstoned := exprChannel(11, `{"abi":[{"expressionStreamID":100}]}`, 100)
+		tombstoned.Tombstone = true
+		channelDefs := llotypes.ChannelDefinitions{
+			1: exprChannel(10, `{"abi":[{"expressionStreamID":100}]}`, 100),
+			2: tombstoned,
+		}
+		require.NoError(t, VerifyChannelDefinitions(codecs, channelDefs))
+	})
+}
+
+type mockFeedIDCodec struct {
+	mockReportCodec
+	feedID [32]byte
+	ok     bool
+	err    error
+}
+
+func (m mockFeedIDCodec) FeedID(llotypes.ChannelDefinition) ([32]byte, bool, error) {
+	return m.feedID, m.ok, m.err
+}
+
+func Test_VerifyChannelDefinitions_FeedIDCollisions(t *testing.T) {
+	mockReportFormat := llotypes.ReportFormat(0)
+	channel := func() llotypes.ChannelDefinition {
+		return llotypes.ChannelDefinition{
+			ReportFormat: mockReportFormat,
+			Streams:      []llotypes.Stream{{StreamID: 1, Aggregator: llotypes.AggregatorMedian}},
+		}
+	}
+	// The mock returns the same feed ID for every channel, so any definitions
+	// set with more than one channel collides.
+	codecs := func(c ReportCodec) map[llotypes.ReportFormat]ReportCodec {
+		return map[llotypes.ReportFormat]ReportCodec{mockReportFormat: c}
+	}
+
+	t.Run("accepts a single channel with a feed ID", func(t *testing.T) {
+		channelDefs := llotypes.ChannelDefinitions{1: channel()}
+		require.NoError(t, VerifyChannelDefinitions(codecs(mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}), channelDefs))
+	})
+	t.Run("fails when two channels share a feed ID", func(t *testing.T) {
+		channelDefs := llotypes.ChannelDefinitions{1: channel(), 2: channel()}
+		err := VerifyChannelDefinitions(codecs(mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}), channelDefs)
+		require.EqualError(t, err, "ChannelDefinition with ID 2 has feed ID 0xab00000000000000000000000000000000000000000000000000000000000000 already used by channel 1")
+	})
+	t.Run("ignores channels that report no feed ID", func(t *testing.T) {
+		channelDefs := llotypes.ChannelDefinitions{1: channel(), 2: channel()}
+		require.NoError(t, VerifyChannelDefinitions(codecs(mockFeedIDCodec{ok: false}), channelDefs))
+	})
+	t.Run("fails when the feed ID cannot be resolved", func(t *testing.T) {
+		channelDefs := llotypes.ChannelDefinitions{1: channel()}
+		err := VerifyChannelDefinitions(codecs(mockFeedIDCodec{err: errors.New("bad opts")}), channelDefs)
+		require.EqualError(t, err, "invalid ChannelDefinition with ID 1: failed to resolve feed ID: bad opts")
+	})
+	t.Run("does not resolve the feed ID of a channel Verify rejected", func(t *testing.T) {
+		channelDefs := llotypes.ChannelDefinitions{1: channel(), 2: channel()}
+		codec := mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}
+		codec.mockReportCodec = mockReportCodec{err: errors.New("rejected")}
+		err := VerifyChannelDefinitions(codecs(codec), channelDefs)
+		// Only the two Verify errors: no feed ID was collected, so no collision.
+		require.EqualError(t, err, "invalid ChannelDefinition with ID 1: rejected\ninvalid ChannelDefinition with ID 2: rejected")
+	})
+	t.Run("ignores tombstoned channels", func(t *testing.T) {
+		tombstoned := channel()
+		tombstoned.Tombstone = true
+		channelDefs := llotypes.ChannelDefinitions{1: channel(), 2: tombstoned}
+		require.NoError(t, VerifyChannelDefinitions(codecs(mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}), channelDefs))
+	})
+}

--- a/llo/protocol/channel_definitions_test.go
+++ b/llo/protocol/channel_definitions_test.go
@@ -170,6 +170,16 @@ func (stubReportCodec) Encode(Report, llotypes.ChannelDefinition, *OptsCache) ([
 }
 func (stubReportCodec) Verify(llotypes.ChannelDefinition) error { return nil }
 
+// verifyAdmittingAll verifies channelDefs with every channel treated as being
+// admitted, which is what the admission-only checks are exercised against.
+func verifyAdmittingAll(codecs map[llotypes.ReportFormat]ReportCodec, channelDefs llotypes.ChannelDefinitions) error {
+	admitting := make(map[llotypes.ChannelID]struct{}, len(channelDefs))
+	for id := range channelDefs {
+		admitting[id] = struct{}{}
+	}
+	return VerifyChannelDefinitionsForAdmission(codecs, channelDefs, admitting)
+}
+
 func Test_VerifyChannelDefinitions_CalculatedStreamCollisions(t *testing.T) {
 	codecs := make(map[llotypes.ReportFormat]ReportCodec)
 
@@ -190,21 +200,21 @@ func Test_VerifyChannelDefinitions_CalculatedStreamCollisions(t *testing.T) {
 			1: exprChannel(10, `{"abi":[{"expressionStreamID":100}]}`, 100),
 			2: exprChannel(11, `{"abi":[{"expressionStreamID":101}]}`, 101),
 		}
-		require.NoError(t, VerifyChannelDefinitions(codecs, channelDefs))
+		require.NoError(t, verifyAdmittingAll(codecs, channelDefs))
 	})
 	t.Run("fails when two channels declare the same calculated stream", func(t *testing.T) {
 		channelDefs := llotypes.ChannelDefinitions{
 			1: exprChannel(10, `{"abi":[{"expressionStreamID":100}]}`, 100),
 			2: exprChannel(11, `{"abi":[{"expressionStreamID":100}]}`, 100),
 		}
-		err := VerifyChannelDefinitions(codecs, channelDefs)
+		err := verifyAdmittingAll(codecs, channelDefs)
 		require.EqualError(t, err, "ChannelDefinition with ID 2 declares calculated stream 100 already declared by channel 1")
 	})
 	t.Run("fails when a channel declares the same calculated stream twice", func(t *testing.T) {
 		channelDefs := llotypes.ChannelDefinitions{
 			1: exprChannel(10, `{"abi":[{"expressionStreamID":100},{"expressionStreamID":100}]}`, 100),
 		}
-		err := VerifyChannelDefinitions(codecs, channelDefs)
+		err := verifyAdmittingAll(codecs, channelDefs)
 		require.EqualError(t, err, "ChannelDefinition with ID 1 declares calculated stream 100 already declared by channel 1")
 	})
 	t.Run("fails when a calculated stream collides with an observed stream", func(t *testing.T) {
@@ -214,14 +224,14 @@ func Test_VerifyChannelDefinitions_CalculatedStreamCollisions(t *testing.T) {
 				Streams: []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}},
 			},
 		}
-		err := VerifyChannelDefinitions(codecs, channelDefs)
+		err := verifyAdmittingAll(codecs, channelDefs)
 		require.EqualError(t, err, "ChannelDefinition with ID 1 declares calculated stream 100, which channel 2 observes")
 	})
 	t.Run("fails when a calculated stream collides with its own channel's observed stream", func(t *testing.T) {
 		channelDefs := llotypes.ChannelDefinitions{
 			1: exprChannel(100, `{"abi":[{"expressionStreamID":100}]}`),
 		}
-		err := VerifyChannelDefinitions(codecs, channelDefs)
+		err := verifyAdmittingAll(codecs, channelDefs)
 		require.EqualError(t, err, "ChannelDefinition with ID 1 declares calculated stream 100, which channel 1 observes")
 	})
 	t.Run("fails for undecodable, empty, and zero-ID expression opts", func(t *testing.T) {
@@ -231,7 +241,7 @@ func Test_VerifyChannelDefinitions_CalculatedStreamCollisions(t *testing.T) {
 			`{"abi":[{"expressionStreamID":0}]}`: "invalid ChannelDefinition with ID 1: expression stream ID is 0, abi index: 0",
 		} {
 			channelDefs := llotypes.ChannelDefinitions{1: exprChannel(10, opts)}
-			require.EqualError(t, VerifyChannelDefinitions(codecs, channelDefs), want)
+			require.EqualError(t, verifyAdmittingAll(codecs, channelDefs), want)
 		}
 	})
 	t.Run("ignores tombstoned channels", func(t *testing.T) {
@@ -241,7 +251,7 @@ func Test_VerifyChannelDefinitions_CalculatedStreamCollisions(t *testing.T) {
 			1: exprChannel(10, `{"abi":[{"expressionStreamID":100}]}`, 100),
 			2: tombstoned,
 		}
-		require.NoError(t, VerifyChannelDefinitions(codecs, channelDefs))
+		require.NoError(t, verifyAdmittingAll(codecs, channelDefs))
 	})
 }
 
@@ -272,27 +282,27 @@ func Test_VerifyChannelDefinitions_FeedIDCollisions(t *testing.T) {
 
 	t.Run("accepts a single channel with a feed ID", func(t *testing.T) {
 		channelDefs := llotypes.ChannelDefinitions{1: channel()}
-		require.NoError(t, VerifyChannelDefinitions(codecs(mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}), channelDefs))
+		require.NoError(t, verifyAdmittingAll(codecs(mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}), channelDefs))
 	})
 	t.Run("fails when two channels share a feed ID", func(t *testing.T) {
 		channelDefs := llotypes.ChannelDefinitions{1: channel(), 2: channel()}
-		err := VerifyChannelDefinitions(codecs(mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}), channelDefs)
+		err := verifyAdmittingAll(codecs(mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}), channelDefs)
 		require.EqualError(t, err, "ChannelDefinition with ID 2 has feed ID 0xab00000000000000000000000000000000000000000000000000000000000000 already used by channel 1")
 	})
 	t.Run("ignores channels that report no feed ID", func(t *testing.T) {
 		channelDefs := llotypes.ChannelDefinitions{1: channel(), 2: channel()}
-		require.NoError(t, VerifyChannelDefinitions(codecs(mockFeedIDCodec{ok: false}), channelDefs))
+		require.NoError(t, verifyAdmittingAll(codecs(mockFeedIDCodec{ok: false}), channelDefs))
 	})
 	t.Run("fails when the feed ID cannot be resolved", func(t *testing.T) {
 		channelDefs := llotypes.ChannelDefinitions{1: channel()}
-		err := VerifyChannelDefinitions(codecs(mockFeedIDCodec{err: errors.New("bad opts")}), channelDefs)
+		err := verifyAdmittingAll(codecs(mockFeedIDCodec{err: errors.New("bad opts")}), channelDefs)
 		require.EqualError(t, err, "invalid ChannelDefinition with ID 1: failed to resolve feed ID: bad opts")
 	})
 	t.Run("does not resolve the feed ID of a channel Verify rejected", func(t *testing.T) {
 		channelDefs := llotypes.ChannelDefinitions{1: channel(), 2: channel()}
 		codec := mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}
 		codec.mockReportCodec = mockReportCodec{err: errors.New("rejected")}
-		err := VerifyChannelDefinitions(codecs(codec), channelDefs)
+		err := verifyAdmittingAll(codecs(codec), channelDefs)
 		// Only the two Verify errors: no feed ID was collected, so no collision.
 		require.EqualError(t, err, "invalid ChannelDefinition with ID 1: rejected\ninvalid ChannelDefinition with ID 2: rejected")
 	})
@@ -300,6 +310,71 @@ func Test_VerifyChannelDefinitions_FeedIDCollisions(t *testing.T) {
 		tombstoned := channel()
 		tombstoned.Tombstone = true
 		channelDefs := llotypes.ChannelDefinitions{1: channel(), 2: tombstoned}
-		require.NoError(t, VerifyChannelDefinitions(codecs(mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}), channelDefs))
+		require.NoError(t, verifyAdmittingAll(codecs(mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true}), channelDefs))
 	})
+}
+
+// mockAdmissionCodec rejects every definition on admission, and accepts every
+// definition otherwise.
+type mockAdmissionCodec struct{ mockReportCodec }
+
+func (mockAdmissionCodec) VerifyForAdmission(llotypes.ChannelDefinition) error {
+	return errors.New("admission rejected")
+}
+
+func Test_VerifyChannelDefinitions_AdmissionScope(t *testing.T) {
+	feedIDCodecs := map[llotypes.ReportFormat]ReportCodec{
+		0: mockFeedIDCodec{feedID: [32]byte{0xab}, ok: true},
+	}
+	channel := func() llotypes.ChannelDefinition {
+		return llotypes.ChannelDefinition{Streams: []llotypes.Stream{{StreamID: 1, Aggregator: llotypes.AggregatorMedian}}}
+	}
+	colliding := llotypes.ChannelDefinitions{1: channel(), 2: channel()}
+
+	t.Run("committed definitions are not held to the admission-only checks", func(t *testing.T) {
+		// Both channels share a feed ID, which would be rejected on admission.
+		// Neither is being admitted, so verification passes and the oracles keep
+		// observing rather than halting.
+		require.NoError(t, VerifyChannelDefinitions(feedIDCodecs, colliding))
+		require.NoError(t, VerifyChannelDefinitionsForAdmission(feedIDCodecs, colliding, nil))
+		require.NoError(t, VerifyChannelDefinitionsForAdmission(feedIDCodecs, colliding, map[llotypes.ChannelID]struct{}{}))
+	})
+	t.Run("a cross-definition finding is kept when either channel is admitted", func(t *testing.T) {
+		// The finding is reported against channel 2, the one seen second, so
+		// admitting only channel 1 must still keep it -- otherwise a new channel
+		// could squat the feed ID of a committed one with a higher ID.
+		for _, admitted := range []llotypes.ChannelID{1, 2} {
+			err := VerifyChannelDefinitionsForAdmission(feedIDCodecs, colliding, map[llotypes.ChannelID]struct{}{admitted: {}})
+			require.EqualError(t, err, "ChannelDefinition with ID 2 has feed ID 0xab00000000000000000000000000000000000000000000000000000000000000 already used by channel 1")
+		}
+	})
+	t.Run("AdmissionVerifier is only consulted for admitted channels", func(t *testing.T) {
+		codecs := map[llotypes.ReportFormat]ReportCodec{0: mockAdmissionCodec{}}
+		defs := llotypes.ChannelDefinitions{1: channel(), 2: channel()}
+		require.NoError(t, VerifyChannelDefinitions(codecs, defs))
+		err := VerifyChannelDefinitionsForAdmission(codecs, defs, map[llotypes.ChannelID]struct{}{2: {}})
+		require.EqualError(t, err, "invalid ChannelDefinition with ID 2: admission rejected")
+	})
+	t.Run("baseline checks apply to committed definitions", func(t *testing.T) {
+		defs := llotypes.ChannelDefinitions{1: {}}
+		require.EqualError(t, VerifyChannelDefinitions(feedIDCodecs, defs), "ChannelDefinition with ID 1 has no streams")
+	})
+}
+
+func Test_ChangedChannelIDs(t *testing.T) {
+	streams := []llotypes.Stream{{StreamID: 1, Aggregator: llotypes.AggregatorMedian}}
+	current := llotypes.ChannelDefinitions{
+		1: {Streams: streams},
+		2: {Streams: streams},
+		3: {Streams: streams},
+	}
+	desired := llotypes.ChannelDefinitions{
+		1: {Streams: streams},                                         // unchanged
+		2: {Streams: streams, ReportFormat: llotypes.ReportFormat(7)}, // changed
+		4: {Streams: streams},                                         // added
+	}
+	// Channel 3 is only being removed, so it is not being admitted.
+	require.Equal(t, map[llotypes.ChannelID]struct{}{2: {}, 4: {}}, ChangedChannelIDs(current, desired))
+	require.Empty(t, ChangedChannelIDs(current, current))
+	require.Empty(t, ChangedChannelIDs(current, nil))
 }

--- a/llo/protocol/history_backfill.go
+++ b/llo/protocol/history_backfill.go
@@ -165,10 +165,10 @@ func ValidateHistoryBackfillAgainstDefinitions(cd llotypes.ChannelDefinition, de
 			return fmt.Errorf("backfill stream %d differs from target", i)
 		}
 	}
-	for _, strm := range target.Streams {
-		if strm.Aggregator == llotypes.AggregatorCalculated {
-			return errors.New("history backfill target channel must not use calculated streams (phase 1 limitation)")
-		}
+	// The target's report format is what says whether it has calculated
+	// streams: they are derived from its opts, not listed on the definition.
+	if HasCalculatedStreams(target) {
+		return errors.New("history backfill target channel must not use calculated streams (phase 1 limitation)")
 	}
 	res, err := TargetChannelTimeResolution(target)
 	if err != nil {

--- a/llo/protocol/history_backfill.go
+++ b/llo/protocol/history_backfill.go
@@ -3,6 +3,8 @@ package protocol
 import (
 	"errors"
 	"fmt"
+	"math"
+	"sort"
 	"strconv"
 
 	"github.com/goccy/go-json"
@@ -35,26 +37,67 @@ func (o *HistoryBackfillOpts) UnmarshalJSON(data []byte) error {
 	if len(w.Observations) == 0 {
 		return errors.New("observations must be non-empty")
 	}
+	if len(w.Observations) > MaxHistoryBackfillObservations {
+		return fmt.Errorf("backfill definition has too many observations: %d > %d",
+			len(w.Observations), MaxHistoryBackfillObservations)
+	}
+
+	// Keys are visited in sorted order so that a definition with more than one
+	// problem always reports the same one, and a duplicate always names the same
+	// pair. Distinct keys can decode to the same number -- ParseUint accepts
+	// leading zeros, so "01" and "1" are both 1 -- which is what the duplicate
+	// checks below are for.
 	o.Observations = make(map[uint64]map[llotypes.StreamID]string, len(w.Observations))
-	for tsStr, streams := range w.Observations {
+	firstTSKey := make(map[uint64]string, len(w.Observations))
+	for _, tsStr := range sortedKeys(w.Observations) {
+		streams := w.Observations[tsStr]
 		ts, err := strconv.ParseUint(tsStr, 10, 64)
 		if err != nil {
 			return fmt.Errorf("invalid observation timestamp key %q: %w", tsStr, err)
 		}
+
+		if earlier, ok := firstTSKey[ts]; ok {
+			return fmt.Errorf("duplicate timestamp key %q: decodes to %d, same as %q", tsStr, ts, earlier)
+		}
+		firstTSKey[ts] = tsStr
+
 		if len(streams) == 0 {
 			return fmt.Errorf("empty stream map for timestamp %s", tsStr)
 		}
+
+		if len(streams) > MaxStreamsPerChannel {
+			return fmt.Errorf("backfill observation has too many streams: %d > %d", len(streams), MaxStreamsPerChannel)
+		}
+
 		inner := make(map[llotypes.StreamID]string, len(streams))
-		for sidStr, val := range streams {
+		firstStreamKey := make(map[llotypes.StreamID]string, len(streams))
+		for _, sidStr := range sortedKeys(streams) {
 			sid64, err := strconv.ParseUint(sidStr, 10, 32)
 			if err != nil {
 				return fmt.Errorf("invalid stream id key %q at timestamp %s: %w", sidStr, tsStr, err)
 			}
-			inner[llotypes.StreamID(sid64)] = val
+
+			sid := llotypes.StreamID(sid64)
+			if earlier, ok := firstStreamKey[sid]; ok {
+				return fmt.Errorf("duplicate stream id key %q at timestamp %s: decodes to %d, same as %q", sidStr, tsStr, sid, earlier)
+			}
+			firstStreamKey[sid] = sidStr
+			inner[sid] = streams[sidStr]
 		}
 		o.Observations[ts] = inner
 	}
 	return nil
+}
+
+// sortedKeys returns a map's keys in ascending order, so that a loop over them
+// reports the same problem on every oracle.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // ParseHistoryBackfillOpts decodes opts bytes into HistoryBackfillOpts.
@@ -66,13 +109,48 @@ func ParseHistoryBackfillOpts(raw llotypes.ChannelOpts) (HistoryBackfillOpts, er
 	if err := json.Unmarshal(raw, &o); err != nil {
 		return o, err
 	}
-	if o.TargetChannelID == 0 {
-		return o, errors.New("targetChannelId must be non-zero")
-	}
-	if len(o.Observations) == 0 {
-		return o, errors.New("observations must be non-empty")
+	if err := o.validate(); err != nil {
+		return o, err
 	}
 	return o, nil
+}
+
+// GetHistoryBackfillOpts returns a history_backfill channel's parsed opts,
+// preferring the (node-local) decode cache and falling back to parsing the
+// definition's raw opts on a miss. The fallback keeps the result identical
+// across oracles even when the cache has not been populated.
+//
+// Selection runs two or three times per backfill channel per round, and the opts
+// carry up to MaxHistoryBackfillObservations observations of stream values, so
+// parsing them afresh each time is the difference between one allocation of that
+// map per generation and several per round.
+func GetHistoryBackfillOpts(optsCache *OptsCache, cd llotypes.ChannelDefinition, cid llotypes.ChannelID) (HistoryBackfillOpts, error) {
+	if optsCache == nil {
+		return ParseHistoryBackfillOpts(cd.Opts)
+	}
+	o, err := GetOpts[HistoryBackfillOpts](optsCache, cid)
+	if err != nil {
+		return ParseHistoryBackfillOpts(cd.Opts)
+	}
+	// GetOpts decodes but does not apply the rules ParseHistoryBackfillOpts
+	// applies after decoding, including the ones that reject empty opts: a
+	// channel with no raw bytes decodes to the zero value without error.
+	if err := o.validate(); err != nil {
+		return HistoryBackfillOpts{}, err
+	}
+	return o, nil
+}
+
+// validate applies the rules that hold for decoded opts however they were
+// decoded.
+func (o HistoryBackfillOpts) validate() error {
+	if o.TargetChannelID == 0 {
+		return errors.New("targetChannelId must be non-zero")
+	}
+	if len(o.Observations) == 0 {
+		return errors.New("observations must be non-empty")
+	}
+	return nil
 }
 
 // ReportCodecHistoryBackfill validates channel definitions; encoding is delegated to the target channel codec.
@@ -112,20 +190,33 @@ func ReportTimestampResolutionNanos(target llotypes.ChannelDefinition) (uint64, 
 	}
 }
 
-// ObservationTimestampKeyToNanoseconds converts a raw observation timestamp key from opts to nanoseconds.
-func ObservationTimestampKeyToNanoseconds(rawKey uint64, res TimeResolution) uint64 {
+// ObservationTimestampKeyToNanoseconds converts a raw observation timestamp key
+// from opts to nanoseconds, reporting whether the key is representable.
+//
+// The scaling is unsigned multiplication, so it wraps: a key beyond about 1.8e10
+// seconds becomes a small number of nanoseconds. That is the dangerous direction
+// -- every caller compares the result against a bound it must be below (now, the
+// round's observation timestamp) and a wrapped value passes all of them, so an
+// unrepresentable far-future timestamp would read as a valid past one. Keys come
+// from channel definition opts, which makes this reachable from configuration.
+func ObservationTimestampKeyToNanoseconds(rawKey uint64, res TimeResolution) (nanoseconds uint64, ok bool) {
+	var multiplier uint64
 	switch res {
-	case ResolutionSeconds:
-		return rawKey * 1e9
 	case ResolutionMilliseconds:
-		return rawKey * 1e6
+		multiplier = 1e6
 	case ResolutionMicroseconds:
-		return rawKey * 1e3
+		multiplier = 1e3
 	case ResolutionNanoseconds:
-		return rawKey
+		return rawKey, true
+	case ResolutionSeconds:
+		multiplier = 1e9
 	default:
-		return rawKey * 1e9
+		multiplier = 1e9
 	}
+	if rawKey > math.MaxUint64/multiplier {
+		return 0, false
+	}
+	return rawKey * multiplier, true
 }
 
 func TargetChannelTimeResolution(target llotypes.ChannelDefinition) (TimeResolution, error) {
@@ -175,7 +266,10 @@ func ValidateHistoryBackfillAgainstDefinitions(cd llotypes.ChannelDefinition, de
 		return err
 	}
 	for rawTS, streams := range opts.Observations {
-		tsNanos := ObservationTimestampKeyToNanoseconds(rawTS, res)
+		tsNanos, ok := ObservationTimestampKeyToNanoseconds(rawTS, res)
+		if !ok {
+			return fmt.Errorf("observation timestamp raw %d cannot be expressed in nanoseconds at the target channel's time resolution", rawTS)
+		}
 		if nowNanos > 0 && tsNanos >= nowNanos {
 			return fmt.Errorf("observation timestamp %d (raw %d) is not strictly in the past relative to reference time", tsNanos, rawTS)
 		}
@@ -187,6 +281,36 @@ func ValidateHistoryBackfillAgainstDefinitions(cd llotypes.ChannelDefinition, de
 				return fmt.Errorf("timestamp %d: missing stream %d", rawTS, strm.StreamID)
 			}
 		}
+	}
+	return nil
+}
+
+// ValidateHistoryBackfillTarget rejects a backfill channel whose target is
+// itself a backfill channel, which includes a channel targeting itself.
+//
+// Such a definition passes every other rule: the resolution lookup falls through
+// to seconds, the stream lists match trivially when the target is the channel
+// itself, and the target declares no calculated streams. It fails only at the
+// very end, in Report, where the codec resolved from the target's report format
+// is ReportCodecHistoryBackfill, whose Encode always errors. The channel is then
+// selected, logged and skipped every round forever, because the watermark only
+// advances on a report that was actually emitted.
+//
+// This is an admission-only rule (see VerifyChannelDefinitionsForAdmission).
+// Rejecting an already-committed definition here would stop an oracle from
+// observing at all, and a definition like this has never produced a report, so
+// there is nothing to protect but the ability to install a new one.
+func ValidateHistoryBackfillTarget(cd llotypes.ChannelDefinition, defs llotypes.ChannelDefinitions) error {
+	opts, err := ParseHistoryBackfillOpts(cd.Opts)
+	if err != nil {
+		return err
+	}
+	target, ok := defs[opts.TargetChannelID]
+	if !ok {
+		return nil // reported by ValidateHistoryBackfillAgainstDefinitions
+	}
+	if target.ReportFormat == llotypes.ReportFormatHistoryBackfill {
+		return fmt.Errorf("target channel %d is itself a history_backfill channel, whose reports cannot be encoded", opts.TargetChannelID)
 	}
 	return nil
 }

--- a/llo/protocol/history_backfill_test.go
+++ b/llo/protocol/history_backfill_test.go
@@ -1,0 +1,123 @@
+package protocol
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+)
+
+func Test_ObservationTimestampKeyToNanoseconds_Overflow(t *testing.T) {
+	// Scaling wraps, and it wraps in the dangerous direction: callers compare
+	// the result against an upper bound it must be below, so a wrapped
+	// far-future key would read as a valid past timestamp.
+	for _, tc := range []struct {
+		name   string
+		rawKey uint64
+		res    TimeResolution
+		want   uint64
+		wantOK bool
+	}{
+		{"seconds", 1_700_000_000, ResolutionSeconds, uint64(1_700_000_000) * uint64(1e9), true},
+		{"largest representable second", math.MaxUint64 / uint64(1e9), ResolutionSeconds, (math.MaxUint64 / uint64(1e9)) * 1e9, true},
+		{"seconds overflow", math.MaxUint64/uint64(1e9) + 1, ResolutionSeconds, 0, false},
+		{"milliseconds overflow", math.MaxUint64/uint64(1e6) + 1, ResolutionMilliseconds, 0, false},
+		{"microseconds overflow", math.MaxUint64/uint64(1e3) + 1, ResolutionMicroseconds, 0, false},
+		{"nanoseconds never overflow", math.MaxUint64, ResolutionNanoseconds, math.MaxUint64, true},
+		{"unknown resolution is treated as seconds", math.MaxUint64, TimeResolution(200), 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ObservationTimestampKeyToNanoseconds(tc.rawKey, tc.res)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	// The wrapped value is what makes this worth guarding: it is far below any
+	// plausible reference time, so every "must be in the past" check it is fed
+	// to would pass. Computed through variables because the constant expression
+	// does not compile.
+	rawKey, multiplier := math.MaxUint64/uint64(1e9)+1, uint64(1e9)
+	require.Less(t, rawKey*multiplier, uint64(1_700_000_000)*multiplier)
+}
+
+func Test_GetHistoryBackfillOpts(t *testing.T) {
+	raw := llotypes.ChannelOpts(`{"targetChannelId":7,"observations":{"1700000000":{"1":"1.5"}}}`)
+	cd := llotypes.ChannelDefinition{ReportFormat: llotypes.ReportFormatHistoryBackfill, Opts: raw}
+
+	want, err := ParseHistoryBackfillOpts(raw)
+	require.NoError(t, err)
+
+	t.Run("no cache parses the definition", func(t *testing.T) {
+		got, err := GetHistoryBackfillOpts(nil, cd, 1)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+	t.Run("cache returns the same opts", func(t *testing.T) {
+		c := NewOptsCache()
+		c.Set(1, raw)
+		got, err := GetHistoryBackfillOpts(c, cd, 1)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+
+		// Served from the decoded entry the second time; same value.
+		got, err = GetHistoryBackfillOpts(c, cd, 1)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+	t.Run("a channel missing from the cache falls back to the definition", func(t *testing.T) {
+		got, err := GetHistoryBackfillOpts(NewOptsCache(), cd, 1)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+	t.Run("empty opts are rejected even though they decode", func(t *testing.T) {
+		// GetOpts skips the unmarshal for empty raw bytes and yields the zero
+		// value without error, which the post-decode rules have to catch.
+		c := NewOptsCache()
+		c.Set(2, nil)
+		_, err := GetHistoryBackfillOpts(c, llotypes.ChannelDefinition{}, 2)
+		require.Error(t, err)
+	})
+}
+
+func Test_ValidateHistoryBackfillTarget(t *testing.T) {
+	backfill := func(targetID llotypes.ChannelID) llotypes.ChannelDefinition {
+		return llotypes.ChannelDefinition{
+			ReportFormat: llotypes.ReportFormatHistoryBackfill,
+			Streams:      []llotypes.Stream{{StreamID: 1, Aggregator: llotypes.AggregatorMedian}},
+			Opts:         llotypes.ChannelOpts(fmt.Sprintf(`{"targetChannelId":%d,"observations":{"1700000000":{"1":"1.5"}}}`, targetID)),
+		}
+	}
+	reportable := llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatEVMPremiumLegacy,
+		Streams:      []llotypes.Stream{{StreamID: 1, Aggregator: llotypes.AggregatorMedian}},
+	}
+
+	t.Run("a reportable target is accepted", func(t *testing.T) {
+		defs := llotypes.ChannelDefinitions{1: backfill(2), 2: reportable}
+		require.NoError(t, ValidateHistoryBackfillTarget(defs[1], defs))
+	})
+	t.Run("targeting itself is rejected", func(t *testing.T) {
+		defs := llotypes.ChannelDefinitions{1: backfill(1)}
+		require.ErrorContains(t, ValidateHistoryBackfillTarget(defs[1], defs),
+			"is itself a history_backfill channel")
+	})
+	t.Run("targeting another backfill channel is rejected", func(t *testing.T) {
+		defs := llotypes.ChannelDefinitions{1: backfill(2), 2: backfill(3), 3: reportable}
+		require.ErrorContains(t, ValidateHistoryBackfillTarget(defs[1], defs),
+			"is itself a history_backfill channel")
+	})
+
+	// The rule is admission-only: a committed self-targeting channel must not
+	// stop an oracle from observing, but it must not be installable either.
+	t.Run("committed definitions keep working", func(t *testing.T) {
+		defs := llotypes.ChannelDefinitions{1: backfill(1)}
+		codecs := map[llotypes.ReportFormat]ReportCodec{}
+		require.NoError(t, VerifyChannelDefinitions(codecs, defs))
+		err := VerifyChannelDefinitionsForAdmission(codecs, defs, map[llotypes.ChannelID]struct{}{1: {}})
+		require.ErrorContains(t, err, "is itself a history_backfill channel")
+	})
+}

--- a/llo/protocol/limits.go
+++ b/llo/protocol/limits.go
@@ -159,4 +159,8 @@ const (
 	// to MaxStreamsPerChannel streams each, which lands in the low single-digit
 	// MiB range. 16 MiB leaves generous headroom.
 	MaxDecompressedObservationLength = 16 << 20
+
+	// MaxHistoryBackfillObservations bounds the maximum number of
+	// observations to backfill per definition.
+	MaxHistoryBackfillObservations = 64
 )

--- a/llo/protocol/limits.go
+++ b/llo/protocol/limits.go
@@ -39,8 +39,119 @@ const (
 	// can be supported
 	MaxOutcomeChannelDefinitionsLength = MaxReportCount
 
+	// Stream history limits.
+	//
+	// A history "pair" is a (streamID, aggregator) tuple: the identity of one
+	// persisted window of past agreed values. The aggregator is part of the
+	// identity because the same stream can be aggregated differently by
+	// different channels, and appending both into one series would silently
+	// interleave two unrelated value series. The stream value's field
+	// (bid/ask/benchmark) is NOT part of the identity: one stored window serves
+	// every field, because a whole stream value is stored per record and the
+	// field is selected when the window is read.
+	//
+	// Measured sizes of a full 1024-record window, marshaled:
+	//
+	//	Decimal, small integers               19.7 KiB  (19.7 B/record)
+	//	Decimal, 18-digit price               26.0 KiB  (26.0 B/record)
+	//	Decimal, 38-digit                     37.0 KiB  (37.0 B/record)
+	//	TimestampedStreamValue, 18-digit      42.0 KiB  (42.0 B/record)
+	//	Quote, three 18-digit decimals        60.0 KiB  (60.0 B/record)
+
+	// MaxHistoryRecordsPerPair bounds the depth of the persisted history window
+	// for a single pair, and therefore the maximum depth any expression may
+	// request. Note this is per pair, not per stream: a stream aggregated two
+	// ways holds two windows of up to this depth each.
+	MaxHistoryRecordsPerPair = 1024
+	// MaxHistoryPairs bounds how many pairs may have history at once. Pairs are
+	// ordered by (streamID, aggregator) and those beyond the cap are denied
+	// history; channels referencing them become unreportable rather than
+	// silently getting a shortened window. A stream aggregated two ways
+	// consumes two of these, not one.
+	MaxHistoryPairs = 128
+	// MaxHistoryTotalBytes bounds the estimated total history bytes rewritten
+	// per round (sum over pairs of requiredCount * MaxHistoryRecordBytes). The
+	// OCR3.1 per-round budget for modified keys plus values is 10 MiB and is
+	// shared with channel definitions and the other key prefixes, so history is
+	// held well below it.
+	MaxHistoryTotalBytes = 4 << 20
+	// MaxHistoryRecordsPerExpression bounds the total history depth a single
+	// expression may request, summed over all of its History calls. Each
+	// requested record is work the evaluator does every round, so without this
+	// one expression could combine many legal per-pair depths into an
+	// arbitrarily expensive evaluation.
+	MaxHistoryRecordsPerExpression = 4 * MaxHistoryRecordsPerPair
+	// MaxHistoryRecordBytes is the maximum serialized size of one history
+	// record, enforced on append (StreamHistory.Append) and used as the
+	// per-record size when admitting pairs against MaxHistoryTotalBytes.
+	// Enforcing the same number that the budget assumes is what makes the
+	// budget a real bound rather than an estimate.
+	//
+	// It has to be enforced rather than assumed because MaxDecimalExponent
+	// bounds a decimal's exponent but not its coefficient length: a 1000-digit
+	// coefficient is ~415 bytes, so an unchecked Quote of three of them would be
+	// ~1.3 KB per record and a full window ~1.3 MB — orders of magnitude past
+	// what the byte budget was sized for, and still under libocr's 2 MiB
+	// per-key limit, so nothing else would reject it.
+	//
+	// 128 B is roughly twice the largest measured record (a quote of three
+	// 18-digit decimals, 60 B), so it accommodates real feeds while rejecting
+	// pathological values. A rejected record leaves a gap in the series, which
+	// is honest, and is logged.
+	MaxHistoryRecordBytes = 128
+
+	// MaxHistoryChunkRecords is the number of records held by one slot of the
+	// chunked ring layout. It is the single knob of that layout: per-round write
+	// bytes are proportional to it, per-round reads are proportional to depth
+	// divided by it, and both are comfortable at 64.
+	//
+	// For a quote stream (60 B/record) a full chunk is 3.9 KiB, so a pair costs
+	// ~1.9 KiB of writes in an average round instead of rewriting the whole
+	// window, and a 1024-deep window is read in 18 point reads instead of 1024.
+	// The value is consensus-relevant — it determines the bytes every oracle
+	// writes — so it is a constant here and never per-node configurable.
+	// Changing it changes the stored layout and requires resetting every window.
+	//
+	// It must divide MaxHistoryRecordsPerPair, so that a window at maximum depth
+	// is an exact number of chunks (asserted by TestHistoryChunkLimits).
+	MaxHistoryChunkRecords = 64
+	// MaxHistoryChunkSlots is the size of the ring: the number of distinct chunk
+	// slots one pair may occupy.
+	//
+	// A window retains at most MaxHistoryRecordsPerPair/MaxHistoryChunkRecords+1
+	// chunks — the +1 for the partially consumed oldest chunk — and a round may
+	// hold one more transiently, between appending into a freshly created chunk
+	// and evicting the oldest. Hence +2.
+	//
+	// The ring is deliberately a fixed, small, statically known slot space
+	// rather than an unbounded sequence: the in-round reader offers no range
+	// scan, so if a header is ever unreadable there is no way to discover which
+	// chunk keys exist. A bounded slot space makes recovery a blind delete of
+	// every slot. Reuse of a slot across a lap of the ring is caught by the
+	// sequence stored inside each chunk.
+	MaxHistoryChunkSlots = MaxHistoryRecordsPerPair/MaxHistoryChunkRecords + 2
+	// MaxHistoryRetainedRecords is the most records a window may hold. Retention
+	// works in whole chunks, so a window overshoots its required depth by up to
+	// one chunk less one record. Readers ask for an exact depth and never see
+	// the overshoot.
+	MaxHistoryRetainedRecords = MaxHistoryRecordsPerPair + MaxHistoryChunkRecords - 1
+	// MaxHistoryHeaderBytes bounds the serialized size of a window header: a
+	// couple of scalars plus two arrays of at most MaxHistoryChunkSlots entries,
+	// which lands under 300 B. 512 leaves headroom without mattering to the
+	// budget it feeds.
+	MaxHistoryHeaderBytes = 512
+	// MaxHistoryPairRoundBytes is what one pair can cost the per-round byte
+	// budget: the newest chunk, rewritten every round, plus the header. Sealed
+	// chunks are immutable and evictions are deletes, so nothing else is
+	// written however deep the window is.
+	//
+	// This is the number that makes the chunked layout worth having: it is
+	// independent of the window depth, where the single-blob layout charged
+	// requiredCount * MaxHistoryRecordBytes every round.
+	MaxHistoryPairRoundBytes = MaxHistoryChunkRecords*MaxHistoryRecordBytes + MaxHistoryHeaderBytes
+
 	// MaxDecompressedObservationLength bounds the size of an observation after
-	// zstd decompression. 
+	// zstd decompression.
 	//
 	// A legitimate observation is bounded by
 	// MaxObservationStreamValuesLength stream values plus

--- a/llo/protocol/plugin_codecs.pb.go
+++ b/llo/protocol/plugin_codecs.pb.go
@@ -336,6 +336,218 @@ func (x *LLOTimestampedStreamValue) GetStreamValue() *LLOStreamValue {
 	return nil
 }
 
+// LLOStreamHistoryRecord is one agreed aggregate value of a stream, with the
+// timestamp it was observed at. Per-record timestamps are required: rounds are
+// not evenly spaced, so time-weighted functions and gap detection cannot work
+// from the window bounds alone.
+type LLOStreamHistoryRecord struct {
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	ObservedAtNanoseconds uint64                 `protobuf:"varint,1,opt,name=observedAtNanoseconds,proto3" json:"observedAtNanoseconds,omitempty"`
+	Value                 *LLOStreamValue        `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *LLOStreamHistoryRecord) Reset() {
+	*x = LLOStreamHistoryRecord{}
+	mi := &file_plugin_codecs_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LLOStreamHistoryRecord) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LLOStreamHistoryRecord) ProtoMessage() {}
+
+func (x *LLOStreamHistoryRecord) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_codecs_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LLOStreamHistoryRecord.ProtoReflect.Descriptor instead.
+func (*LLOStreamHistoryRecord) Descriptor() ([]byte, []int) {
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *LLOStreamHistoryRecord) GetObservedAtNanoseconds() uint64 {
+	if x != nil {
+		return x.ObservedAtNanoseconds
+	}
+	return 0
+}
+
+func (x *LLOStreamHistoryRecord) GetValue() *LLOStreamValue {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+// LLOStreamHistoryChunkProto is one slot of the chunked ring layout: a run of
+// consecutive history records for a single (streamID, aggregator) pair.
+//
+// Only the newest chunk of a window is ever rewritten; once a chunk is full it
+// is immutable for as long as it is retained. That is what makes the per-round
+// write cost a function of the chunk size rather than of the window depth.
+type LLOStreamHistoryChunkProto struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Absolute chunk index, monotonically increasing over the life of the
+	// window. The key holds only sequence mod MaxHistoryChunkSlots, so this is
+	// what distinguishes a live chunk from a stale one left by an earlier lap of
+	// the ring.
+	Sequence uint64 `protobuf:"varint,1,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	// Oldest first, newest last; observedAtNanoseconds strictly increasing.
+	Records       []*LLOStreamHistoryRecord `protobuf:"bytes,2,rep,name=records,proto3" json:"records,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LLOStreamHistoryChunkProto) Reset() {
+	*x = LLOStreamHistoryChunkProto{}
+	mi := &file_plugin_codecs_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LLOStreamHistoryChunkProto) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LLOStreamHistoryChunkProto) ProtoMessage() {}
+
+func (x *LLOStreamHistoryChunkProto) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_codecs_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LLOStreamHistoryChunkProto.ProtoReflect.Descriptor instead.
+func (*LLOStreamHistoryChunkProto) Descriptor() ([]byte, []int) {
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *LLOStreamHistoryChunkProto) GetSequence() uint64 {
+	if x != nil {
+		return x.Sequence
+	}
+	return 0
+}
+
+func (x *LLOStreamHistoryChunkProto) GetRecords() []*LLOStreamHistoryRecord {
+	if x != nil {
+		return x.Records
+	}
+	return nil
+}
+
+// LLOStreamHistoryHeaderProto is the index of a chunked history window: which
+// chunks are retained, how full each one is, and when each one starts.
+//
+// It is sized so that every decision a round makes — is there enough depth,
+// which chunks must be read, may this value be appended, which chunk falls out
+// — can be taken from the header alone, without reading a single chunk.
+type LLOStreamHistoryHeaderProto struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Capacity: the maximum depth required by any live channel/expression
+	// referencing this pair. Zero means the pair is torn down.
+	RequiredCount uint32 `protobuf:"varint,1,opt,name=requiredCount,proto3" json:"requiredCount,omitempty"`
+	// Absolute sequence of the oldest retained chunk. Zero when nothing is
+	// stored.
+	FirstSequence uint64 `protobuf:"varint,2,opt,name=firstSequence,proto3" json:"firstSequence,omitempty"`
+	// Records held by each retained chunk, oldest first. Every entry except the
+	// last equals MaxHistoryChunkRecords; the last is in [1, MaxHistoryChunkRecords].
+	Counts []uint32 `protobuf:"varint,3,rep,packed,name=counts,proto3" json:"counts,omitempty"`
+	// observedAtNanoseconds of the first record of each retained chunk, parallel
+	// to counts and strictly increasing. Denormalized so that evicting a chunk
+	// does not require loading its successor to learn the window's new start.
+	ChunkFirstObservationTimestampNanoseconds []uint64 `protobuf:"varint,4,rep,packed,name=chunkFirstObservationTimestampNanoseconds,proto3" json:"chunkFirstObservationTimestampNanoseconds,omitempty"`
+	// observedAtNanoseconds of the newest record in the window, or 0 when empty.
+	// The strictly-newer append rule is decided against this alone.
+	LastObservationTimestampNanoseconds uint64 `protobuf:"varint,5,opt,name=lastObservationTimestampNanoseconds,proto3" json:"lastObservationTimestampNanoseconds,omitempty"`
+	unknownFields                       protoimpl.UnknownFields
+	sizeCache                           protoimpl.SizeCache
+}
+
+func (x *LLOStreamHistoryHeaderProto) Reset() {
+	*x = LLOStreamHistoryHeaderProto{}
+	mi := &file_plugin_codecs_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LLOStreamHistoryHeaderProto) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LLOStreamHistoryHeaderProto) ProtoMessage() {}
+
+func (x *LLOStreamHistoryHeaderProto) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_codecs_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LLOStreamHistoryHeaderProto.ProtoReflect.Descriptor instead.
+func (*LLOStreamHistoryHeaderProto) Descriptor() ([]byte, []int) {
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *LLOStreamHistoryHeaderProto) GetRequiredCount() uint32 {
+	if x != nil {
+		return x.RequiredCount
+	}
+	return 0
+}
+
+func (x *LLOStreamHistoryHeaderProto) GetFirstSequence() uint64 {
+	if x != nil {
+		return x.FirstSequence
+	}
+	return 0
+}
+
+func (x *LLOStreamHistoryHeaderProto) GetCounts() []uint32 {
+	if x != nil {
+		return x.Counts
+	}
+	return nil
+}
+
+func (x *LLOStreamHistoryHeaderProto) GetChunkFirstObservationTimestampNanoseconds() []uint64 {
+	if x != nil {
+		return x.ChunkFirstObservationTimestampNanoseconds
+	}
+	return nil
+}
+
+func (x *LLOStreamHistoryHeaderProto) GetLastObservationTimestampNanoseconds() uint64 {
+	if x != nil {
+		return x.LastObservationTimestampNanoseconds
+	}
+	return 0
+}
+
 type LLOChannelDefinitionProto struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	ReportFormat           uint32                 `protobuf:"varint,1,opt,name=reportFormat,proto3" json:"reportFormat,omitempty"`
@@ -350,7 +562,7 @@ type LLOChannelDefinitionProto struct {
 
 func (x *LLOChannelDefinitionProto) Reset() {
 	*x = LLOChannelDefinitionProto{}
-	mi := &file_plugin_codecs_proto_msgTypes[4]
+	mi := &file_plugin_codecs_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -362,7 +574,7 @@ func (x *LLOChannelDefinitionProto) String() string {
 func (*LLOChannelDefinitionProto) ProtoMessage() {}
 
 func (x *LLOChannelDefinitionProto) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[4]
+	mi := &file_plugin_codecs_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -375,7 +587,7 @@ func (x *LLOChannelDefinitionProto) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLOChannelDefinitionProto.ProtoReflect.Descriptor instead.
 func (*LLOChannelDefinitionProto) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{4}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *LLOChannelDefinitionProto) GetReportFormat() uint32 {
@@ -430,7 +642,7 @@ type LLOStreamDefinition struct {
 
 func (x *LLOStreamDefinition) Reset() {
 	*x = LLOStreamDefinition{}
-	mi := &file_plugin_codecs_proto_msgTypes[5]
+	mi := &file_plugin_codecs_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -442,7 +654,7 @@ func (x *LLOStreamDefinition) String() string {
 func (*LLOStreamDefinition) ProtoMessage() {}
 
 func (x *LLOStreamDefinition) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[5]
+	mi := &file_plugin_codecs_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -455,7 +667,7 @@ func (x *LLOStreamDefinition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLOStreamDefinition.ProtoReflect.Descriptor instead.
 func (*LLOStreamDefinition) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{5}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *LLOStreamDefinition) GetStreamID() uint32 {
@@ -482,7 +694,7 @@ type LLOStreamObservationProto struct {
 
 func (x *LLOStreamObservationProto) Reset() {
 	*x = LLOStreamObservationProto{}
-	mi := &file_plugin_codecs_proto_msgTypes[6]
+	mi := &file_plugin_codecs_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -494,7 +706,7 @@ func (x *LLOStreamObservationProto) String() string {
 func (*LLOStreamObservationProto) ProtoMessage() {}
 
 func (x *LLOStreamObservationProto) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[6]
+	mi := &file_plugin_codecs_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -507,7 +719,7 @@ func (x *LLOStreamObservationProto) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLOStreamObservationProto.ProtoReflect.Descriptor instead.
 func (*LLOStreamObservationProto) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{6}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *LLOStreamObservationProto) GetValid() bool {
@@ -538,7 +750,7 @@ type LLOOutcomeProtoV0 struct {
 
 func (x *LLOOutcomeProtoV0) Reset() {
 	*x = LLOOutcomeProtoV0{}
-	mi := &file_plugin_codecs_proto_msgTypes[7]
+	mi := &file_plugin_codecs_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -550,7 +762,7 @@ func (x *LLOOutcomeProtoV0) String() string {
 func (*LLOOutcomeProtoV0) ProtoMessage() {}
 
 func (x *LLOOutcomeProtoV0) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[7]
+	mi := &file_plugin_codecs_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -563,7 +775,7 @@ func (x *LLOOutcomeProtoV0) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLOOutcomeProtoV0.ProtoReflect.Descriptor instead.
 func (*LLOOutcomeProtoV0) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{7}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *LLOOutcomeProtoV0) GetLifeCycleStage() string {
@@ -615,7 +827,7 @@ type LLOOutcomeProtoV1 struct {
 
 func (x *LLOOutcomeProtoV1) Reset() {
 	*x = LLOOutcomeProtoV1{}
-	mi := &file_plugin_codecs_proto_msgTypes[8]
+	mi := &file_plugin_codecs_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -627,7 +839,7 @@ func (x *LLOOutcomeProtoV1) String() string {
 func (*LLOOutcomeProtoV1) ProtoMessage() {}
 
 func (x *LLOOutcomeProtoV1) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[8]
+	mi := &file_plugin_codecs_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -640,7 +852,7 @@ func (x *LLOOutcomeProtoV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLOOutcomeProtoV1.ProtoReflect.Descriptor instead.
 func (*LLOOutcomeProtoV1) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{8}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *LLOOutcomeProtoV1) GetLifeCycleStage() string {
@@ -688,7 +900,7 @@ type LLOChannelIDAndDefinitionProto struct {
 
 func (x *LLOChannelIDAndDefinitionProto) Reset() {
 	*x = LLOChannelIDAndDefinitionProto{}
-	mi := &file_plugin_codecs_proto_msgTypes[9]
+	mi := &file_plugin_codecs_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -700,7 +912,7 @@ func (x *LLOChannelIDAndDefinitionProto) String() string {
 func (*LLOChannelIDAndDefinitionProto) ProtoMessage() {}
 
 func (x *LLOChannelIDAndDefinitionProto) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[9]
+	mi := &file_plugin_codecs_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -713,7 +925,7 @@ func (x *LLOChannelIDAndDefinitionProto) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLOChannelIDAndDefinitionProto.ProtoReflect.Descriptor instead.
 func (*LLOChannelIDAndDefinitionProto) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{9}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *LLOChannelIDAndDefinitionProto) GetChannelID() uint32 {
@@ -740,7 +952,7 @@ type LLOChannelIDAndValidAfterSecondsProto struct {
 
 func (x *LLOChannelIDAndValidAfterSecondsProto) Reset() {
 	*x = LLOChannelIDAndValidAfterSecondsProto{}
-	mi := &file_plugin_codecs_proto_msgTypes[10]
+	mi := &file_plugin_codecs_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -752,7 +964,7 @@ func (x *LLOChannelIDAndValidAfterSecondsProto) String() string {
 func (*LLOChannelIDAndValidAfterSecondsProto) ProtoMessage() {}
 
 func (x *LLOChannelIDAndValidAfterSecondsProto) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[10]
+	mi := &file_plugin_codecs_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -765,7 +977,7 @@ func (x *LLOChannelIDAndValidAfterSecondsProto) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use LLOChannelIDAndValidAfterSecondsProto.ProtoReflect.Descriptor instead.
 func (*LLOChannelIDAndValidAfterSecondsProto) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{10}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *LLOChannelIDAndValidAfterSecondsProto) GetChannelID() uint32 {
@@ -792,7 +1004,7 @@ type LLOChannelIDAndValidAfterNanosecondsProto struct {
 
 func (x *LLOChannelIDAndValidAfterNanosecondsProto) Reset() {
 	*x = LLOChannelIDAndValidAfterNanosecondsProto{}
-	mi := &file_plugin_codecs_proto_msgTypes[11]
+	mi := &file_plugin_codecs_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -804,7 +1016,7 @@ func (x *LLOChannelIDAndValidAfterNanosecondsProto) String() string {
 func (*LLOChannelIDAndValidAfterNanosecondsProto) ProtoMessage() {}
 
 func (x *LLOChannelIDAndValidAfterNanosecondsProto) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[11]
+	mi := &file_plugin_codecs_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -817,7 +1029,7 @@ func (x *LLOChannelIDAndValidAfterNanosecondsProto) ProtoReflect() protoreflect.
 
 // Deprecated: Use LLOChannelIDAndValidAfterNanosecondsProto.ProtoReflect.Descriptor instead.
 func (*LLOChannelIDAndValidAfterNanosecondsProto) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{11}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *LLOChannelIDAndValidAfterNanosecondsProto) GetChannelID() uint32 {
@@ -845,7 +1057,7 @@ type LLOStreamAggregate struct {
 
 func (x *LLOStreamAggregate) Reset() {
 	*x = LLOStreamAggregate{}
-	mi := &file_plugin_codecs_proto_msgTypes[12]
+	mi := &file_plugin_codecs_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -857,7 +1069,7 @@ func (x *LLOStreamAggregate) String() string {
 func (*LLOStreamAggregate) ProtoMessage() {}
 
 func (x *LLOStreamAggregate) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[12]
+	mi := &file_plugin_codecs_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -870,7 +1082,7 @@ func (x *LLOStreamAggregate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLOStreamAggregate.ProtoReflect.Descriptor instead.
 func (*LLOStreamAggregate) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{12}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *LLOStreamAggregate) GetStreamID() uint32 {
@@ -910,7 +1122,7 @@ type LLOChannelStateProto struct {
 
 func (x *LLOChannelStateProto) Reset() {
 	*x = LLOChannelStateProto{}
-	mi := &file_plugin_codecs_proto_msgTypes[13]
+	mi := &file_plugin_codecs_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -922,7 +1134,7 @@ func (x *LLOChannelStateProto) String() string {
 func (*LLOChannelStateProto) ProtoMessage() {}
 
 func (x *LLOChannelStateProto) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[13]
+	mi := &file_plugin_codecs_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -935,7 +1147,7 @@ func (x *LLOChannelStateProto) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLOChannelStateProto.ProtoReflect.Descriptor instead.
 func (*LLOChannelStateProto) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{13}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *LLOChannelStateProto) GetChannelDefinitions() []*LLOChannelIDAndDefinitionProto {
@@ -969,7 +1181,7 @@ type LLOHotStateProto struct {
 
 func (x *LLOHotStateProto) Reset() {
 	*x = LLOHotStateProto{}
-	mi := &file_plugin_codecs_proto_msgTypes[14]
+	mi := &file_plugin_codecs_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -981,7 +1193,7 @@ func (x *LLOHotStateProto) String() string {
 func (*LLOHotStateProto) ProtoMessage() {}
 
 func (x *LLOHotStateProto) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[14]
+	mi := &file_plugin_codecs_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -994,7 +1206,7 @@ func (x *LLOHotStateProto) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLOHotStateProto.ProtoReflect.Descriptor instead.
 func (*LLOHotStateProto) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{14}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *LLOHotStateProto) GetObservationTimestampNanoseconds() uint64 {
@@ -1049,7 +1261,7 @@ type LLOPrecursorProto struct {
 
 func (x *LLOPrecursorProto) Reset() {
 	*x = LLOPrecursorProto{}
-	mi := &file_plugin_codecs_proto_msgTypes[15]
+	mi := &file_plugin_codecs_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1061,7 +1273,7 @@ func (x *LLOPrecursorProto) String() string {
 func (*LLOPrecursorProto) ProtoMessage() {}
 
 func (x *LLOPrecursorProto) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_codecs_proto_msgTypes[15]
+	mi := &file_plugin_codecs_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1074,7 +1286,7 @@ func (x *LLOPrecursorProto) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLOPrecursorProto.ProtoReflect.Descriptor instead.
 func (*LLOPrecursorProto) Descriptor() ([]byte, []int) {
-	return file_plugin_codecs_proto_rawDescGZIP(), []int{15}
+	return file_plugin_codecs_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *LLOPrecursorProto) GetLifeCycleStage() string {
@@ -1151,7 +1363,19 @@ const file_plugin_codecs_proto_rawDesc = "" +
 	"\x03ask\x18\x03 \x01(\fR\x03ask\"\x87\x01\n" +
 	"\x19LLOTimestampedStreamValue\x124\n" +
 	"\x15observedAtNanoseconds\x18\x01 \x01(\x04R\x15observedAtNanoseconds\x124\n" +
-	"\vstreamValue\x18\x02 \x01(\v2\x12.v1.LLOStreamValueR\vstreamValue\"\xf4\x01\n" +
+	"\vstreamValue\x18\x02 \x01(\v2\x12.v1.LLOStreamValueR\vstreamValue\"x\n" +
+	"\x16LLOStreamHistoryRecord\x124\n" +
+	"\x15observedAtNanoseconds\x18\x01 \x01(\x04R\x15observedAtNanoseconds\x12(\n" +
+	"\x05value\x18\x02 \x01(\v2\x12.v1.LLOStreamValueR\x05value\"n\n" +
+	"\x1aLLOStreamHistoryChunkProto\x12\x1a\n" +
+	"\bsequence\x18\x01 \x01(\x04R\bsequence\x124\n" +
+	"\arecords\x18\x02 \x03(\v2\x1a.v1.LLOStreamHistoryRecordR\arecords\"\xb1\x02\n" +
+	"\x1bLLOStreamHistoryHeaderProto\x12$\n" +
+	"\rrequiredCount\x18\x01 \x01(\rR\rrequiredCount\x12$\n" +
+	"\rfirstSequence\x18\x02 \x01(\x04R\rfirstSequence\x12\x16\n" +
+	"\x06counts\x18\x03 \x03(\rR\x06counts\x12\\\n" +
+	")chunkFirstObservationTimestampNanoseconds\x18\x04 \x03(\x04R)chunkFirstObservationTimestampNanoseconds\x12P\n" +
+	"#lastObservationTimestampNanoseconds\x18\x05 \x01(\x04R#lastObservationTimestampNanoseconds\"\xf4\x01\n" +
 	"\x19LLOChannelDefinitionProto\x12\"\n" +
 	"\freportFormat\x18\x01 \x01(\rR\freportFormat\x121\n" +
 	"\astreams\x18\x02 \x03(\v2\x17.v1.LLOStreamDefinitionR\astreams\x12\x12\n" +
@@ -1223,55 +1447,60 @@ func file_plugin_codecs_proto_rawDescGZIP() []byte {
 }
 
 var file_plugin_codecs_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_plugin_codecs_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_plugin_codecs_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_plugin_codecs_proto_goTypes = []any{
 	(LLOStreamValue_Type)(0),                          // 0: v1.LLOStreamValue.Type
 	(*LLOObservationProto)(nil),                       // 1: v1.LLOObservationProto
 	(*LLOStreamValue)(nil),                            // 2: v1.LLOStreamValue
 	(*LLOStreamValueQuote)(nil),                       // 3: v1.LLOStreamValueQuote
 	(*LLOTimestampedStreamValue)(nil),                 // 4: v1.LLOTimestampedStreamValue
-	(*LLOChannelDefinitionProto)(nil),                 // 5: v1.LLOChannelDefinitionProto
-	(*LLOStreamDefinition)(nil),                       // 6: v1.LLOStreamDefinition
-	(*LLOStreamObservationProto)(nil),                 // 7: v1.LLOStreamObservationProto
-	(*LLOOutcomeProtoV0)(nil),                         // 8: v1.LLOOutcomeProtoV0
-	(*LLOOutcomeProtoV1)(nil),                         // 9: v1.LLOOutcomeProtoV1
-	(*LLOChannelIDAndDefinitionProto)(nil),            // 10: v1.LLOChannelIDAndDefinitionProto
-	(*LLOChannelIDAndValidAfterSecondsProto)(nil),     // 11: v1.LLOChannelIDAndValidAfterSecondsProto
-	(*LLOChannelIDAndValidAfterNanosecondsProto)(nil), // 12: v1.LLOChannelIDAndValidAfterNanosecondsProto
-	(*LLOStreamAggregate)(nil),                        // 13: v1.LLOStreamAggregate
-	(*LLOChannelStateProto)(nil),                      // 14: v1.LLOChannelStateProto
-	(*LLOHotStateProto)(nil),                          // 15: v1.LLOHotStateProto
-	(*LLOPrecursorProto)(nil),                         // 16: v1.LLOPrecursorProto
-	nil,                                               // 17: v1.LLOObservationProto.UpdateChannelDefinitionsEntry
-	nil,                                               // 18: v1.LLOObservationProto.StreamValuesEntry
+	(*LLOStreamHistoryRecord)(nil),                    // 5: v1.LLOStreamHistoryRecord
+	(*LLOStreamHistoryChunkProto)(nil),                // 6: v1.LLOStreamHistoryChunkProto
+	(*LLOStreamHistoryHeaderProto)(nil),               // 7: v1.LLOStreamHistoryHeaderProto
+	(*LLOChannelDefinitionProto)(nil),                 // 8: v1.LLOChannelDefinitionProto
+	(*LLOStreamDefinition)(nil),                       // 9: v1.LLOStreamDefinition
+	(*LLOStreamObservationProto)(nil),                 // 10: v1.LLOStreamObservationProto
+	(*LLOOutcomeProtoV0)(nil),                         // 11: v1.LLOOutcomeProtoV0
+	(*LLOOutcomeProtoV1)(nil),                         // 12: v1.LLOOutcomeProtoV1
+	(*LLOChannelIDAndDefinitionProto)(nil),            // 13: v1.LLOChannelIDAndDefinitionProto
+	(*LLOChannelIDAndValidAfterSecondsProto)(nil),     // 14: v1.LLOChannelIDAndValidAfterSecondsProto
+	(*LLOChannelIDAndValidAfterNanosecondsProto)(nil), // 15: v1.LLOChannelIDAndValidAfterNanosecondsProto
+	(*LLOStreamAggregate)(nil),                        // 16: v1.LLOStreamAggregate
+	(*LLOChannelStateProto)(nil),                      // 17: v1.LLOChannelStateProto
+	(*LLOHotStateProto)(nil),                          // 18: v1.LLOHotStateProto
+	(*LLOPrecursorProto)(nil),                         // 19: v1.LLOPrecursorProto
+	nil,                                               // 20: v1.LLOObservationProto.UpdateChannelDefinitionsEntry
+	nil,                                               // 21: v1.LLOObservationProto.StreamValuesEntry
 }
 var file_plugin_codecs_proto_depIdxs = []int32{
-	17, // 0: v1.LLOObservationProto.updateChannelDefinitions:type_name -> v1.LLOObservationProto.UpdateChannelDefinitionsEntry
-	18, // 1: v1.LLOObservationProto.streamValues:type_name -> v1.LLOObservationProto.StreamValuesEntry
+	20, // 0: v1.LLOObservationProto.updateChannelDefinitions:type_name -> v1.LLOObservationProto.UpdateChannelDefinitionsEntry
+	21, // 1: v1.LLOObservationProto.streamValues:type_name -> v1.LLOObservationProto.StreamValuesEntry
 	0,  // 2: v1.LLOStreamValue.type:type_name -> v1.LLOStreamValue.Type
 	2,  // 3: v1.LLOTimestampedStreamValue.streamValue:type_name -> v1.LLOStreamValue
-	6,  // 4: v1.LLOChannelDefinitionProto.streams:type_name -> v1.LLOStreamDefinition
-	10, // 5: v1.LLOOutcomeProtoV0.channelDefinitions:type_name -> v1.LLOChannelIDAndDefinitionProto
-	11, // 6: v1.LLOOutcomeProtoV0.validAfterSeconds:type_name -> v1.LLOChannelIDAndValidAfterSecondsProto
-	13, // 7: v1.LLOOutcomeProtoV0.streamAggregates:type_name -> v1.LLOStreamAggregate
-	10, // 8: v1.LLOOutcomeProtoV1.channelDefinitions:type_name -> v1.LLOChannelIDAndDefinitionProto
-	12, // 9: v1.LLOOutcomeProtoV1.validAfterNanoseconds:type_name -> v1.LLOChannelIDAndValidAfterNanosecondsProto
-	13, // 10: v1.LLOOutcomeProtoV1.streamAggregates:type_name -> v1.LLOStreamAggregate
-	5,  // 11: v1.LLOChannelIDAndDefinitionProto.channelDefinition:type_name -> v1.LLOChannelDefinitionProto
-	2,  // 12: v1.LLOStreamAggregate.streamValue:type_name -> v1.LLOStreamValue
-	10, // 13: v1.LLOChannelStateProto.channelDefinitions:type_name -> v1.LLOChannelIDAndDefinitionProto
-	12, // 14: v1.LLOHotStateProto.validAfterNanoseconds:type_name -> v1.LLOChannelIDAndValidAfterNanosecondsProto
-	13, // 15: v1.LLOHotStateProto.streamAggregates:type_name -> v1.LLOStreamAggregate
-	10, // 16: v1.LLOPrecursorProto.channelDefinitions:type_name -> v1.LLOChannelIDAndDefinitionProto
-	12, // 17: v1.LLOPrecursorProto.validAfterNanoseconds:type_name -> v1.LLOChannelIDAndValidAfterNanosecondsProto
-	13, // 18: v1.LLOPrecursorProto.streamAggregates:type_name -> v1.LLOStreamAggregate
-	5,  // 19: v1.LLOObservationProto.UpdateChannelDefinitionsEntry.value:type_name -> v1.LLOChannelDefinitionProto
-	2,  // 20: v1.LLOObservationProto.StreamValuesEntry.value:type_name -> v1.LLOStreamValue
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	2,  // 4: v1.LLOStreamHistoryRecord.value:type_name -> v1.LLOStreamValue
+	5,  // 5: v1.LLOStreamHistoryChunkProto.records:type_name -> v1.LLOStreamHistoryRecord
+	9,  // 6: v1.LLOChannelDefinitionProto.streams:type_name -> v1.LLOStreamDefinition
+	13, // 7: v1.LLOOutcomeProtoV0.channelDefinitions:type_name -> v1.LLOChannelIDAndDefinitionProto
+	14, // 8: v1.LLOOutcomeProtoV0.validAfterSeconds:type_name -> v1.LLOChannelIDAndValidAfterSecondsProto
+	16, // 9: v1.LLOOutcomeProtoV0.streamAggregates:type_name -> v1.LLOStreamAggregate
+	13, // 10: v1.LLOOutcomeProtoV1.channelDefinitions:type_name -> v1.LLOChannelIDAndDefinitionProto
+	15, // 11: v1.LLOOutcomeProtoV1.validAfterNanoseconds:type_name -> v1.LLOChannelIDAndValidAfterNanosecondsProto
+	16, // 12: v1.LLOOutcomeProtoV1.streamAggregates:type_name -> v1.LLOStreamAggregate
+	8,  // 13: v1.LLOChannelIDAndDefinitionProto.channelDefinition:type_name -> v1.LLOChannelDefinitionProto
+	2,  // 14: v1.LLOStreamAggregate.streamValue:type_name -> v1.LLOStreamValue
+	13, // 15: v1.LLOChannelStateProto.channelDefinitions:type_name -> v1.LLOChannelIDAndDefinitionProto
+	15, // 16: v1.LLOHotStateProto.validAfterNanoseconds:type_name -> v1.LLOChannelIDAndValidAfterNanosecondsProto
+	16, // 17: v1.LLOHotStateProto.streamAggregates:type_name -> v1.LLOStreamAggregate
+	13, // 18: v1.LLOPrecursorProto.channelDefinitions:type_name -> v1.LLOChannelIDAndDefinitionProto
+	15, // 19: v1.LLOPrecursorProto.validAfterNanoseconds:type_name -> v1.LLOChannelIDAndValidAfterNanosecondsProto
+	16, // 20: v1.LLOPrecursorProto.streamAggregates:type_name -> v1.LLOStreamAggregate
+	8,  // 21: v1.LLOObservationProto.UpdateChannelDefinitionsEntry.value:type_name -> v1.LLOChannelDefinitionProto
+	2,  // 22: v1.LLOObservationProto.StreamValuesEntry.value:type_name -> v1.LLOStreamValue
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_plugin_codecs_proto_init() }
@@ -1285,7 +1514,7 @@ func file_plugin_codecs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_codecs_proto_rawDesc), len(file_plugin_codecs_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   18,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/llo/protocol/plugin_codecs.proto
+++ b/llo/protocol/plugin_codecs.proto
@@ -51,6 +51,56 @@ message LLOTimestampedStreamValue {
   LLOStreamValue streamValue = 2;
 }
 
+// LLOStreamHistoryRecord is one agreed aggregate value of a stream, with the
+// timestamp it was observed at. Per-record timestamps are required: rounds are
+// not evenly spaced, so time-weighted functions and gap detection cannot work
+// from the window bounds alone.
+message LLOStreamHistoryRecord {
+  uint64 observedAtNanoseconds = 1;
+  LLOStreamValue value = 2;
+}
+
+// LLOStreamHistoryChunkProto is one slot of the chunked ring layout: a run of
+// consecutive history records for a single (streamID, aggregator) pair.
+//
+// Only the newest chunk of a window is ever rewritten; once a chunk is full it
+// is immutable for as long as it is retained. That is what makes the per-round
+// write cost a function of the chunk size rather than of the window depth.
+message LLOStreamHistoryChunkProto {
+  // Absolute chunk index, monotonically increasing over the life of the
+  // window. The key holds only sequence mod MaxHistoryChunkSlots, so this is
+  // what distinguishes a live chunk from a stale one left by an earlier lap of
+  // the ring.
+  uint64 sequence = 1;
+  // Oldest first, newest last; observedAtNanoseconds strictly increasing.
+  repeated LLOStreamHistoryRecord records = 2;
+}
+
+// LLOStreamHistoryHeaderProto is the index of a chunked history window: which
+// chunks are retained, how full each one is, and when each one starts.
+//
+// It is sized so that every decision a round makes — is there enough depth,
+// which chunks must be read, may this value be appended, which chunk falls out
+// — can be taken from the header alone, without reading a single chunk.
+message LLOStreamHistoryHeaderProto {
+  // Capacity: the maximum depth required by any live channel/expression
+  // referencing this pair. Zero means the pair is torn down.
+  uint32 requiredCount = 1;
+  // Absolute sequence of the oldest retained chunk. Zero when nothing is
+  // stored.
+  uint64 firstSequence = 2;
+  // Records held by each retained chunk, oldest first. Every entry except the
+  // last equals MaxHistoryChunkRecords; the last is in [1, MaxHistoryChunkRecords].
+  repeated uint32 counts = 3;
+  // observedAtNanoseconds of the first record of each retained chunk, parallel
+  // to counts and strictly increasing. Denormalized so that evicting a chunk
+  // does not require loading its successor to learn the window's new start.
+  repeated uint64 chunkFirstObservationTimestampNanoseconds = 4;
+  // observedAtNanoseconds of the newest record in the window, or 0 when empty.
+  // The strictly-newer append rule is decided against this alone.
+  uint64 lastObservationTimestampNanoseconds = 5;
+}
+
 
 message LLOChannelDefinitionProto {
     uint32 reportFormat = 1;

--- a/llo/protocol/stream_history.go
+++ b/llo/protocol/stream_history.go
@@ -27,9 +27,16 @@ var (
 	ErrHistoryRecordTooLarge = errors.New("history record too large")
 )
 
-// deterministicHistoryMarshal marshals history deterministically. History is
-// replicated KeyValueState, so a non-deterministic encoding would halt the DON.
-var deterministicHistoryMarshal = proto.MarshalOptions{Deterministic: true}
+// deterministicMarshal is the marshaller for anything whose bytes are compared
+// across oracles: replicated KeyValueState (history headers and chunks), and the
+// serialized stream values ModeAggregator counts to pick a mode. A
+// non-deterministic encoding there would halt the DON.
+//
+// None of the messages marshalled through it has a map field today, and
+// Deterministic only orders map entries, so it is currently a no-op. It is
+// applied anyway so that adding a map field to one of them cannot silently
+// introduce a divergence.
+var deterministicMarshal = proto.MarshalOptions{Deterministic: true}
 
 // StreamHistoryRecord is one agreed aggregate value of a stream together with
 // the timestamp it was observed at.

--- a/llo/protocol/stream_history.go
+++ b/llo/protocol/stream_history.go
@@ -1,0 +1,65 @@
+package protocol
+
+import (
+	"errors"
+
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	// ErrCorruptStreamHistory is returned when a stored history window cannot
+	// be decoded, or decodes into something that violates the type's
+	// invariants (bad header, non-monotonic timestamps, over-capacity).
+	//
+	// Stored state is untrusted input: callers must handle this by discarding
+	// the window and re-warming, never by panicking.
+	ErrCorruptStreamHistory = errors.New("corrupt stream history")
+
+	// ErrInsufficientStreamHistory is returned when fewer records are stored
+	// than were asked for. It means "not yet evaluable" and must never be
+	// treated as zero or as a shorter window.
+	ErrInsufficientStreamHistory = errors.New("insufficient stream history")
+
+	// ErrHistoryRecordTooLarge is returned when a value serializes to more than
+	// MaxHistoryRecordBytes. Rejecting the record leaves an honest gap in the
+	// series; accepting it would let one pair's window grow past what the
+	// per-round byte budget was sized for.
+	ErrHistoryRecordTooLarge = errors.New("history record too large")
+)
+
+// deterministicHistoryMarshal marshals history deterministically. History is
+// replicated KeyValueState, so a non-deterministic encoding would halt the DON.
+var deterministicHistoryMarshal = proto.MarshalOptions{Deterministic: true}
+
+// StreamHistoryRecord is one agreed aggregate value of a stream together with
+// the timestamp it was observed at.
+type StreamHistoryRecord struct {
+	ObservedAtNanoseconds uint64
+	Value                 StreamValue
+}
+
+// historyRecordSize returns the serialized size of one history record, so the
+// per-record cap is enforced against what is actually stored rather than an
+// assumed size.
+func historyRecordSize(observedAtNanoseconds uint64, value StreamValue) (int, error) {
+	pb, err := marshalProtoStreamValue(value)
+	if err != nil {
+		return 0, err
+	}
+	return proto.Size(&LLOStreamHistoryRecord{
+		ObservedAtNanoseconds: observedAtNanoseconds,
+		Value:                 pb,
+	}), nil
+}
+
+// marshalProtoStreamValue converts a StreamValue to its tagged wire form.
+func marshalProtoStreamValue(sv StreamValue) (*LLOStreamValue, error) {
+	if sv == nil {
+		return nil, ErrNilStreamValue
+	}
+	value, err := sv.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return &LLOStreamValue{Type: sv.Type(), Value: value}, nil
+}

--- a/llo/protocol/stream_history_ring.go
+++ b/llo/protocol/stream_history_ring.go
@@ -15,6 +15,10 @@ import (
 // and to hand them to Provide before mutating or reading the window.
 var ErrHistoryChunkNotLoaded = errors.New("stream history chunk not loaded")
 
+// ErrHistoryAlreadyAppended is returned by RingWindow.Append when a pair is
+// appended to twice in one round. See Append for why that cannot be allowed.
+var ErrHistoryAlreadyAppended = errors.New("stream history already appended this round")
+
 // StreamHistoryChunk is one slot of a chunked history ring: a run of
 // consecutive records for one (streamID, aggregator) pair, oldest first.
 //
@@ -445,6 +449,9 @@ type RingWindow struct {
 
 	headerDirty bool
 	dirtyChunk  *StreamHistoryChunk
+	// stored reports whether this round already appended a record, which it is
+	// allowed to do at most once. See Append.
+	stored bool
 }
 
 // NewRingWindow returns a working copy over an existing header. A nil header
@@ -659,9 +666,21 @@ func (w *RingWindow) SetRequiredCount(requiredCount uint32) (changed bool, err e
 // A pair with zero capacity stores nothing. A value serializing to more than
 // MaxHistoryRecordBytes is rejected with ErrHistoryRecordTooLarge, leaving an
 // honest gap rather than a window larger than the byte budget assumed.
+//
+// At most one record may be stored per round, and a second attempt returns
+// ErrHistoryAlreadyAppended. Two rules depend on it. The write set carries the
+// newest chunk only, so a second append that sealed a chunk and started another
+// would leave the sealed one's final record unpersisted while the header already
+// counted it -- next round the window reads short and is discarded as corrupt.
+// And the round's write budget is sized on one header and one chunk per pair.
+// The aggregation path appends once per pair per round, so this only rejects
+// misuse, but it is checked rather than assumed because Append is exported.
 func (w *RingWindow) Append(observedAtNanoseconds uint64, value StreamValue) (appended bool, err error) {
 	if value == nil {
 		return false, ErrNilStreamValue
+	}
+	if w.stored {
+		return false, ErrHistoryAlreadyAppended
 	}
 	if w.header.requiredCount == 0 {
 		return false, nil
@@ -706,6 +725,7 @@ func (w *RingWindow) Append(observedAtNanoseconds uint64, value StreamValue) (ap
 	w.header.last = observedAtNanoseconds
 	w.headerDirty = true
 	w.dirtyChunk = tail
+	w.stored = true
 	w.evict()
 	return true, nil
 }

--- a/llo/protocol/stream_history_ring.go
+++ b/llo/protocol/stream_history_ring.go
@@ -93,7 +93,7 @@ func (c *StreamHistoryChunk) MarshalBinary() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return deterministicHistoryMarshal.Marshal(pb)
+	return deterministicMarshal.Marshal(pb)
 }
 
 // StreamHistoryChunkFromProto validates and converts a decoded chunk.
@@ -298,7 +298,7 @@ func (h *StreamHistoryHeader) ToProto() *LLOStreamHistoryHeaderProto {
 
 // MarshalBinary serializes the header deterministically for storage.
 func (h *StreamHistoryHeader) MarshalBinary() ([]byte, error) {
-	return deterministicHistoryMarshal.Marshal(h.ToProto())
+	return deterministicMarshal.Marshal(h.ToProto())
 }
 
 // StreamHistoryHeaderFromProto validates and converts a decoded header.

--- a/llo/protocol/stream_history_ring.go
+++ b/llo/protocol/stream_history_ring.go
@@ -1,0 +1,773 @@
+package protocol
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// ErrHistoryChunkNotLoaded is returned when an operation needs a chunk the
+// caller has not provided yet. It is a programming error, not corruption: the
+// caller is expected to read exactly the chunks AppendPlan and ReadPlan name,
+// and to hand them to Provide before mutating or reading the window.
+var ErrHistoryChunkNotLoaded = errors.New("stream history chunk not loaded")
+
+// StreamHistoryChunk is one slot of a chunked history ring: a run of
+// consecutive records for one (streamID, aggregator) pair, oldest first.
+//
+// Only the newest chunk of a window is ever rewritten. Once a chunk holds
+// MaxHistoryChunkRecords records it is sealed: immutable for as long as it is
+// retained, and never part of a write set again. That is what makes per-round
+// write cost a function of the chunk size rather than of the window depth.
+//
+// The records slice is unexported so a caller cannot assemble a chunk that
+// violates the invariants the decoder enforces.
+type StreamHistoryChunk struct {
+	sequence uint64
+	records  []StreamHistoryRecord
+}
+
+// Sequence is the chunk's absolute index in the window, monotonically
+// increasing over the window's life. The key holds only the slot
+// (sequence mod MaxHistoryChunkSlots), so this is what tells a live chunk apart
+// from a stale one left behind by an earlier lap of the ring.
+func (c *StreamHistoryChunk) Sequence() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.sequence
+}
+
+// Records returns the chunk's records, oldest first. The slice aliases internal
+// state and must be treated as read-only; it is not copied because this is on
+// the per-round hot path.
+func (c *StreamHistoryChunk) Records() []StreamHistoryRecord {
+	if c == nil {
+		return nil
+	}
+	return c.records
+}
+
+// Len is the number of records in the chunk.
+func (c *StreamHistoryChunk) Len() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.records)
+}
+
+// Slot is the ring slot this chunk occupies.
+func (c *StreamHistoryChunk) Slot() uint32 {
+	return HistoryChunkSlot(c.Sequence())
+}
+
+// ToProto converts the chunk to its wire form.
+func (c *StreamHistoryChunk) ToProto() (*LLOStreamHistoryChunkProto, error) {
+	pb := &LLOStreamHistoryChunkProto{
+		Sequence: c.sequence,
+		Records:  make([]*LLOStreamHistoryRecord, 0, len(c.records)),
+	}
+	for i, rec := range c.records {
+		value, err := marshalProtoStreamValue(rec.Value)
+		if err != nil {
+			return nil, fmt.Errorf("marshal chunk %d record %d: %w", c.sequence, i, err)
+		}
+		pb.Records = append(pb.Records, &LLOStreamHistoryRecord{
+			ObservedAtNanoseconds: rec.ObservedAtNanoseconds,
+			Value:                 value,
+		})
+	}
+	return pb, nil
+}
+
+// MarshalBinary serializes the chunk deterministically for storage.
+func (c *StreamHistoryChunk) MarshalBinary() ([]byte, error) {
+	pb, err := c.ToProto()
+	if err != nil {
+		return nil, err
+	}
+	return deterministicHistoryMarshal.Marshal(pb)
+}
+
+// StreamHistoryChunkFromProto validates and converts a decoded chunk.
+//
+// Everything checkable without the header is checked here; the header-relative
+// checks (is this sequence still retained, does it hold the number of records
+// the header claims) happen in RingWindow.Provide.
+func StreamHistoryChunkFromProto(pb *LLOStreamHistoryChunkProto) (*StreamHistoryChunk, error) {
+	if pb == nil {
+		return nil, fmt.Errorf("%w: nil chunk proto", ErrCorruptStreamHistory)
+	}
+	if len(pb.Records) == 0 {
+		return nil, fmt.Errorf("%w: chunk %d holds no records", ErrCorruptStreamHistory, pb.Sequence)
+	}
+	if len(pb.Records) > MaxHistoryChunkRecords {
+		return nil, fmt.Errorf("%w: chunk %d holds %d records, exceeding MaxHistoryChunkRecords %d",
+			ErrCorruptStreamHistory, pb.Sequence, len(pb.Records), MaxHistoryChunkRecords)
+	}
+
+	c := &StreamHistoryChunk{
+		sequence: pb.Sequence,
+		records:  make([]StreamHistoryRecord, 0, len(pb.Records)),
+	}
+	var prev uint64
+	for i, rec := range pb.Records {
+		if rec == nil {
+			return nil, fmt.Errorf("%w: chunk %d record %d is nil", ErrCorruptStreamHistory, pb.Sequence, i)
+		}
+		if i > 0 && rec.ObservedAtNanoseconds <= prev {
+			return nil, fmt.Errorf("%w: chunk %d record %d timestamp %d is not strictly after %d",
+				ErrCorruptStreamHistory, pb.Sequence, i, rec.ObservedAtNanoseconds, prev)
+		}
+		// The per-record cap is enforced on decode as well as on append, so the
+		// bound holds for state this process did not write: a chunk restored
+		// after a restart, or one corrupted in storage, cannot exceed what the
+		// byte budget was sized for.
+		if size := proto.Size(rec); size > MaxHistoryRecordBytes {
+			return nil, fmt.Errorf("%w: chunk %d record %d is %d bytes, exceeding the maximum of %d",
+				ErrCorruptStreamHistory, pb.Sequence, i, size, MaxHistoryRecordBytes)
+		}
+		sv, err := UnmarshalProtoStreamValue(rec.Value)
+		if err != nil {
+			return nil, fmt.Errorf("%w: chunk %d record %d: %s", ErrCorruptStreamHistory, pb.Sequence, i, err)
+		}
+		prev = rec.ObservedAtNanoseconds
+		c.records = append(c.records, StreamHistoryRecord{
+			ObservedAtNanoseconds: rec.ObservedAtNanoseconds,
+			Value:                 sv,
+		})
+	}
+	return c, nil
+}
+
+// UnmarshalStreamHistoryChunk decodes and validates a stored chunk.
+func UnmarshalStreamHistoryChunk(data []byte) (*StreamHistoryChunk, error) {
+	pb := &LLOStreamHistoryChunkProto{}
+	if err := proto.Unmarshal(data, pb); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrCorruptStreamHistory, err)
+	}
+	return StreamHistoryChunkFromProto(pb)
+}
+
+// StreamHistoryHeader is the index of a chunked history window: which chunks
+// are retained, how full each one is, and when each one starts.
+//
+// It is deliberately sufficient on its own. Every decision a round makes — is
+// there enough depth, which chunks must be read, may this value be appended,
+// which chunk falls out — is taken from the header without reading a chunk, so
+// a pair that is still warming up costs exactly one read for the whole round.
+//
+// Invariants, enforced on decode and by every mutator:
+//
+//   - len(counts) == len(chunkFirst) <= MaxHistoryChunkSlots.
+//   - counts[i] == MaxHistoryChunkRecords for every i but the last, which is in
+//     [1, MaxHistoryChunkRecords].
+//   - chunkFirst is strictly increasing, and chunkFirst[last] <= last.
+//   - total() < requiredCount + MaxHistoryChunkRecords, and dropping the oldest
+//     chunk would leave fewer than requiredCount records — retention keeps as
+//     few whole chunks as cover the required depth.
+//   - an empty window has firstSequence == 0 and last == 0.
+type StreamHistoryHeader struct {
+	requiredCount uint32
+	firstSequence uint64
+	counts        []uint32
+	chunkFirst    []uint64
+	last          uint64
+}
+
+// HistoryChunkSlot maps an absolute chunk sequence onto its ring slot.
+func HistoryChunkSlot(sequence uint64) uint32 {
+	return uint32(sequence % MaxHistoryChunkSlots)
+}
+
+// RequiredCount is the window capacity: the deepest history any live channel
+// requires for this pair. Zero means the pair is torn down.
+func (h *StreamHistoryHeader) RequiredCount() uint32 {
+	if h == nil {
+		return 0
+	}
+	return h.requiredCount
+}
+
+// FirstSequence is the absolute sequence of the oldest retained chunk.
+func (h *StreamHistoryHeader) FirstSequence() uint64 {
+	if h == nil {
+		return 0
+	}
+	return h.firstSequence
+}
+
+// ChunkCount is the number of retained chunks.
+func (h *StreamHistoryHeader) ChunkCount() int {
+	if h == nil {
+		return 0
+	}
+	return len(h.counts)
+}
+
+// Counts returns a copy of the per-chunk record counts, oldest first.
+func (h *StreamHistoryHeader) Counts() []uint32 {
+	if h == nil {
+		return nil
+	}
+	return append([]uint32(nil), h.counts...)
+}
+
+// Sequences returns the absolute sequences of the retained chunks, oldest
+// first.
+func (h *StreamHistoryHeader) Sequences() []uint64 {
+	if h == nil {
+		return nil
+	}
+	seqs := make([]uint64, 0, len(h.counts))
+	for i := range h.counts {
+		seqs = append(seqs, h.firstSequence+uint64(i))
+	}
+	return seqs
+}
+
+// Len is the number of records the window holds across all retained chunks. It
+// may exceed RequiredCount by up to one chunk, because retention works in whole
+// chunks; readers ask for an exact depth and never see the overshoot.
+func (h *StreamHistoryHeader) Len() int {
+	return int(h.total())
+}
+
+func (h *StreamHistoryHeader) total() uint32 {
+	if h == nil {
+		return 0
+	}
+	var total uint32
+	for _, c := range h.counts {
+		total += c
+	}
+	return total
+}
+
+// FirstObservationTimestampNanoseconds is the timestamp of the oldest retained
+// record, or zero when the window is empty.
+func (h *StreamHistoryHeader) FirstObservationTimestampNanoseconds() uint64 {
+	if h == nil || len(h.chunkFirst) == 0 {
+		return 0
+	}
+	return h.chunkFirst[0]
+}
+
+// LastObservationTimestampNanoseconds is the timestamp of the newest record, or
+// zero when the window is empty. The strictly-newer append rule is decided
+// against this alone, so appending costs no chunk read beyond the tail.
+func (h *StreamHistoryHeader) LastObservationTimestampNanoseconds() uint64 {
+	if h == nil {
+		return 0
+	}
+	return h.last
+}
+
+// index returns the position of a sequence among the retained chunks.
+func (h *StreamHistoryHeader) index(sequence uint64) (int, bool) {
+	if sequence < h.firstSequence {
+		return 0, false
+	}
+	i := sequence - h.firstSequence
+	if i >= uint64(len(h.counts)) {
+		return 0, false
+	}
+	return int(i), true
+}
+
+// ToProto converts the header to its wire form.
+func (h *StreamHistoryHeader) ToProto() *LLOStreamHistoryHeaderProto {
+	pb := &LLOStreamHistoryHeaderProto{
+		RequiredCount:                       h.requiredCount,
+		FirstSequence:                       h.firstSequence,
+		LastObservationTimestampNanoseconds: h.last,
+	}
+	if len(h.counts) > 0 {
+		pb.Counts = append([]uint32(nil), h.counts...)
+		pb.ChunkFirstObservationTimestampNanoseconds = append([]uint64(nil), h.chunkFirst...)
+	}
+	return pb
+}
+
+// MarshalBinary serializes the header deterministically for storage.
+func (h *StreamHistoryHeader) MarshalBinary() ([]byte, error) {
+	return deterministicHistoryMarshal.Marshal(h.ToProto())
+}
+
+// StreamHistoryHeaderFromProto validates and converts a decoded header.
+//
+// Every check guards against corrupt or byzantine stored state, and every
+// failure is ErrCorruptStreamHistory so callers can uniformly discard the whole
+// window and re-warm. A header that decodes is trustworthy enough to plan reads
+// and evictions from without cross-checking it against the chunks.
+func StreamHistoryHeaderFromProto(pb *LLOStreamHistoryHeaderProto) (*StreamHistoryHeader, error) {
+	if pb == nil {
+		return nil, fmt.Errorf("%w: nil header proto", ErrCorruptStreamHistory)
+	}
+	if pb.RequiredCount > MaxHistoryRecordsPerPair {
+		return nil, fmt.Errorf("%w: requiredCount %d exceeds MaxHistoryRecordsPerPair %d",
+			ErrCorruptStreamHistory, pb.RequiredCount, MaxHistoryRecordsPerPair)
+	}
+	if len(pb.Counts) != len(pb.ChunkFirstObservationTimestampNanoseconds) {
+		return nil, fmt.Errorf("%w: %d counts but %d chunk timestamps",
+			ErrCorruptStreamHistory, len(pb.Counts), len(pb.ChunkFirstObservationTimestampNanoseconds))
+	}
+	if len(pb.Counts) > MaxHistoryChunkSlots {
+		return nil, fmt.Errorf("%w: %d retained chunks exceeds MaxHistoryChunkSlots %d",
+			ErrCorruptStreamHistory, len(pb.Counts), MaxHistoryChunkSlots)
+	}
+
+	h := &StreamHistoryHeader{
+		requiredCount: pb.RequiredCount,
+		firstSequence: pb.FirstSequence,
+		last:          pb.LastObservationTimestampNanoseconds,
+	}
+
+	if len(pb.Counts) == 0 {
+		if pb.FirstSequence != 0 || pb.LastObservationTimestampNanoseconds != 0 {
+			return nil, fmt.Errorf("%w: empty window with firstSequence %d and last timestamp %d",
+				ErrCorruptStreamHistory, pb.FirstSequence, pb.LastObservationTimestampNanoseconds)
+		}
+		return h, nil
+	}
+
+	if pb.FirstSequence > math.MaxUint64-uint64(len(pb.Counts)) {
+		return nil, fmt.Errorf("%w: firstSequence %d overflows with %d chunks",
+			ErrCorruptStreamHistory, pb.FirstSequence, len(pb.Counts))
+	}
+
+	var total uint32
+	for i, count := range pb.Counts {
+		last := i == len(pb.Counts)-1
+		switch {
+		case count == 0:
+			return nil, fmt.Errorf("%w: chunk %d holds no records", ErrCorruptStreamHistory, i)
+		case count > MaxHistoryChunkRecords:
+			return nil, fmt.Errorf("%w: chunk %d holds %d records, exceeding MaxHistoryChunkRecords %d",
+				ErrCorruptStreamHistory, i, count, MaxHistoryChunkRecords)
+		case !last && count != MaxHistoryChunkRecords:
+			// Only the newest chunk may be partial: a sealed chunk is never
+			// rewritten, so a short one in the middle means the series has a
+			// hole the counts do not describe.
+			return nil, fmt.Errorf("%w: sealed chunk %d holds %d records, expected %d",
+				ErrCorruptStreamHistory, i, count, MaxHistoryChunkRecords)
+		}
+		total += count
+
+		if i > 0 && pb.ChunkFirstObservationTimestampNanoseconds[i] <= pb.ChunkFirstObservationTimestampNanoseconds[i-1] {
+			return nil, fmt.Errorf("%w: chunk %d starts at %d, which is not strictly after %d",
+				ErrCorruptStreamHistory, i, pb.ChunkFirstObservationTimestampNanoseconds[i], pb.ChunkFirstObservationTimestampNanoseconds[i-1])
+		}
+	}
+
+	newestFirst := pb.ChunkFirstObservationTimestampNanoseconds[len(pb.Counts)-1]
+	newestCount := pb.Counts[len(pb.Counts)-1]
+	switch {
+	case newestCount == 1 && newestFirst != pb.LastObservationTimestampNanoseconds:
+		return nil, fmt.Errorf("%w: single-record newest chunk starts at %d but the window ends at %d",
+			ErrCorruptStreamHistory, newestFirst, pb.LastObservationTimestampNanoseconds)
+	case newestFirst > pb.LastObservationTimestampNanoseconds:
+		return nil, fmt.Errorf("%w: newest chunk starts at %d, after the window end %d",
+			ErrCorruptStreamHistory, newestFirst, pb.LastObservationTimestampNanoseconds)
+	}
+
+	// Retention keeps as few whole chunks as cover the required depth. Both
+	// bounds matter: the first is what makes the window usable, the second is
+	// what stops a byzantine or corrupt header from making a round read and
+	// hold far more than the byte budget was sized for.
+	if total-pb.Counts[0] >= pb.RequiredCount {
+		return nil, fmt.Errorf("%w: %d records retained for a required depth of %d; the oldest chunk (%d records) is redundant",
+			ErrCorruptStreamHistory, total, pb.RequiredCount, pb.Counts[0])
+	}
+	if uint64(total) >= uint64(pb.RequiredCount)+MaxHistoryChunkRecords {
+		return nil, fmt.Errorf("%w: %d records retained exceeds the required depth %d by a whole chunk",
+			ErrCorruptStreamHistory, total, pb.RequiredCount)
+	}
+
+	h.counts = append([]uint32(nil), pb.Counts...)
+	h.chunkFirst = append([]uint64(nil), pb.ChunkFirstObservationTimestampNanoseconds...)
+	return h, nil
+}
+
+// UnmarshalStreamHistoryHeader decodes and validates a stored header.
+func UnmarshalStreamHistoryHeader(data []byte) (*StreamHistoryHeader, error) {
+	pb := &LLOStreamHistoryHeaderProto{}
+	if err := proto.Unmarshal(data, pb); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrCorruptStreamHistory, err)
+	}
+	return StreamHistoryHeaderFromProto(pb)
+}
+
+// RingWriteSet is what one round's mutations mean for storage. It is produced
+// by RingWindow.WriteSet and executed by the plugin, which owns the KV types.
+//
+// Writes must be applied before deletes. A slot is never both written and
+// deleted in the same round — WriteSet drops the tail slot from DeletedSlots if
+// it somehow appears — but ordering the two makes that independent of the
+// caller getting the argument order right.
+type RingWriteSet struct {
+	// Header is the header to write, or nil when it did not change.
+	Header *StreamHistoryHeader
+	// Chunk is the newest chunk, the only one a round ever rewrites, or nil
+	// when nothing was appended.
+	Chunk *StreamHistoryChunk
+	// DeletedSlots are ring slots to delete, ascending: chunks evicted this
+	// round, or every slot when the window was reset.
+	DeletedSlots []uint32
+}
+
+// Empty reports whether the round changed nothing about this window.
+func (s RingWriteSet) Empty() bool {
+	return s.Header == nil && s.Chunk == nil && len(s.DeletedSlots) == 0
+}
+
+// RingWindow is the per-round working copy of one pair's chunked history.
+//
+// Chunks are supplied by the caller rather than read by this type, which is
+// what keeps the layout logic free of KV types and independently testable. The
+// protocol is:
+//
+//	w := NewRingWindow(header)          // header read from storage, nil if none
+//	for _, seq := range w.AppendPlan()  // and/or w.ReadPlan(n)
+//	    w.Provide(chunk)                // chunks read from storage
+//	w.Append(...) / w.Newest(n)         // mutate and read
+//	w.WriteSet()                        // what to persist
+//
+// AppendPlan and ReadPlan name chunks by absolute sequence; HistoryChunkSlot
+// turns those into the keys to read.
+type RingWindow struct {
+	header  StreamHistoryHeader
+	chunks  map[uint64]*StreamHistoryChunk
+	deleted []uint32
+
+	headerDirty bool
+	dirtyChunk  *StreamHistoryChunk
+}
+
+// NewRingWindow returns a working copy over an existing header. A nil header
+// means nothing is stored yet.
+func NewRingWindow(header *StreamHistoryHeader) *RingWindow {
+	w := &RingWindow{chunks: map[uint64]*StreamHistoryChunk{}}
+	if header != nil {
+		w.header = *header
+		w.header.counts = append([]uint32(nil), header.counts...)
+		w.header.chunkFirst = append([]uint64(nil), header.chunkFirst...)
+	}
+	return w
+}
+
+// ResetRingWindow returns an empty working copy whose write set deletes every
+// slot of the ring.
+//
+// This is the recovery path for a window that failed to decode. The header is
+// the only thing that says which chunks exist, so when it is unusable the only
+// safe move is to delete the whole slot space — which is bounded, and is the
+// reason the layout uses a fixed ring rather than an unbounded sequence. The
+// cost of recovery is a warmup, never a halted round.
+func ResetRingWindow() *RingWindow {
+	w := NewRingWindow(nil)
+	w.headerDirty = true
+	w.deleted = make([]uint32, 0, MaxHistoryChunkSlots)
+	for slot := range uint32(MaxHistoryChunkSlots) {
+		w.deleted = append(w.deleted, slot)
+	}
+	return w
+}
+
+// Header returns the window's current header.
+func (w *RingWindow) Header() *StreamHistoryHeader {
+	if w == nil {
+		return nil
+	}
+	return &w.header
+}
+
+// RequiredCount is the window capacity.
+func (w *RingWindow) RequiredCount() uint32 { return w.Header().RequiredCount() }
+
+// Len is the number of records retained, which may overshoot RequiredCount by
+// less than one chunk.
+func (w *RingWindow) Len() int { return w.Header().Len() }
+
+// FirstObservationTimestampNanoseconds is the timestamp of the oldest retained
+// record, or zero when empty.
+func (w *RingWindow) FirstObservationTimestampNanoseconds() uint64 {
+	return w.Header().FirstObservationTimestampNanoseconds()
+}
+
+// LastObservationTimestampNanoseconds is the timestamp of the newest record, or
+// zero when empty.
+func (w *RingWindow) LastObservationTimestampNanoseconds() uint64 {
+	return w.Header().LastObservationTimestampNanoseconds()
+}
+
+// AppendPlan returns the sequences that must be provided before Append can
+// succeed: the newest chunk, when there is one with room left. Appending into a
+// sealed or absent chunk starts a new one and needs nothing loaded.
+func (w *RingWindow) AppendPlan() []uint64 {
+	if w.header.requiredCount == 0 {
+		return nil
+	}
+	last := len(w.header.counts) - 1
+	if last < 0 || w.header.counts[last] >= MaxHistoryChunkRecords {
+		return nil
+	}
+	return []uint64{w.header.firstSequence + uint64(last)}
+}
+
+// ReadPlan returns the sequences covering the newest n records, oldest first.
+//
+// It returns ErrInsufficientStreamHistory when fewer than n records are
+// retained — decided from the header, so a warming-up pair costs no chunk reads
+// at all. A short window is never silently substituted.
+func (w *RingWindow) ReadPlan(n uint32) ([]uint64, error) {
+	if n == 0 {
+		return nil, nil
+	}
+	total := w.header.total()
+	if total < n {
+		return nil, fmt.Errorf("%w: have %d, need %d", ErrInsufficientStreamHistory, total, n)
+	}
+
+	var acc uint32
+	first := len(w.header.counts) - 1
+	for ; first >= 0; first-- {
+		acc += w.header.counts[first]
+		if acc >= n {
+			break
+		}
+	}
+
+	seqs := make([]uint64, 0, len(w.header.counts)-first)
+	for i := first; i < len(w.header.counts); i++ {
+		seqs = append(seqs, w.header.firstSequence+uint64(i))
+	}
+	return seqs, nil
+}
+
+// Loaded reports whether a chunk has already been provided.
+//
+// Callers must consult this before re-reading a planned sequence: a chunk the
+// window has already been given may have been appended to since, so the stored
+// bytes are stale until the write set is flushed and providing them again would
+// look like corruption.
+func (w *RingWindow) Loaded(sequence uint64) bool {
+	_, ok := w.chunks[sequence]
+	return ok
+}
+
+// Provide hands a decoded chunk to the window, checking it against the header.
+//
+// This is where a stale chunk is caught: reads are by ring slot, so a slot left
+// behind by an earlier lap decodes fine but carries a sequence the header no
+// longer retains. Treating that as corruption — rather than as data — is what
+// makes slot reuse safe.
+func (w *RingWindow) Provide(chunk *StreamHistoryChunk) error {
+	if chunk == nil {
+		return fmt.Errorf("%w: nil chunk", ErrCorruptStreamHistory)
+	}
+	i, ok := w.header.index(chunk.sequence)
+	if !ok {
+		return fmt.Errorf("%w: chunk sequence %d is not retained (%d chunks from %d)",
+			ErrCorruptStreamHistory, chunk.sequence, len(w.header.counts), w.header.firstSequence)
+	}
+	if len(chunk.records) != int(w.header.counts[i]) {
+		return fmt.Errorf("%w: chunk %d holds %d records, header says %d",
+			ErrCorruptStreamHistory, chunk.sequence, len(chunk.records), w.header.counts[i])
+	}
+	if chunk.records[0].ObservedAtNanoseconds != w.header.chunkFirst[i] {
+		return fmt.Errorf("%w: chunk %d starts at %d, header says %d",
+			ErrCorruptStreamHistory, chunk.sequence, chunk.records[0].ObservedAtNanoseconds, w.header.chunkFirst[i])
+	}
+	if newest := chunk.records[len(chunk.records)-1].ObservedAtNanoseconds; i == len(w.header.counts)-1 && newest != w.header.last {
+		return fmt.Errorf("%w: newest chunk %d ends at %d, header says %d",
+			ErrCorruptStreamHistory, chunk.sequence, newest, w.header.last)
+	}
+	w.chunks[chunk.sequence] = chunk
+	return nil
+}
+
+// Newest returns the n most recent records, oldest first, from the chunks
+// ReadPlan named. It returns ErrInsufficientStreamHistory if fewer than n are
+// retained, and ErrHistoryChunkNotLoaded if a planned chunk was not provided.
+func (w *RingWindow) Newest(n uint32) ([]StreamHistoryRecord, error) {
+	seqs, err := w.ReadPlan(n)
+	if err != nil {
+		return nil, err
+	}
+	if n == 0 {
+		return nil, nil
+	}
+
+	records := make([]StreamHistoryRecord, 0, n+MaxHistoryChunkRecords)
+	for _, seq := range seqs {
+		chunk := w.chunks[seq]
+		if chunk == nil {
+			return nil, fmt.Errorf("%w: sequence %d", ErrHistoryChunkNotLoaded, seq)
+		}
+		// Monotonicity within a chunk is checked on decode and the per-chunk
+		// start timestamps are checked against each other in the header; this
+		// is the remaining seam, between one chunk's end and the next one's
+		// start.
+		if len(records) > 0 {
+			prev := records[len(records)-1].ObservedAtNanoseconds
+			if chunk.records[0].ObservedAtNanoseconds <= prev {
+				return nil, fmt.Errorf("%w: chunk %d starts at %d, which is not strictly after %d",
+					ErrCorruptStreamHistory, seq, chunk.records[0].ObservedAtNanoseconds, prev)
+			}
+		}
+		records = append(records, chunk.records...)
+	}
+	return records[uint32(len(records))-n:], nil
+}
+
+// SetRequiredCount updates the capacity, evicting chunks the new depth no
+// longer needs. It reports whether anything changed, so callers can avoid
+// writing an unmodified header.
+//
+// Growing the capacity does not synthesize records and touches no chunk: the
+// extra depth fills over subsequent rounds, and expressions needing it stay
+// unsatisfied meanwhile. Shrinking is deletes only — a sealed chunk is never
+// rewritten. Setting zero tears the window down, evicting everything.
+func (w *RingWindow) SetRequiredCount(requiredCount uint32) (changed bool, err error) {
+	if requiredCount > MaxHistoryRecordsPerPair {
+		return false, fmt.Errorf("requiredCount %d exceeds MaxHistoryRecordsPerPair %d", requiredCount, MaxHistoryRecordsPerPair)
+	}
+	if w.header.requiredCount == requiredCount {
+		return false, nil
+	}
+	w.header.requiredCount = requiredCount
+	w.headerDirty = true
+	w.evict()
+	return true, nil
+}
+
+// Append adds a value to the newest end of the window, sealing the newest chunk
+// and starting another when it fills, and evicting whole chunks from the oldest
+// end once they are no longer needed. It reports whether the record was stored.
+//
+// A record is stored only if its timestamp is strictly newer than the current
+// newest. That single rule keeps the series monotonic and prevents the two ways
+// a value could otherwise be double counted: a carry-forward timestamped
+// aggregate re-appended every round until it refreshes, and a non-advancing or
+// regressing consensus observation timestamp. Neither is an error — both are
+// normal — so a rejected append returns (false, nil).
+//
+// A pair with zero capacity stores nothing. A value serializing to more than
+// MaxHistoryRecordBytes is rejected with ErrHistoryRecordTooLarge, leaving an
+// honest gap rather than a window larger than the byte budget assumed.
+func (w *RingWindow) Append(observedAtNanoseconds uint64, value StreamValue) (appended bool, err error) {
+	if value == nil {
+		return false, ErrNilStreamValue
+	}
+	if w.header.requiredCount == 0 {
+		return false, nil
+	}
+	if len(w.header.counts) > 0 && observedAtNanoseconds <= w.header.last {
+		return false, nil
+	}
+	size, err := historyRecordSize(observedAtNanoseconds, value)
+	if err != nil {
+		return false, err
+	}
+	if size > MaxHistoryRecordBytes {
+		return false, fmt.Errorf("%w: %d bytes exceeds the maximum of %d", ErrHistoryRecordTooLarge, size, MaxHistoryRecordBytes)
+	}
+
+	last := len(w.header.counts) - 1
+	var tail *StreamHistoryChunk
+	if last >= 0 && w.header.counts[last] < MaxHistoryChunkRecords {
+		sequence := w.header.firstSequence + uint64(last)
+		if tail = w.chunks[sequence]; tail == nil {
+			return false, fmt.Errorf("%w: sequence %d", ErrHistoryChunkNotLoaded, sequence)
+		}
+		w.header.counts[last]++
+	} else {
+		// The ring is sized so this cannot collide: retention leaves at most
+		// MaxHistoryChunkSlots-1 chunks, so the new sequence lands on the one
+		// slot none of them occupy, and eviction below frees the oldest again.
+		if len(w.header.counts) >= MaxHistoryChunkSlots {
+			return false, fmt.Errorf("%w: %d chunks retained, no free ring slot", ErrCorruptStreamHistory, len(w.header.counts))
+		}
+		sequence := w.header.firstSequence + uint64(len(w.header.counts))
+		tail = &StreamHistoryChunk{sequence: sequence}
+		w.chunks[sequence] = tail
+		w.header.counts = append(w.header.counts, 1)
+		w.header.chunkFirst = append(w.header.chunkFirst, observedAtNanoseconds)
+	}
+
+	tail.records = append(tail.records, StreamHistoryRecord{
+		ObservedAtNanoseconds: observedAtNanoseconds,
+		Value:                 value,
+	})
+	w.header.last = observedAtNanoseconds
+	w.headerDirty = true
+	w.dirtyChunk = tail
+	w.evict()
+	return true, nil
+}
+
+// evict drops whole chunks from the oldest end for as long as the window would
+// still cover the required depth without them.
+//
+// Eviction is deletes only, never a rewrite, and it needs no chunk loaded: the
+// header carries each chunk's record count and start timestamp precisely so
+// that dropping one does not mean reading its successor to learn where the
+// window now begins.
+func (w *RingWindow) evict() {
+	for len(w.header.counts) > 0 {
+		if w.header.total()-w.header.counts[0] < w.header.requiredCount {
+			return
+		}
+		sequence := w.header.firstSequence
+		delete(w.chunks, sequence)
+		w.deleted = append(w.deleted, HistoryChunkSlot(sequence))
+		w.header.counts = w.header.counts[1:]
+		w.header.chunkFirst = w.header.chunkFirst[1:]
+		w.header.firstSequence++
+		w.headerDirty = true
+	}
+	// Only reachable at teardown (requiredCount zero); an empty window is
+	// canonically zero-valued so two oracles that arrive here by different
+	// routes write identical bytes.
+	w.header.firstSequence = 0
+	w.header.last = 0
+	w.header.counts = nil
+	w.header.chunkFirst = nil
+}
+
+// WriteSet returns what this round's mutations mean for storage: at most one
+// header, at most one chunk — the newest, the only one a round ever rewrites —
+// and the slots of any chunks evicted.
+func (w *RingWindow) WriteSet() RingWriteSet {
+	set := RingWriteSet{Chunk: w.dirtyChunk}
+	if w.headerDirty {
+		set.Header = &w.header
+	}
+	if len(w.deleted) == 0 {
+		return set
+	}
+
+	// A slot is never both written and deleted, but say so structurally rather
+	// than relying on the ring arithmetic staying correct forever.
+	var written uint32
+	hasWritten := false
+	if w.dirtyChunk != nil {
+		written, hasWritten = w.dirtyChunk.Slot(), true
+	}
+	slots := make([]uint32, 0, len(w.deleted))
+	seen := make(map[uint32]bool, len(w.deleted))
+	for _, slot := range w.deleted {
+		if seen[slot] || (hasWritten && slot == written) {
+			continue
+		}
+		seen[slot] = true
+		slots = append(slots, slot)
+	}
+	slices.Sort(slots)
+	set.DeletedSlots = slots
+	return set
+}

--- a/llo/protocol/stream_history_ring_bench_test.go
+++ b/llo/protocol/stream_history_ring_bench_test.go
@@ -1,0 +1,159 @@
+package protocol
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// Benchmarks for the chunked ring layout, measured against the single-blob
+// layout it replaces.
+//
+// The number that matters is kvBytes/op: bytes a round writes for one pair.
+// That is what is charged against the OCR3.1 per-round budget, and under the
+// blob layout it is proportional to the window depth — which is what made the
+// byte budget, rather than the pair count, the binding constraint. The point of
+// the ring is that this figure becomes a function of the chunk size instead.
+//
+// A quote of three 18-digit decimals is the case worth measuring: one window
+// serves _bid/_ask/_benchmark, and it is the largest realistic record.
+
+func benchRingQuote(i int) StreamValue {
+	return &Quote{
+		Bid:       decimal.New(int64(110000000000000000+i), -8),
+		Benchmark: decimal.New(int64(110000000000000001+i), -8),
+		Ask:       decimal.New(int64(110000000000000002+i), -8),
+	}
+}
+
+// benchRingStore is the storage the benchmarks write through, counting bytes the
+// way the round budget does: key plus value for every write.
+type benchRingStore struct {
+	header []byte
+	slots  map[uint32][]byte
+	bytes  int
+}
+
+func (s *benchRingStore) apply(b *testing.B, set RingWriteSet) {
+	b.Helper()
+	if set.Header != nil {
+		v, err := set.Header.MarshalBinary()
+		if err != nil {
+			b.Fatal(err)
+		}
+		s.header = v
+		s.bytes += len(v) + 10 // hh/<streamID><aggregator>
+	}
+	if set.Chunk != nil {
+		v, err := set.Chunk.MarshalBinary()
+		if err != nil {
+			b.Fatal(err)
+		}
+		s.slots[set.Chunk.Slot()] = v
+		s.bytes += len(v) + 14 // hc/<streamID><aggregator><slot>
+	}
+	for _, slot := range set.DeletedSlots {
+		delete(s.slots, slot)
+		s.bytes += 14
+	}
+}
+
+// benchRingRound runs one round: decode the header, read what appending needs,
+// append, persist. Exactly the work the plugin will do per pair.
+func benchRingRound(b *testing.B, s *benchRingStore, required uint32, ts uint64, value StreamValue) {
+	b.Helper()
+	var header *StreamHistoryHeader
+	if len(s.header) > 0 {
+		var err error
+		if header, err = UnmarshalStreamHistoryHeader(s.header); err != nil {
+			b.Fatal(err)
+		}
+	}
+	w := NewRingWindow(header)
+	if _, err := w.SetRequiredCount(required); err != nil {
+		b.Fatal(err)
+	}
+	for _, sequence := range w.AppendPlan() {
+		chunk, err := UnmarshalStreamHistoryChunk(s.slots[HistoryChunkSlot(sequence)])
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := w.Provide(chunk); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if _, err := w.Append(ts, value); err != nil {
+		b.Fatal(err)
+	}
+	s.apply(b, w.WriteSet())
+}
+
+func warmBenchRing(b *testing.B, required uint32, rounds int) *benchRingStore {
+	b.Helper()
+	s := &benchRingStore{slots: map[uint32][]byte{}}
+	for i := 1; i <= rounds; i++ {
+		benchRingRound(b, s, required, uint64(i)*1_000_000_000, benchRingQuote(i))
+	}
+	return s
+}
+
+// BenchmarkRingAppendRound measures one round's append for one pair at a
+// settled window: the cost the plugin pays every round, per pair.
+func BenchmarkRingAppendRound(b *testing.B) {
+	for _, depth := range []uint32{100, 300, MaxHistoryRecordsPerPair} {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			warm := warmBenchRing(b, depth, int(depth)+MaxHistoryChunkRecords)
+			ts := uint64(int(depth)+MaxHistoryChunkRecords) * 1_000_000_000
+
+			b.ResetTimer()
+			s := &benchRingStore{header: warm.header, slots: warm.slots}
+			for i := range b.N {
+				ts += 1_000_000_000
+				benchRingRound(b, s, depth, ts, benchRingQuote(i))
+			}
+			b.StopTimer()
+
+			b.ReportMetric(float64(s.bytes)/float64(b.N), "kvBytes/op")
+		})
+	}
+}
+
+// BenchmarkRingNewest measures the read side: decoding a full window back into
+// records, which is the cost the chunking does not remove.
+func BenchmarkRingNewest(b *testing.B) {
+	for _, depth := range []uint32{100, 300, MaxHistoryRecordsPerPair} {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			s := warmBenchRing(b, depth, int(depth)+MaxHistoryChunkRecords)
+
+			b.ResetTimer()
+			reads := 0
+			for range b.N {
+				header, err := UnmarshalStreamHistoryHeader(s.header)
+				if err != nil {
+					b.Fatal(err)
+				}
+				w := NewRingWindow(header)
+				plan, err := w.ReadPlan(depth)
+				if err != nil {
+					b.Fatal(err)
+				}
+				for _, sequence := range plan {
+					chunk, err := UnmarshalStreamHistoryChunk(s.slots[HistoryChunkSlot(sequence)])
+					if err != nil {
+						b.Fatal(err)
+					}
+					if err := w.Provide(chunk); err != nil {
+						b.Fatal(err)
+					}
+					reads++
+				}
+				if _, err := w.Newest(depth); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(reads)/float64(b.N), "chunkReads/op")
+		})
+	}
+}

--- a/llo/protocol/stream_history_ring_fuzz_test.go
+++ b/llo/protocol/stream_history_ring_fuzz_test.go
@@ -18,7 +18,7 @@ import (
 // also replicated state read every round, so a panic here takes the node down.
 func FuzzUnmarshalStreamHistoryHeader(f *testing.F) {
 	seed := func(pb *LLOStreamHistoryHeaderProto) {
-		b, err := deterministicHistoryMarshal.Marshal(pb)
+		b, err := deterministicMarshal.Marshal(pb)
 		require.NoError(f, err)
 		f.Add(b)
 	}
@@ -127,7 +127,7 @@ func FuzzUnmarshalStreamHistoryChunk(f *testing.F) {
 	require.NoError(f, err)
 
 	seed := func(pb *LLOStreamHistoryChunkProto) {
-		b, err := deterministicHistoryMarshal.Marshal(pb)
+		b, err := deterministicMarshal.Marshal(pb)
 		require.NoError(f, err)
 		f.Add(b)
 	}

--- a/llo/protocol/stream_history_ring_fuzz_test.go
+++ b/llo/protocol/stream_history_ring_fuzz_test.go
@@ -1,0 +1,291 @@
+package protocol
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzUnmarshalStreamHistoryHeader fuzzes the header decoder.
+//
+// The header is the most trusted thing in the chunked layout: read planning,
+// eviction and the append rule are all decided from it without consulting a
+// chunk, so a header that decoded while violating an invariant would put the
+// round's reads and writes outside every bound the byte budget assumes. It is
+// also replicated state read every round, so a panic here takes the node down.
+func FuzzUnmarshalStreamHistoryHeader(f *testing.F) {
+	seed := func(pb *LLOStreamHistoryHeaderProto) {
+		b, err := deterministicHistoryMarshal.Marshal(pb)
+		require.NoError(f, err)
+		f.Add(b)
+	}
+
+	f.Add([]byte(nil))
+	f.Add([]byte{})
+	f.Add([]byte("not a protobuf"))
+	seed(&LLOStreamHistoryHeaderProto{})
+	seed(&LLOStreamHistoryHeaderProto{
+		RequiredCount: 10,
+		Counts:        []uint32{3},
+		ChunkFirstObservationTimestampNanoseconds: []uint64{100},
+		LastObservationTimestampNanoseconds:       300,
+	})
+	seed(&LLOStreamHistoryHeaderProto{
+		RequiredCount: 150,
+		FirstSequence: 7,
+		Counts:        []uint32{MaxHistoryChunkRecords, MaxHistoryChunkRecords, 30},
+		ChunkFirstObservationTimestampNanoseconds: []uint64{100, 200, 300},
+		LastObservationTimestampNanoseconds:       400,
+	})
+	seed(&LLOStreamHistoryHeaderProto{
+		RequiredCount: MaxHistoryRecordsPerPair,
+		FirstSequence: math.MaxUint64 - 4,
+		Counts:        []uint32{MaxHistoryChunkRecords, 1},
+		ChunkFirstObservationTimestampNanoseconds: []uint64{1, 2},
+		LastObservationTimestampNanoseconds:       2,
+	})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		header, err := UnmarshalStreamHistoryHeader(data)
+		if err != nil {
+			require.ErrorIs(t, err, ErrCorruptStreamHistory,
+				"every decode failure must be reported as corruption so callers can uniformly reset and re-warm")
+			require.Nil(t, header)
+			return
+		}
+		require.NotNil(t, header)
+
+		// Caps hold, so the reads and writes planned from this header stay
+		// within what the byte budget was sized for.
+		require.LessOrEqual(t, header.RequiredCount(), uint32(MaxHistoryRecordsPerPair))
+		require.LessOrEqual(t, header.ChunkCount(), MaxHistoryChunkSlots)
+		require.LessOrEqual(t, header.Len(), MaxHistoryRetainedRecords)
+
+		counts := header.Counts()
+		var total uint32
+		for i, count := range counts {
+			require.Positive(t, count)
+			require.LessOrEqual(t, count, uint32(MaxHistoryChunkRecords))
+			if i < len(counts)-1 {
+				require.Equal(t, uint32(MaxHistoryChunkRecords), count, "only the newest chunk may be partial")
+			}
+			total += count
+		}
+		require.Equal(t, int(total), header.Len())
+
+		if len(counts) > 0 {
+			// Retention holds as few whole chunks as cover the requirement.
+			require.Less(t, total-counts[0], header.RequiredCount())
+			require.Less(t, uint64(total), uint64(header.RequiredCount())+MaxHistoryChunkRecords)
+
+			// Sequences are contiguous and do not overflow.
+			sequences := header.Sequences()
+			require.Len(t, sequences, len(counts))
+			for i, sequence := range sequences {
+				require.Equal(t, header.FirstSequence()+uint64(i), sequence)
+			}
+
+			// The window's bounds are ordered.
+			require.LessOrEqual(t, header.FirstObservationTimestampNanoseconds(), header.LastObservationTimestampNanoseconds())
+		} else {
+			require.Zero(t, header.FirstSequence())
+			require.Zero(t, header.FirstObservationTimestampNanoseconds())
+			require.Zero(t, header.LastObservationTimestampNanoseconds())
+		}
+
+		// Anything that decodes must re-encode identically, or a node that
+		// restarted would write different bytes than one that did not.
+		first, err := header.MarshalBinary()
+		require.NoError(t, err)
+		again, err := header.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, first, again)
+
+		reparsed, err := UnmarshalStreamHistoryHeader(first)
+		require.NoError(t, err)
+		reencoded, err := reparsed.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, first, reencoded)
+	})
+}
+
+// FuzzUnmarshalStreamHistoryChunk fuzzes the chunk decoder, which stands between
+// arbitrary stored bytes and the records an expression evaluates.
+func FuzzUnmarshalStreamHistoryChunk(f *testing.F) {
+	value, err := marshalProtoStreamValue(ToDecimal(decimal.New(110000000000000000, -8)))
+	require.NoError(f, err)
+	quote, err := marshalProtoStreamValue(&Quote{
+		Bid:       decimal.New(110000000000000000, -8),
+		Benchmark: decimal.New(110000000000000001, -8),
+		Ask:       decimal.New(110000000000000002, -8),
+	})
+	require.NoError(f, err)
+	long, err := ToDecimal(decimal.NewFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(1000), nil), -2)).MarshalBinary()
+	require.NoError(f, err)
+
+	seed := func(pb *LLOStreamHistoryChunkProto) {
+		b, err := deterministicHistoryMarshal.Marshal(pb)
+		require.NoError(f, err)
+		f.Add(b)
+	}
+
+	f.Add([]byte(nil))
+	f.Add([]byte("not a protobuf"))
+	seed(&LLOStreamHistoryChunkProto{})
+	seed(&LLOStreamHistoryChunkProto{
+		Sequence: 3,
+		Records: []*LLOStreamHistoryRecord{
+			{ObservedAtNanoseconds: 100, Value: value},
+			{ObservedAtNanoseconds: 200, Value: quote},
+		},
+	})
+	seed(&LLOStreamHistoryChunkProto{
+		Sequence: math.MaxUint64,
+		Records: []*LLOStreamHistoryRecord{
+			{ObservedAtNanoseconds: 1, Value: &LLOStreamValue{Type: LLOStreamValue_Decimal, Value: long}},
+		},
+	})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		chunk, err := UnmarshalStreamHistoryChunk(data)
+		if err != nil {
+			require.ErrorIs(t, err, ErrCorruptStreamHistory)
+			require.Nil(t, chunk)
+			return
+		}
+		require.NotNil(t, chunk)
+
+		records := chunk.Records()
+		require.NotEmpty(t, records)
+		require.LessOrEqual(t, len(records), MaxHistoryChunkRecords)
+		for i, record := range records {
+			require.NotNil(t, record.Value)
+			if i > 0 {
+				require.Greater(t, record.ObservedAtNanoseconds, records[i-1].ObservedAtNanoseconds)
+			}
+			size, err := historyRecordSize(record.ObservedAtNanoseconds, record.Value)
+			require.NoError(t, err)
+			require.LessOrEqual(t, size, MaxHistoryRecordBytes)
+		}
+		require.Equal(t, chunk.Sequence()%MaxHistoryChunkSlots, uint64(chunk.Slot()))
+
+		first, err := chunk.MarshalBinary()
+		require.NoError(t, err)
+		again, err := chunk.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, first, again)
+
+		reparsed, err := UnmarshalStreamHistoryChunk(first)
+		require.NoError(t, err)
+		reencoded, err := reparsed.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, first, reencoded)
+	})
+}
+
+// FuzzRingWindowRounds fuzzes the mutation path end to end, driving a window
+// through storage the way a round does.
+//
+// The invariants asserted after every round are the ones the plugin will rely
+// on: the window never holds more than a chunk past its requirement, only the
+// newest chunk is ever written, a slot is never written and deleted at once,
+// and the stored slots are exactly the retained ones — the last of which is
+// what stops the ring from leaking state it can no longer address.
+func FuzzRingWindowRounds(f *testing.F) {
+	f.Add(uint32(100), uint32(0), uint8(200), uint64(1_000_000_000), uint8(7))
+	f.Add(uint32(1), uint32(1), uint8(10), uint64(1), uint8(1))
+	f.Add(uint32(MaxHistoryChunkRecords), uint32(MaxHistoryChunkRecords*2), uint8(255), uint64(1), uint8(3))
+	f.Add(uint32(MaxHistoryRecordsPerPair), uint32(0), uint8(255), uint64(1_000), uint8(11))
+	f.Add(uint32(0), uint32(50), uint8(64), uint64(1_000), uint8(2))
+
+	f.Fuzz(func(t *testing.T, required, laterRequired uint32, rounds uint8, interval uint64, switchAt uint8) {
+		if required > MaxHistoryRecordsPerPair || laterRequired > MaxHistoryRecordsPerPair {
+			return // rejected by construction; covered by the unit tests
+		}
+		if interval == 0 {
+			interval = 1 // a non-advancing timestamp is covered separately
+		}
+
+		header := (*StreamHistoryHeader)(nil)
+		slots := map[uint32][]byte{}
+		var ts uint64
+
+		for round := range int(rounds) {
+			want := required
+			if switchAt > 0 && round >= int(switchAt) {
+				want = laterRequired
+			}
+
+			w := NewRingWindow(header)
+			_, err := w.SetRequiredCount(want)
+			require.NoError(t, err)
+
+			for _, sequence := range w.AppendPlan() {
+				b, ok := slots[HistoryChunkSlot(sequence)]
+				require.True(t, ok, "the append plan named a slot that is not stored")
+				chunk, err := UnmarshalStreamHistoryChunk(b)
+				require.NoError(t, err)
+				require.NoError(t, w.Provide(chunk))
+			}
+
+			ts += interval
+			_, err = w.Append(ts, ToDecimal(decimal.NewFromInt(int64(round))))
+			require.NoError(t, err)
+
+			set := w.WriteSet()
+			if set.Chunk != nil {
+				require.Equal(t, set.Chunk.Sequence(), w.Header().FirstSequence()+uint64(w.Header().ChunkCount())-1,
+					"only the newest chunk may be written")
+				b, err := set.Chunk.MarshalBinary()
+				require.NoError(t, err)
+				slots[set.Chunk.Slot()] = b
+				require.NotContains(t, set.DeletedSlots, set.Chunk.Slot(),
+					"a slot must never be both written and deleted in one round")
+			}
+			for _, slot := range set.DeletedSlots {
+				delete(slots, slot)
+			}
+			if set.Header != nil {
+				b, err := set.Header.MarshalBinary()
+				require.NoError(t, err)
+				// Whatever a round writes must decode on the next one, on this
+				// node or any other.
+				header, err = UnmarshalStreamHistoryHeader(b)
+				require.NoError(t, err)
+			}
+
+			require.Len(t, slots, header.ChunkCount(),
+				"the stored slots must be exactly the retained chunks")
+			require.Less(t, uint64(header.Len()), uint64(header.RequiredCount())+MaxHistoryChunkRecords)
+			if header.RequiredCount() == 0 {
+				require.Zero(t, header.Len())
+			}
+		}
+
+		if header.RequiredCount() == 0 || header.Len() == 0 {
+			return
+		}
+
+		// Whatever depth was reached must read back, oldest to newest, with the
+		// last append at the end.
+		n := uint32(header.Len())
+		w := NewRingWindow(header)
+		plan, err := w.ReadPlan(n)
+		require.NoError(t, err)
+		for _, sequence := range plan {
+			chunk, err := UnmarshalStreamHistoryChunk(slots[HistoryChunkSlot(sequence)])
+			require.NoError(t, err)
+			require.NoError(t, w.Provide(chunk))
+		}
+		records, err := w.Newest(n)
+		require.NoError(t, err)
+		require.Len(t, records, int(n))
+		require.Equal(t, ts, records[len(records)-1].ObservedAtNanoseconds)
+		for i := 1; i < len(records); i++ {
+			require.Greater(t, records[i].ObservedAtNanoseconds, records[i-1].ObservedAtNanoseconds)
+		}
+	})
+}

--- a/llo/protocol/stream_history_ring_test.go
+++ b/llo/protocol/stream_history_ring_test.go
@@ -1,0 +1,825 @@
+package protocol
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ringStore is a stand-in for the plugin's KeyValueState: one header value and
+// MaxHistoryChunkSlots slot values per pair, addressed exactly the way the real
+// store will address them.
+//
+// It exists so the tests drive the layout the way a round does — decode header,
+// read only the planned slots, mutate, apply the write set, throw the working
+// copy away — rather than reaching into an in-memory window that never went
+// through storage. Slot reads are counted, because "how many reads does a round
+// cost" is the property this layout exists to control.
+type ringStore struct {
+	header    []byte
+	slots     map[uint32][]byte
+	slotReads int
+}
+
+func newRingStore() *ringStore {
+	return &ringStore{slots: map[uint32][]byte{}}
+}
+
+// window decodes the stored header and returns a working copy for a round.
+func (s *ringStore) window(t *testing.T) *RingWindow {
+	t.Helper()
+	if len(s.header) == 0 {
+		return NewRingWindow(nil)
+	}
+	header, err := UnmarshalStreamHistoryHeader(s.header)
+	require.NoError(t, err)
+	return NewRingWindow(header)
+}
+
+// provide reads the named sequences from their slots and hands them over.
+func (s *ringStore) provide(t *testing.T, w *RingWindow, sequences []uint64) {
+	t.Helper()
+	for _, sequence := range sequences {
+		b, ok := s.slots[HistoryChunkSlot(sequence)]
+		require.True(t, ok, "planned sequence %d is not stored", sequence)
+		s.slotReads++
+		chunk, err := UnmarshalStreamHistoryChunk(b)
+		require.NoError(t, err)
+		require.NoError(t, w.Provide(chunk))
+	}
+}
+
+// apply persists a write set: writes first, then deletes.
+func (s *ringStore) apply(t *testing.T, set RingWriteSet) {
+	t.Helper()
+	if set.Header != nil {
+		b, err := set.Header.MarshalBinary()
+		require.NoError(t, err)
+		s.header = b
+	}
+	if set.Chunk != nil {
+		b, err := set.Chunk.MarshalBinary()
+		require.NoError(t, err)
+		s.slots[set.Chunk.Slot()] = b
+	}
+	for _, slot := range set.DeletedSlots {
+		delete(s.slots, slot)
+	}
+}
+
+// round runs one full round against the store: apply the requirement, load what
+// appending needs, append, persist.
+func (s *ringStore) round(t *testing.T, required uint32, observedAtNanoseconds uint64, value StreamValue) RingWriteSet {
+	t.Helper()
+	w := s.window(t)
+	_, err := w.SetRequiredCount(required)
+	require.NoError(t, err)
+	s.provide(t, w, w.AppendPlan())
+	appended, err := w.Append(observedAtNanoseconds, value)
+	require.NoError(t, err)
+	require.True(t, appended)
+	set := w.WriteSet()
+	s.apply(t, set)
+	return set
+}
+
+// newest reads the newest n records back through storage.
+func (s *ringStore) newest(t *testing.T, n uint32) ([]StreamHistoryRecord, error) {
+	t.Helper()
+	w := s.window(t)
+	sequences, err := w.ReadPlan(n)
+	if err != nil {
+		return nil, err
+	}
+	s.provide(t, w, sequences)
+	return w.Newest(n)
+}
+
+func testValue(i int) StreamValue { return ToDecimal(decimal.NewFromInt(int64(i))) }
+
+func testTs(i int) uint64 { return uint64(i) * 1_000_000_000 }
+
+// warm appends n records, one per round, at second cadence.
+func warmRing(t *testing.T, s *ringStore, required uint32, n int) {
+	t.Helper()
+	for i := 1; i <= n; i++ {
+		s.round(t, required, testTs(i), testValue(i))
+	}
+}
+
+func TestHistoryChunkLimits(t *testing.T) {
+	// The chunk size must divide the maximum depth, so a window at full depth is
+	// a whole number of chunks and the "only the newest chunk is partial"
+	// invariant is reachable at the boundary.
+	require.Zero(t, MaxHistoryRecordsPerPair%MaxHistoryChunkRecords)
+
+	// The ring must hold the deepest window plus the chunk a round creates
+	// before eviction runs, or a new chunk would land on a live slot.
+	maxRetained := (MaxHistoryRetainedRecords + MaxHistoryChunkRecords - 1) / MaxHistoryChunkRecords
+	require.Equal(t, MaxHistoryChunkSlots, maxRetained+1,
+		"the ring must have exactly one slot spare above the deepest retention")
+}
+
+func TestRingWindowWarmup(t *testing.T) {
+	const required = 100
+	s := newRingStore()
+
+	// An empty window plans no reads and reports insufficiency from the header.
+	w := s.window(t)
+	require.Empty(t, w.AppendPlan())
+	_, err := w.ReadPlan(required)
+	require.ErrorIs(t, err, ErrInsufficientStreamHistory)
+
+	for i := 1; i < required; i++ {
+		s.round(t, required, testTs(i), testValue(i))
+
+		// Warming up costs a single header read: the shortfall is decided from
+		// the header, so no chunk is touched.
+		before := s.slotReads
+		_, err := s.newest(t, required)
+		require.ErrorIs(t, err, ErrInsufficientStreamHistory)
+		require.Equal(t, before, s.slotReads, "an unsatisfied read must not touch a chunk")
+	}
+
+	s.round(t, required, testTs(required), testValue(required))
+	records, err := s.newest(t, required)
+	require.NoError(t, err)
+	require.Len(t, records, required)
+	require.Equal(t, testTs(1), records[0].ObservedAtNanoseconds)
+	require.Equal(t, testTs(required), records[required-1].ObservedAtNanoseconds)
+}
+
+func TestRingWindowSealsAndWritesOnlyTheNewestChunk(t *testing.T) {
+	s := newRingStore()
+	const required = 200
+
+	// Filling the first chunk rewrites the same slot every round.
+	for i := 1; i <= MaxHistoryChunkRecords; i++ {
+		set := s.round(t, required, testTs(i), testValue(i))
+		require.NotNil(t, set.Chunk)
+		require.Equal(t, uint64(0), set.Chunk.Sequence())
+		require.Empty(t, set.DeletedSlots)
+	}
+	sealed := append([]byte(nil), s.slots[0]...)
+
+	// The next record starts a new chunk, and the sealed one is never rewritten
+	// again — which is the whole point of the layout.
+	set := s.round(t, required, testTs(MaxHistoryChunkRecords+1), testValue(MaxHistoryChunkRecords+1))
+	require.NotNil(t, set.Chunk)
+	require.Equal(t, uint64(1), set.Chunk.Sequence())
+	require.Equal(t, 1, set.Chunk.Len())
+	require.Equal(t, sealed, s.slots[0])
+
+	for i := MaxHistoryChunkRecords + 2; i <= 3*MaxHistoryChunkRecords; i++ {
+		s.round(t, required, testTs(i), testValue(i))
+		require.Equal(t, sealed, s.slots[0], "a sealed chunk must never be rewritten")
+	}
+}
+
+func TestRingWindowAppendPlan(t *testing.T) {
+	s := newRingStore()
+	const required = 200
+
+	require.Empty(t, s.window(t).AppendPlan(), "an empty window starts a chunk and needs nothing loaded")
+
+	warmRing(t, s, required, 1)
+	require.Equal(t, []uint64{0}, s.window(t).AppendPlan(), "a partial newest chunk must be loaded to append into")
+
+	for i := 2; i <= MaxHistoryChunkRecords; i++ {
+		s.round(t, required, testTs(i), testValue(i))
+	}
+	require.Empty(t, s.window(t).AppendPlan(), "a sealed newest chunk needs nothing loaded")
+
+	s.round(t, required, testTs(MaxHistoryChunkRecords+1), testValue(MaxHistoryChunkRecords+1))
+	require.Equal(t, []uint64{1}, s.window(t).AppendPlan())
+}
+
+func TestRingWindowAppendRequiresTheTailChunk(t *testing.T) {
+	s := newRingStore()
+	warmRing(t, s, 200, 3)
+
+	w := s.window(t)
+	_, err := w.Append(testTs(4), testValue(4))
+	require.ErrorIs(t, err, ErrHistoryChunkNotLoaded)
+	require.True(t, w.WriteSet().Empty(), "a failed append must not produce a write")
+}
+
+func TestRingWindowAppendRules(t *testing.T) {
+	t.Run("zero capacity stores nothing", func(t *testing.T) {
+		w := NewRingWindow(nil)
+		appended, err := w.Append(testTs(1), testValue(1))
+		require.NoError(t, err)
+		require.False(t, appended)
+		require.True(t, w.WriteSet().Empty())
+	})
+
+	t.Run("nil value", func(t *testing.T) {
+		w := NewRingWindow(nil)
+		_, err := w.SetRequiredCount(10)
+		require.NoError(t, err)
+		_, err = w.Append(testTs(1), nil)
+		require.ErrorIs(t, err, ErrNilStreamValue)
+	})
+
+	t.Run("not strictly newer", func(t *testing.T) {
+		s := newRingStore()
+		warmRing(t, s, 10, 3)
+
+		for _, ts := range []uint64{testTs(3), testTs(2), 0} {
+			w := s.window(t)
+			s.provide(t, w, w.AppendPlan())
+			appended, err := w.Append(ts, testValue(99))
+			require.NoError(t, err, "a non-advancing timestamp is normal, not an error")
+			require.False(t, appended)
+			require.Nil(t, w.WriteSet().Chunk)
+		}
+
+		records, err := s.newest(t, 3)
+		require.NoError(t, err)
+		require.Len(t, records, 3)
+	})
+
+	t.Run("oversized record", func(t *testing.T) {
+		w := NewRingWindow(nil)
+		_, err := w.SetRequiredCount(10)
+		require.NoError(t, err)
+		huge := ToDecimal(decimal.NewFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(1000), nil), -2))
+		_, err = w.Append(testTs(1), huge)
+		require.ErrorIs(t, err, ErrHistoryRecordTooLarge)
+		require.Zero(t, w.Len(), "a rejected record leaves a gap, it does not half-append")
+	})
+}
+
+func TestRingWindowEviction(t *testing.T) {
+	const required = 100
+	s := newRingStore()
+
+	deleted := 0
+	for i := 1; i <= 500; i++ {
+		set := s.round(t, required, testTs(i), testValue(i))
+		deleted += len(set.DeletedSlots)
+
+		header, err := UnmarshalStreamHistoryHeader(s.header)
+		require.NoError(t, err)
+
+		// Retention keeps as few whole chunks as cover the required depth, so
+		// the window overshoots by less than one chunk and never more.
+		if i >= required {
+			require.GreaterOrEqual(t, header.Len(), required)
+		}
+		require.Less(t, header.Len(), required+MaxHistoryChunkRecords)
+		require.Len(t, s.slots, header.ChunkCount(), "every retained chunk is stored and nothing else is")
+	}
+	require.Positive(t, deleted, "eviction must actually delete slots")
+
+	records, err := s.newest(t, required)
+	require.NoError(t, err)
+	require.Len(t, records, required)
+	require.Equal(t, testTs(500), records[required-1].ObservedAtNanoseconds, "the newest record must survive")
+	require.Equal(t, testTs(500-required+1), records[0].ObservedAtNanoseconds)
+}
+
+func TestRingWindowLapsTheRing(t *testing.T) {
+	// Long enough to reuse every slot several times over, which is what makes
+	// stale-slot handling reachable at all.
+	const (
+		required = 128
+		rounds   = 3000
+	)
+	s := newRingStore()
+
+	for i := 1; i <= rounds; i++ {
+		s.round(t, required, testTs(i), testValue(i))
+		require.LessOrEqual(t, len(s.slots), MaxHistoryChunkSlots)
+	}
+	require.Greater(t, s.window(t).Header().FirstSequence(), uint64(2*MaxHistoryChunkSlots),
+		"the ring must have wrapped several times")
+
+	records, err := s.newest(t, required)
+	require.NoError(t, err)
+	require.Len(t, records, required)
+	for i, record := range records {
+		want := rounds - required + 1 + i
+		require.Equal(t, testTs(want), record.ObservedAtNanoseconds)
+	}
+}
+
+func TestRingWindowRejectsAStaleChunk(t *testing.T) {
+	s := newRingStore()
+	const required = 64
+	warmRing(t, s, required, 3*MaxHistoryChunkRecords)
+
+	// A chunk from an earlier lap of the ring: it decodes, but its sequence is
+	// no longer retained. Reads address slots, so this is exactly what a missed
+	// delete or a resurrected value would look like.
+	header := s.window(t).Header()
+	stale := &StreamHistoryChunk{
+		sequence: header.FirstSequence() - 1,
+		records:  []StreamHistoryRecord{{ObservedAtNanoseconds: testTs(1), Value: testValue(1)}},
+	}
+	b, err := stale.MarshalBinary()
+	require.NoError(t, err)
+	decoded, err := UnmarshalStreamHistoryChunk(b)
+	require.NoError(t, err, "a stale chunk is well formed in isolation")
+
+	err = s.window(t).Provide(decoded)
+	require.ErrorIs(t, err, ErrCorruptStreamHistory)
+	require.Contains(t, err.Error(), "not retained")
+}
+
+func TestRingWindowReadPlanIsMinimal(t *testing.T) {
+	const required = MaxHistoryChunkRecords * 4
+	s := newRingStore()
+	warmRing(t, s, required, required)
+
+	w := s.window(t)
+	require.Equal(t, 4, w.Header().ChunkCount())
+
+	for _, tc := range []struct {
+		n     uint32
+		reads int
+	}{
+		{n: 1, reads: 1},
+		{n: MaxHistoryChunkRecords, reads: 1},
+		{n: MaxHistoryChunkRecords + 1, reads: 2},
+		{n: required, reads: 4},
+	} {
+		t.Run(fmt.Sprintf("newest %d", tc.n), func(t *testing.T) {
+			plan, err := s.window(t).ReadPlan(tc.n)
+			require.NoError(t, err)
+			require.Len(t, plan, tc.reads)
+
+			records, err := s.newest(t, tc.n)
+			require.NoError(t, err)
+			require.Len(t, records, int(tc.n))
+			require.Equal(t, testTs(required), records[len(records)-1].ObservedAtNanoseconds)
+		})
+	}
+
+	plan, err := w.ReadPlan(0)
+	require.NoError(t, err)
+	require.Empty(t, plan)
+}
+
+func TestRingWindowNewestNeedsThePlannedChunks(t *testing.T) {
+	const required = MaxHistoryChunkRecords * 2
+	s := newRingStore()
+	warmRing(t, s, required, required)
+
+	w := s.window(t)
+	s.provide(t, w, []uint64{1}) // the newest chunk only
+	_, err := w.Newest(required)
+	require.ErrorIs(t, err, ErrHistoryChunkNotLoaded)
+}
+
+func TestRingWindowNewestRejectsABrokenSeam(t *testing.T) {
+	const required = MaxHistoryChunkRecords * 2
+	s := newRingStore()
+	warmRing(t, s, required, required)
+
+	// Timestamps are strictly increasing within a chunk and across the header's
+	// per-chunk start timestamps; the seam between two chunks is the remaining
+	// gap, so it is checked when the records are concatenated.
+	w := s.window(t)
+	s.provide(t, w, []uint64{0, 1})
+	older := w.chunks[0]
+	older.records[len(older.records)-1].ObservedAtNanoseconds = w.chunks[1].records[0].ObservedAtNanoseconds
+
+	_, err := w.Newest(required)
+	require.ErrorIs(t, err, ErrCorruptStreamHistory)
+	require.Contains(t, err.Error(), "not strictly after")
+}
+
+func TestRingWindowSetRequiredCount(t *testing.T) {
+	t.Run("increase writes only the header", func(t *testing.T) {
+		s := newRingStore()
+		warmRing(t, s, 100, 100)
+
+		w := s.window(t)
+		changed, err := w.SetRequiredCount(300)
+		require.NoError(t, err)
+		require.True(t, changed)
+
+		set := w.WriteSet()
+		require.NotNil(t, set.Header)
+		require.Nil(t, set.Chunk, "growing capacity must not rewrite a chunk")
+		require.Empty(t, set.DeletedSlots)
+
+		// The extra depth fills over subsequent rounds; until then, unsatisfied.
+		s.apply(t, set)
+		_, err = s.newest(t, 300)
+		require.ErrorIs(t, err, ErrInsufficientStreamHistory)
+	})
+
+	t.Run("decrease deletes only", func(t *testing.T) {
+		s := newRingStore()
+		warmRing(t, s, 300, 300)
+		before := len(s.slots)
+
+		w := s.window(t)
+		_, err := w.SetRequiredCount(10)
+		require.NoError(t, err)
+		set := w.WriteSet()
+		require.NotNil(t, set.Header)
+		require.Nil(t, set.Chunk, "shrinking capacity must not rewrite a chunk")
+		require.NotEmpty(t, set.DeletedSlots)
+		s.apply(t, set)
+
+		require.Less(t, len(s.slots), before)
+		require.Len(t, s.slots, s.window(t).Header().ChunkCount())
+
+		records, err := s.newest(t, 10)
+		require.NoError(t, err)
+		require.Equal(t, testTs(300), records[9].ObservedAtNanoseconds)
+	})
+
+	t.Run("unchanged", func(t *testing.T) {
+		w := NewRingWindow(nil)
+		changed, err := w.SetRequiredCount(0)
+		require.NoError(t, err)
+		require.False(t, changed)
+		require.True(t, w.WriteSet().Empty())
+	})
+
+	t.Run("over the cap", func(t *testing.T) {
+		w := NewRingWindow(nil)
+		_, err := w.SetRequiredCount(MaxHistoryRecordsPerPair + 1)
+		require.Error(t, err)
+	})
+
+	t.Run("teardown evicts everything", func(t *testing.T) {
+		s := newRingStore()
+		warmRing(t, s, 200, 200)
+
+		w := s.window(t)
+		_, err := w.SetRequiredCount(0)
+		require.NoError(t, err)
+		require.Zero(t, w.Len())
+		require.Zero(t, w.Header().ChunkCount())
+
+		set := w.WriteSet()
+		require.Len(t, set.DeletedSlots, 4)
+		s.apply(t, set)
+		require.Empty(t, s.slots)
+
+		// An emptied window is canonically zero-valued, so two oracles that
+		// arrive here by different routes write identical bytes.
+		empty, err := NewRingWindow(nil).Header().MarshalBinary()
+		require.NoError(t, err)
+		torn, err := set.Header.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, empty, torn)
+	})
+}
+
+func TestResetRingWindow(t *testing.T) {
+	w := ResetRingWindow()
+	require.Zero(t, w.Len())
+	require.Zero(t, w.RequiredCount())
+
+	set := w.WriteSet()
+	require.NotNil(t, set.Header)
+	require.Nil(t, set.Chunk)
+	require.Len(t, set.DeletedSlots, MaxHistoryChunkSlots,
+		"recovery deletes the whole slot space, because a bad header cannot say which slots are live")
+	for i, slot := range set.DeletedSlots {
+		require.Equal(t, uint32(i), slot)
+	}
+
+	// A reset window re-warms from empty.
+	_, err := w.SetRequiredCount(10)
+	require.NoError(t, err)
+	appended, err := w.Append(testTs(1), testValue(1))
+	require.NoError(t, err)
+	require.True(t, appended)
+
+	set = w.WriteSet()
+	require.NotNil(t, set.Chunk)
+	require.Equal(t, uint64(0), set.Chunk.Sequence())
+	require.NotContains(t, set.DeletedSlots, set.Chunk.Slot(),
+		"a slot must never be both written and deleted in one round")
+	require.Len(t, set.DeletedSlots, MaxHistoryChunkSlots-1)
+}
+
+func TestRingWindowWriteSetIsDeterministic(t *testing.T) {
+	// Two oracles running the same rounds must produce identical bytes, key for
+	// key: the layout is replicated state, so any divergence halts the DON.
+	run := func() *ringStore {
+		s := newRingStore()
+		for i := 1; i <= 400; i++ {
+			required := uint32(150)
+			if i > 250 {
+				required = 80
+			}
+			s.round(t, required, testTs(i), testValue(i))
+		}
+		return s
+	}
+
+	a, b := run(), run()
+	require.Equal(t, a.header, b.header)
+	require.Equal(t, a.slots, b.slots)
+
+	// And repeated marshaling of the same window is byte-identical.
+	header, err := UnmarshalStreamHistoryHeader(a.header)
+	require.NoError(t, err)
+	first, err := header.MarshalBinary()
+	require.NoError(t, err)
+	again, err := header.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, first, again)
+	require.Equal(t, a.header, first)
+}
+
+func TestRingWindowRoundTripsEveryValueType(t *testing.T) {
+	values := []StreamValue{
+		ToDecimal(decimal.New(110000000000000000, -8)),
+		&Quote{
+			Bid:       decimal.New(110000000000000000, -8),
+			Benchmark: decimal.New(110000000000000001, -8),
+			Ask:       decimal.New(110000000000000002, -8),
+		},
+		&TimestampedStreamValue{
+			ObservedAtNanoseconds: 999,
+			StreamValue:           ToDecimal(decimal.NewFromInt(7)),
+		},
+	}
+
+	s := newRingStore()
+	for i, value := range values {
+		s.round(t, uint32(len(values)), testTs(i+1), value)
+	}
+
+	records, err := s.newest(t, uint32(len(values)))
+	require.NoError(t, err)
+	require.Len(t, records, len(values))
+	for i, record := range records {
+		require.Equal(t, values[i].Type(), record.Value.Type())
+		want, err := values[i].MarshalBinary()
+		require.NoError(t, err)
+		got, err := record.Value.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+}
+
+func TestUnmarshalStreamHistoryHeaderCorruption(t *testing.T) {
+	// A valid header to mutate: two sealed chunks and a partial one.
+	valid := func() *LLOStreamHistoryHeaderProto {
+		return &LLOStreamHistoryHeaderProto{
+			RequiredCount: 150,
+			FirstSequence: 7,
+			Counts:        []uint32{MaxHistoryChunkRecords, MaxHistoryChunkRecords, 30},
+			ChunkFirstObservationTimestampNanoseconds: []uint64{100, 200, 300},
+			LastObservationTimestampNanoseconds:       400,
+		}
+	}
+	b, err := deterministicHistoryMarshal.Marshal(valid())
+	require.NoError(t, err)
+	header, err := UnmarshalStreamHistoryHeader(b)
+	require.NoError(t, err)
+	require.Equal(t, 158, header.Len())
+	require.Equal(t, []uint64{7, 8, 9}, header.Sequences())
+
+	for name, mutate := range map[string]func(*LLOStreamHistoryHeaderProto){
+		"required over the cap": func(h *LLOStreamHistoryHeaderProto) {
+			h.RequiredCount = MaxHistoryRecordsPerPair + 1
+		},
+		"counts and timestamps disagree in length": func(h *LLOStreamHistoryHeaderProto) {
+			h.Counts = h.Counts[:2]
+		},
+		"too many chunks": func(h *LLOStreamHistoryHeaderProto) {
+			h.RequiredCount = MaxHistoryRecordsPerPair
+			h.Counts = make([]uint32, MaxHistoryChunkSlots+1)
+			h.ChunkFirstObservationTimestampNanoseconds = make([]uint64, MaxHistoryChunkSlots+1)
+			for i := range h.Counts {
+				h.Counts[i] = MaxHistoryChunkRecords
+				h.ChunkFirstObservationTimestampNanoseconds[i] = uint64(i + 1)
+			}
+			h.LastObservationTimestampNanoseconds = uint64(len(h.Counts))
+		},
+		"empty with a sequence": func(h *LLOStreamHistoryHeaderProto) {
+			h.Counts = nil
+			h.ChunkFirstObservationTimestampNanoseconds = nil
+			h.LastObservationTimestampNanoseconds = 0
+		},
+		"empty with a last timestamp": func(h *LLOStreamHistoryHeaderProto) {
+			h.Counts = nil
+			h.ChunkFirstObservationTimestampNanoseconds = nil
+			h.FirstSequence = 0
+		},
+		"empty chunk": func(h *LLOStreamHistoryHeaderProto) { h.Counts[1] = 0 },
+		"chunk over the chunk size": func(h *LLOStreamHistoryHeaderProto) {
+			h.Counts[2] = MaxHistoryChunkRecords + 1
+		},
+		"partial sealed chunk": func(h *LLOStreamHistoryHeaderProto) { h.Counts[0] = 1 },
+		"chunk starts out of order": func(h *LLOStreamHistoryHeaderProto) {
+			h.ChunkFirstObservationTimestampNanoseconds[1] = 100
+		},
+		"chunk starts after the window ends": func(h *LLOStreamHistoryHeaderProto) {
+			h.LastObservationTimestampNanoseconds = 250
+		},
+		"single-record newest chunk disagreeing with the end": func(h *LLOStreamHistoryHeaderProto) {
+			h.Counts[2] = 1
+		},
+		"redundant oldest chunk": func(h *LLOStreamHistoryHeaderProto) { h.RequiredCount = 90 },
+		"retained more than a chunk past the requirement": func(h *LLOStreamHistoryHeaderProto) {
+			h.Counts = []uint32{MaxHistoryChunkRecords, MaxHistoryChunkRecords}
+			h.ChunkFirstObservationTimestampNanoseconds = []uint64{100, 200}
+			h.RequiredCount = MaxHistoryChunkRecords
+		},
+		"sequence overflow": func(h *LLOStreamHistoryHeaderProto) { h.FirstSequence = math.MaxUint64 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			pb := valid()
+			mutate(pb)
+			b, err := deterministicHistoryMarshal.Marshal(pb)
+			require.NoError(t, err)
+
+			header, err := UnmarshalStreamHistoryHeader(b)
+			require.ErrorIs(t, err, ErrCorruptStreamHistory)
+			require.Nil(t, header)
+		})
+	}
+
+	t.Run("garbage", func(t *testing.T) {
+		_, err := UnmarshalStreamHistoryHeader([]byte("not a protobuf"))
+		require.ErrorIs(t, err, ErrCorruptStreamHistory)
+	})
+
+	t.Run("nil proto", func(t *testing.T) {
+		_, err := StreamHistoryHeaderFromProto(nil)
+		require.ErrorIs(t, err, ErrCorruptStreamHistory)
+	})
+
+	t.Run("empty is a valid empty window", func(t *testing.T) {
+		header, err := UnmarshalStreamHistoryHeader(nil)
+		require.NoError(t, err)
+		require.Zero(t, header.Len())
+		require.Zero(t, header.FirstObservationTimestampNanoseconds())
+		require.Zero(t, header.LastObservationTimestampNanoseconds())
+	})
+}
+
+func TestUnmarshalStreamHistoryChunkCorruption(t *testing.T) {
+	value, err := marshalProtoStreamValue(testValue(1))
+	require.NoError(t, err)
+	valid := func() *LLOStreamHistoryChunkProto {
+		return &LLOStreamHistoryChunkProto{
+			Sequence: 3,
+			Records: []*LLOStreamHistoryRecord{
+				{ObservedAtNanoseconds: 100, Value: value},
+				{ObservedAtNanoseconds: 200, Value: value},
+			},
+		}
+	}
+	b, err := deterministicHistoryMarshal.Marshal(valid())
+	require.NoError(t, err)
+	chunk, err := UnmarshalStreamHistoryChunk(b)
+	require.NoError(t, err)
+	require.Equal(t, 2, chunk.Len())
+	require.Equal(t, uint64(3), chunk.Sequence())
+	require.Equal(t, uint32(3), chunk.Slot())
+
+	long, err := ToDecimal(decimal.NewFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(1000), nil), -2)).MarshalBinary()
+	require.NoError(t, err)
+	huge, err := ToDecimal(decimal.New(1, MaxDecimalExponent+1)).MarshalBinary()
+	require.NoError(t, err)
+
+	for name, mutate := range map[string]func(*LLOStreamHistoryChunkProto){
+		"no records": func(c *LLOStreamHistoryChunkProto) { c.Records = nil },
+		"too many records": func(c *LLOStreamHistoryChunkProto) {
+			c.Records = make([]*LLOStreamHistoryRecord, MaxHistoryChunkRecords+1)
+			for i := range c.Records {
+				c.Records[i] = &LLOStreamHistoryRecord{ObservedAtNanoseconds: uint64(i + 1), Value: value}
+			}
+		},
+		"nil record": func(c *LLOStreamHistoryChunkProto) { c.Records[1] = nil },
+		"non-advancing timestamp": func(c *LLOStreamHistoryChunkProto) {
+			c.Records[1].ObservedAtNanoseconds = 100
+		},
+		"regressing timestamp": func(c *LLOStreamHistoryChunkProto) {
+			c.Records[1].ObservedAtNanoseconds = 50
+		},
+		"record over the size cap": func(c *LLOStreamHistoryChunkProto) {
+			c.Records[1].Value = &LLOStreamValue{Type: LLOStreamValue_Decimal, Value: long}
+		},
+		"decimal exponent out of range": func(c *LLOStreamHistoryChunkProto) {
+			c.Records[1].Value = &LLOStreamValue{Type: LLOStreamValue_Decimal, Value: huge}
+		},
+		"undecodable value": func(c *LLOStreamHistoryChunkProto) {
+			c.Records[1].Value = &LLOStreamValue{Type: LLOStreamValue_Decimal, Value: []byte("nope")}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			pb := valid()
+			mutate(pb)
+			b, err := deterministicHistoryMarshal.Marshal(pb)
+			require.NoError(t, err)
+
+			chunk, err := UnmarshalStreamHistoryChunk(b)
+			require.ErrorIs(t, err, ErrCorruptStreamHistory)
+			require.Nil(t, chunk)
+		})
+	}
+
+	t.Run("garbage", func(t *testing.T) {
+		_, err := UnmarshalStreamHistoryChunk([]byte("not a protobuf"))
+		require.ErrorIs(t, err, ErrCorruptStreamHistory)
+	})
+
+	t.Run("nil proto", func(t *testing.T) {
+		_, err := StreamHistoryChunkFromProto(nil)
+		require.ErrorIs(t, err, ErrCorruptStreamHistory)
+	})
+}
+
+func TestRingWindowProvideRejectsAMismatch(t *testing.T) {
+	s := newRingStore()
+	const required = MaxHistoryChunkRecords * 2
+	warmRing(t, s, required, required)
+
+	load := func(t *testing.T, sequence uint64) *StreamHistoryChunk {
+		t.Helper()
+		chunk, err := UnmarshalStreamHistoryChunk(s.slots[HistoryChunkSlot(sequence)])
+		require.NoError(t, err)
+		return chunk
+	}
+
+	for name, tc := range map[string]struct {
+		chunk func(*testing.T) *StreamHistoryChunk
+		want  string
+	}{
+		"nil": {
+			chunk: func(*testing.T) *StreamHistoryChunk { return nil },
+			want:  "nil chunk",
+		},
+		"unretained sequence": {
+			chunk: func(t *testing.T) *StreamHistoryChunk {
+				c := load(t, 0)
+				c.sequence = 99
+				return c
+			},
+			want: "not retained",
+		},
+		"wrong record count": {
+			chunk: func(t *testing.T) *StreamHistoryChunk {
+				c := load(t, 0)
+				c.records = c.records[:len(c.records)-1]
+				return c
+			},
+			want: "header says",
+		},
+		"wrong start timestamp": {
+			chunk: func(t *testing.T) *StreamHistoryChunk {
+				c := load(t, 0)
+				c.records[0].ObservedAtNanoseconds = 1
+				return c
+			},
+			want: "starts at",
+		},
+		"newest chunk ends elsewhere": {
+			chunk: func(t *testing.T) *StreamHistoryChunk {
+				c := load(t, 1)
+				c.records[len(c.records)-1].ObservedAtNanoseconds = math.MaxUint64
+				return c
+			},
+			want: "ends at",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := s.window(t).Provide(tc.chunk(t))
+			require.ErrorIs(t, err, ErrCorruptStreamHistory)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestRingWindowAtMaximumDepth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("fills a full-depth window")
+	}
+	const required = MaxHistoryRecordsPerPair
+	s := newRingStore()
+	warmRing(t, s, required, required+MaxHistoryChunkRecords)
+
+	header, err := UnmarshalStreamHistoryHeader(s.header)
+	require.NoError(t, err)
+	require.LessOrEqual(t, header.ChunkCount(), MaxHistoryChunkSlots-1,
+		"a settled window must leave a spare slot for the next chunk")
+	require.Less(t, header.Len(), MaxHistoryRetainedRecords+1)
+
+	before := s.slotReads
+	records, err := s.newest(t, required)
+	require.NoError(t, err)
+	require.Len(t, records, required)
+
+	// The read cost of the deepest possible window, which is the number this
+	// layout exists to keep small.
+	assert.LessOrEqual(t, s.slotReads-before, MaxHistoryRecordsPerPair/MaxHistoryChunkRecords+1)
+}

--- a/llo/protocol/stream_history_ring_test.go
+++ b/llo/protocol/stream_history_ring_test.go
@@ -823,3 +823,42 @@ func TestRingWindowAtMaximumDepth(t *testing.T) {
 	// layout exists to keep small.
 	assert.LessOrEqual(t, s.slotReads-before, MaxHistoryRecordsPerPair/MaxHistoryChunkRecords+1)
 }
+
+func Test_RingWindow_AppendOncePerRound(t *testing.T) {
+	// The write set carries only the newest chunk, so a second append that
+	// sealed one would lose its last record while the header already counted it.
+	// Rejecting the second append keeps the stored window and its header in
+	// agreement.
+	w := NewRingWindow(nil)
+	_, err := w.SetRequiredCount(MaxHistoryChunkRecords * 2)
+	require.NoError(t, err)
+
+	appended, err := w.Append(1, ToDecimal(decimal.NewFromInt(1)))
+	require.NoError(t, err)
+	require.True(t, appended)
+
+	appended, err = w.Append(2, ToDecimal(decimal.NewFromInt(2)))
+	require.ErrorIs(t, err, ErrHistoryAlreadyAppended)
+	require.False(t, appended)
+	require.Equal(t, uint32(1), w.Header().total(), "a rejected append must not be counted")
+
+	// A rejected append stores nothing, so it does not spend the round's one
+	// append either.
+	w = NewRingWindow(nil)
+	_, err = w.SetRequiredCount(4)
+	require.NoError(t, err)
+	appended, err = w.Append(10, ToDecimal(decimal.NewFromInt(1)))
+	require.NoError(t, err)
+	require.True(t, appended)
+
+	stored := w.WriteSet().Chunk
+	require.NotNil(t, stored)
+	w = NewRingWindow(w.Header())
+	require.NoError(t, w.Provide(stored))
+	appended, err = w.Append(10, ToDecimal(decimal.NewFromInt(2)))
+	require.NoError(t, err, "a value that is not strictly newer is rejected, not an error")
+	require.False(t, appended)
+	appended, err = w.Append(11, ToDecimal(decimal.NewFromInt(3)))
+	require.NoError(t, err)
+	require.True(t, appended)
+}

--- a/llo/protocol/stream_history_ring_test.go
+++ b/llo/protocol/stream_history_ring_test.go
@@ -579,7 +579,7 @@ func TestUnmarshalStreamHistoryHeaderCorruption(t *testing.T) {
 			LastObservationTimestampNanoseconds:       400,
 		}
 	}
-	b, err := deterministicHistoryMarshal.Marshal(valid())
+	b, err := deterministicMarshal.Marshal(valid())
 	require.NoError(t, err)
 	header, err := UnmarshalStreamHistoryHeader(b)
 	require.NoError(t, err)
@@ -638,7 +638,7 @@ func TestUnmarshalStreamHistoryHeaderCorruption(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			pb := valid()
 			mutate(pb)
-			b, err := deterministicHistoryMarshal.Marshal(pb)
+			b, err := deterministicMarshal.Marshal(pb)
 			require.NoError(t, err)
 
 			header, err := UnmarshalStreamHistoryHeader(b)
@@ -678,7 +678,7 @@ func TestUnmarshalStreamHistoryChunkCorruption(t *testing.T) {
 			},
 		}
 	}
-	b, err := deterministicHistoryMarshal.Marshal(valid())
+	b, err := deterministicMarshal.Marshal(valid())
 	require.NoError(t, err)
 	chunk, err := UnmarshalStreamHistoryChunk(b)
 	require.NoError(t, err)
@@ -719,7 +719,7 @@ func TestUnmarshalStreamHistoryChunkCorruption(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			pb := valid()
 			mutate(pb)
-			b, err := deterministicHistoryMarshal.Marshal(pb)
+			b, err := deterministicMarshal.Marshal(pb)
 			require.NoError(t, err)
 
 			chunk, err := UnmarshalStreamHistoryChunk(b)

--- a/llo/protocol/stream_value.go
+++ b/llo/protocol/stream_value.go
@@ -173,7 +173,9 @@ func (v *Quote) MarshalBinary() (b []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return proto.Marshal(&q)
+	// Deterministic: these bytes are compared across oracles. See
+	// deterministicMarshal.
+	return deterministicMarshal.Marshal(&q)
 }
 
 func (v *Quote) UnmarshalBinary(data []byte) error {
@@ -305,7 +307,9 @@ func (v *TimestampedStreamValue) MarshalBinary() ([]byte, error) {
 		Type:  v.StreamValue.Type(),
 		Value: sv,
 	}
-	return proto.Marshal(&t)
+	// Deterministic: these bytes are compared across oracles. See
+	// deterministicMarshal.
+	return deterministicMarshal.Marshal(&t)
 }
 
 func (v *TimestampedStreamValue) UnmarshalBinary(data []byte) error {

--- a/llo/protocol/types.go
+++ b/llo/protocol/types.go
@@ -30,6 +30,20 @@ type ReportCodec interface {
 	Verify(llotypes.ChannelDefinition) error
 }
 
+// FeedIDer is optionally implemented by a ReportCodec whose reports are
+// published under a feed ID. It exists so that VerifyChannelDefinitions can
+// check feed IDs are unique across the whole definition set without knowing the
+// format-specific opts the ID is carried in, or the format-specific rules for
+// when a channel has one at all.
+//
+// FeedID must be a pure function of the definition, like Verify, and is only
+// consulted for definitions Verify accepted. The boolean is false for a channel
+// whose reports carry no feed ID -- those are identified by channel ID, which is
+// unique by construction and so needs no check.
+type FeedIDer interface {
+	FeedID(llotypes.ChannelDefinition) (feedID [32]byte, ok bool, err error)
+}
+
 type ChannelDefinitionWithID struct {
 	llotypes.ChannelDefinition
 	ChannelID llotypes.ChannelID

--- a/llo/protocol/types.go
+++ b/llo/protocol/types.go
@@ -30,6 +30,18 @@ type ReportCodec interface {
 	Verify(llotypes.ChannelDefinition) error
 }
 
+// AdmissionVerifier is optionally implemented by a ReportCodec that has checks
+// which must gate a definition being added or changed, but must not be applied
+// to one that is already committed -- typically a check added after channels
+// were already live, which a grandfathered definition may not satisfy.
+//
+// VerifyForAdmission is only consulted for definitions Verify accepted, and only
+// on the admission path; see VerifyChannelDefinitionsForAdmission. Like Verify it
+// must be a pure function of the definition.
+type AdmissionVerifier interface {
+	VerifyForAdmission(llotypes.ChannelDefinition) error
+}
+
 // FeedIDer is optionally implemented by a ReportCodec whose reports are
 // published under a feed ID. It exists so that VerifyChannelDefinitions can
 // check feed IDs are unique across the whole definition set without knowing the

--- a/llo/reportcodec/evm/feed_id_test.go
+++ b/llo/reportcodec/evm/feed_id_test.go
@@ -1,0 +1,41 @@
+package evm
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
+
+	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+)
+
+func Test_FeedID(t *testing.T) {
+	feedID := common.HexToHash("0x0003111111111111111111111111111111111111111111111111111111111111")
+
+	codecs := map[string]protocol.FeedIDer{
+		"premium legacy":           ReportCodecPremiumLegacy{},
+		"abi encode unpacked":      ReportCodecEVMABIEncodeUnpacked{},
+		"abi encode unpacked expr": ReportCodecEVMABIEncodeUnpackedExpr{},
+		"streamlined":              ReportCodecEVMStreamlined{},
+	}
+	for name, codec := range codecs {
+		t.Run(name, func(t *testing.T) {
+			cd := llotypes.ChannelDefinition{Opts: []byte(`{"feedID":"` + feedID.Hex() + `"}`)}
+			got, ok, err := codec.FeedID(cd)
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, [32]byte(feedID), got)
+
+			_, _, err = codec.FeedID(llotypes.ChannelDefinition{Opts: []byte(`not json`)})
+			require.ErrorContains(t, err, "invalid Opts")
+		})
+	}
+
+	t.Run("streamlined reports no feed ID when unset", func(t *testing.T) {
+		_, ok, err := ReportCodecEVMStreamlined{}.FeedID(llotypes.ChannelDefinition{Opts: []byte(`{}`)})
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+}

--- a/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked.go
+++ b/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	_ protocol.ReportCodec = ReportCodecEVMABIEncodeUnpacked{}
+	_ protocol.FeedIDer    = ReportCodecEVMABIEncodeUnpacked{}
 
 	zero = big.NewInt(0)
 )
@@ -260,4 +261,14 @@ func (r ReportCodecEVMABIEncodeUnpacked) buildHeader(rf BaseReportFields, resolu
 		return nil, fmt.Errorf("failed to pack base report blob; %w", err)
 	}
 	return b, nil
+}
+
+// FeedID implements protocol.FeedIDer: these reports always carry a feed ID, and
+// Verify has already rejected a zero one.
+func (r ReportCodecEVMABIEncodeUnpacked) FeedID(cd llotypes.ChannelDefinition) ([32]byte, bool, error) {
+	opts := new(ReportFormatEVMABIEncodeOpts)
+	if err := opts.Decode(cd.Opts); err != nil {
+		return [32]byte{}, false, fmt.Errorf("invalid Opts, got: %q; %w", cd.Opts, err)
+	}
+	return opts.FeedID, true, nil
 }

--- a/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr.go
+++ b/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr.go
@@ -11,6 +11,7 @@ import (
 	llotypes "github.com/smartcontractkit/chainlink-common/pkg/types/llo"
 
 	protocol "github.com/smartcontractkit/chainlink-data-streams/llo/protocol"
+	"github.com/smartcontractkit/chainlink-data-streams/llo/protocol/calculated"
 )
 
 var (
@@ -96,6 +97,18 @@ func (r ReportCodecEVMABIEncodeUnpackedExpr) Verify(cd llotypes.ChannelDefinitio
 	}
 	if len(cd.Streams) < 3 {
 		return fmt.Errorf("expected at least 3 streams; got: %d", len(cd.Streams))
+	}
+	// Reject statically invalid expressions here, before the definition can
+	// reach consensus. An expression that cannot be analyzed can never produce a
+	// value, so the channel would be installed and then never report.
+	//
+	// Verify runs on an untrusted definition and must be a pure function of it:
+	// this check parses and analyzes only, with no stream values and no state.
+	//
+	// nil opts cache: Verify is given the definition directly, so the opts are
+	// decoded from it rather than looked up.
+	if err := calculated.ValidateChannelExpressions(nil, cd, 0); err != nil {
+		return fmt.Errorf("invalid calculated stream expressions: %w", err)
 	}
 	return nil
 }

--- a/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr.go
+++ b/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	_ protocol.ReportCodec = ReportCodecEVMABIEncodeUnpackedExpr{}
+	_ protocol.FeedIDer    = ReportCodecEVMABIEncodeUnpackedExpr{}
 )
 
 type ReportCodecEVMABIEncodeUnpackedExpr struct {
@@ -164,4 +165,14 @@ func (r ReportCodecEVMABIEncodeUnpackedExpr) buildHeader(rf BaseReportFields, re
 		return nil, fmt.Errorf("failed to pack base report blob; %w", err)
 	}
 	return b, nil
+}
+
+// FeedID implements protocol.FeedIDer: these reports always carry a feed ID, and
+// Verify has already rejected a zero one.
+func (r ReportCodecEVMABIEncodeUnpackedExpr) FeedID(cd llotypes.ChannelDefinition) ([32]byte, bool, error) {
+	opts := new(ReportFormatEVMABIEncodeOpts)
+	if err := opts.Decode(cd.Opts); err != nil {
+		return [32]byte{}, false, fmt.Errorf("invalid Opts, got: %q; %w", cd.Opts, err)
+	}
+	return opts.FeedID, true, nil
 }

--- a/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr.go
+++ b/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	_ protocol.ReportCodec = ReportCodecEVMABIEncodeUnpackedExpr{}
-	_ protocol.FeedIDer    = ReportCodecEVMABIEncodeUnpackedExpr{}
+	_ protocol.ReportCodec       = ReportCodecEVMABIEncodeUnpackedExpr{}
+	_ protocol.FeedIDer          = ReportCodecEVMABIEncodeUnpackedExpr{}
+	_ protocol.AdmissionVerifier = ReportCodecEVMABIEncodeUnpackedExpr{}
 )
 
 type ReportCodecEVMABIEncodeUnpackedExpr struct {
@@ -102,15 +103,24 @@ func (r ReportCodecEVMABIEncodeUnpackedExpr) Verify(cd llotypes.ChannelDefinitio
 	if len(cd.Streams) < 3 {
 		return fmt.Errorf("expected at least 3 streams; got: %d", len(cd.Streams))
 	}
-	// Reject statically invalid expressions here, before the definition can
-	// reach consensus. An expression that cannot be analyzed can never produce a
-	// value, so the channel would be installed and then never report.
-	//
-	// Verify runs on an untrusted definition and must be a pure function of it:
-	// this check parses and analyzes only, with no stream values and no state.
-	//
-	// nil opts cache: Verify is given the definition directly, so the opts are
-	// decoded from it rather than looked up.
+	return nil
+}
+
+// VerifyForAdmission implements protocol.AdmissionVerifier: it rejects
+// statically invalid expressions before the definition can reach consensus. An
+// expression that cannot be analyzed can never produce a value, so the channel
+// would be installed and then never report.
+//
+// This is not part of Verify because definitions committed before the check
+// existed may fail it, and rejecting those would stop every oracle from
+// observing rather than just stopping that one channel from reporting.
+//
+// Like Verify it runs on an untrusted definition and is a pure function of it:
+// this parses and analyzes only, with no stream values and no state.
+//
+// nil opts cache: the definition is given directly, so the opts are decoded from
+// it rather than looked up.
+func (r ReportCodecEVMABIEncodeUnpackedExpr) VerifyForAdmission(cd llotypes.ChannelDefinition) error {
 	if err := calculated.ValidateChannelExpressions(nil, cd, 0); err != nil {
 		return fmt.Errorf("invalid calculated stream expressions: %w", err)
 	}

--- a/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr.go
+++ b/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr.go
@@ -53,9 +53,12 @@ func (r ReportCodecEVMABIEncodeUnpackedExpr) Encode(report protocol.Report, cd l
 		return nil, fmt.Errorf("ReportCodecEVMABIEncodeUnpackedExpr no expressions found in channel definition")
 	}
 
-	// not enough streams for calculated feed
-	if cd.Streams[len(cd.Streams)-1].StreamID != opts.ABI[len(opts.ABI)-1].encoders[0].ExpressionStreamID {
-		return nil, fmt.Errorf("ReportCodecEVMABIEncodeUnpackedExpr not enough streams for calculated streams; expected: %d, got: %d", opts.ABI[len(opts.ABI)-1].encoders[0].ExpressionStreamID, len(cd.Streams))
+	// The payload is the trailing len(opts.ABI) values, one per declared
+	// calculated stream. protocol.EffectiveStreams guarantees that ordering when
+	// the report is assembled; this asserts the values actually arrived, which
+	// they do not when an expression failed to evaluate.
+	if len(report.Values) < len(opts.ABI) {
+		return nil, fmt.Errorf("ReportCodecEVMABIEncodeUnpackedExpr not enough values for calculated streams; expected at least: %d, got: %d", len(opts.ABI), len(report.Values))
 	}
 
 	report.ValidAfterNanoseconds = ClampReportRange(r, report, opts.MaxReportRange)

--- a/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr_test.go
+++ b/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr_test.go
@@ -413,10 +413,27 @@ func TestReportCodecEVMABIEncodeUnpackedExpr_Verify(t *testing.T) {
 				{StreamID: 3},
 				{StreamID: 4},
 			},
-			Opts: []byte(`{"ABI":[{"type":"int192"}],"feedID":"0x1111111111111111111111111111111111111111111111111111111111111111"}`),
+			Opts: []byte(`{"ABI":[{"type":"int192","expression":"Add(s3, s4)","expressionStreamID":999}],"feedID":"0x1111111111111111111111111111111111111111111111111111111111111111"}`),
 		}
 		err := c.Verify(cd)
 		require.NoError(t, err)
+	})
+	t.Run("ABI entry without an expression is rejected", func(t *testing.T) {
+		// This format's ABI entries each declare a calculated stream. An entry
+		// with no expression names a stream nothing can produce, so the channel
+		// could never report.
+		cd := llotypes.ChannelDefinition{
+			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+			Streams: []llotypes.Stream{
+				{StreamID: 1},
+				{StreamID: 2},
+				{StreamID: 3},
+			},
+			Opts: []byte(`{"ABI":[{"type":"int192"}],"feedID":"0x1111111111111111111111111111111111111111111111111111111111111111"}`),
+		}
+		err := c.Verify(cd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expression is empty")
 	})
 	t.Run("invalid feedID", func(t *testing.T) {
 		cd := llotypes.ChannelDefinition{
@@ -435,10 +452,66 @@ func TestReportCodecEVMABIEncodeUnpackedExpr_Verify(t *testing.T) {
 				{StreamID: 3},
 			},
 			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
-			Opts:         []byte(`{"baseUSDFee":"1","feedID":"0x1111111111111111111111111111111111111111111111111111111111111111","ABI":[{"streamID":1,"type":"int192"}]}`),
+			Opts:         []byte(`{"baseUSDFee":"1","feedID":"0x1111111111111111111111111111111111111111111111111111111111111111","ABI":[{"streamID":1,"type":"int192","expression":"Add(s1, s2)","expressionStreamID":999}]}`),
 		}
 		err := c.Verify(cd)
 		require.NoError(t, err)
+	})
+	t.Run("valid expression", func(t *testing.T) {
+		cd := llotypes.ChannelDefinition{
+			Streams: []llotypes.Stream{
+				{StreamID: 1, Aggregator: llotypes.AggregatorMedian},
+				{StreamID: 2, Aggregator: llotypes.AggregatorMedian},
+				{StreamID: 3, Aggregator: llotypes.AggregatorMedian},
+			},
+			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+			Opts:         []byte(`{"baseUSDFee":"1","feedID":"0x1111111111111111111111111111111111111111111111111111111111111111","ABI":[{"type":"int192","expression":"Avg(History(s3, 10))","expressionStreamID":999}]}`),
+		}
+		require.NoError(t, c.Verify(cd))
+	})
+	t.Run("statically invalid expression is rejected", func(t *testing.T) {
+		// A window in a scalar position can never produce a value, so accepting
+		// this definition would install a channel that never reports.
+		cd := llotypes.ChannelDefinition{
+			Streams: []llotypes.Stream{
+				{StreamID: 1, Aggregator: llotypes.AggregatorMedian},
+				{StreamID: 2, Aggregator: llotypes.AggregatorMedian},
+				{StreamID: 3, Aggregator: llotypes.AggregatorMedian},
+			},
+			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+			Opts:         []byte(`{"baseUSDFee":"1","feedID":"0x1111111111111111111111111111111111111111111111111111111111111111","ABI":[{"type":"int192","expression":"Add(History(s3, 10), 1)","expressionStreamID":999}]}`),
+		}
+		err := c.Verify(cd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid calculated stream expressions")
+	})
+	t.Run("unparseable expression is rejected", func(t *testing.T) {
+		cd := llotypes.ChannelDefinition{
+			Streams: []llotypes.Stream{
+				{StreamID: 1, Aggregator: llotypes.AggregatorMedian},
+				{StreamID: 2, Aggregator: llotypes.AggregatorMedian},
+				{StreamID: 3, Aggregator: llotypes.AggregatorMedian},
+			},
+			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+			Opts:         []byte(`{"baseUSDFee":"1","feedID":"0x1111111111111111111111111111111111111111111111111111111111111111","ABI":[{"type":"int192","expression":"Add(s1,","expressionStreamID":999}]}`),
+		}
+		require.Error(t, c.Verify(cd))
+	})
+	t.Run("ambiguous stream aggregation is rejected", func(t *testing.T) {
+		// Which aggregation a History call means would be undecidable.
+		cd := llotypes.ChannelDefinition{
+			Streams: []llotypes.Stream{
+				{StreamID: 1, Aggregator: llotypes.AggregatorMedian},
+				{StreamID: 2, Aggregator: llotypes.AggregatorMedian},
+				{StreamID: 3, Aggregator: llotypes.AggregatorMedian},
+				{StreamID: 3, Aggregator: llotypes.AggregatorMode},
+			},
+			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
+			Opts:         []byte(`{"baseUSDFee":"1","feedID":"0x1111111111111111111111111111111111111111111111111111111111111111","ABI":[{"type":"int192","expression":"Avg(History(s3, 10))","expressionStreamID":999}]}`),
+		}
+		err := c.Verify(cd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "aggregators")
 	})
 }
 

--- a/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr_test.go
+++ b/llo/reportcodec/evm/report_codec_evm_abi_encode_unpacked_expr_test.go
@@ -431,7 +431,10 @@ func TestReportCodecEVMABIEncodeUnpackedExpr_Verify(t *testing.T) {
 			},
 			Opts: []byte(`{"ABI":[{"type":"int192"}],"feedID":"0x1111111111111111111111111111111111111111111111111111111111111111"}`),
 		}
-		err := c.Verify(cd)
+		// Grandfathered: Verify still accepts it, so a committed definition
+		// keeps working; only admission rejects it.
+		require.NoError(t, c.Verify(cd))
+		err := c.VerifyForAdmission(cd)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expression is empty")
 	})
@@ -468,6 +471,7 @@ func TestReportCodecEVMABIEncodeUnpackedExpr_Verify(t *testing.T) {
 			Opts:         []byte(`{"baseUSDFee":"1","feedID":"0x1111111111111111111111111111111111111111111111111111111111111111","ABI":[{"type":"int192","expression":"Avg(History(s3, 10))","expressionStreamID":999}]}`),
 		}
 		require.NoError(t, c.Verify(cd))
+		require.NoError(t, c.VerifyForAdmission(cd))
 	})
 	t.Run("statically invalid expression is rejected", func(t *testing.T) {
 		// A window in a scalar position can never produce a value, so accepting
@@ -481,7 +485,8 @@ func TestReportCodecEVMABIEncodeUnpackedExpr_Verify(t *testing.T) {
 			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
 			Opts:         []byte(`{"baseUSDFee":"1","feedID":"0x1111111111111111111111111111111111111111111111111111111111111111","ABI":[{"type":"int192","expression":"Add(History(s3, 10), 1)","expressionStreamID":999}]}`),
 		}
-		err := c.Verify(cd)
+		require.NoError(t, c.Verify(cd))
+		err := c.VerifyForAdmission(cd)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid calculated stream expressions")
 	})
@@ -495,7 +500,8 @@ func TestReportCodecEVMABIEncodeUnpackedExpr_Verify(t *testing.T) {
 			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
 			Opts:         []byte(`{"baseUSDFee":"1","feedID":"0x1111111111111111111111111111111111111111111111111111111111111111","ABI":[{"type":"int192","expression":"Add(s1,","expressionStreamID":999}]}`),
 		}
-		require.Error(t, c.Verify(cd))
+		require.NoError(t, c.Verify(cd))
+		require.Error(t, c.VerifyForAdmission(cd))
 	})
 	t.Run("ambiguous stream aggregation is rejected", func(t *testing.T) {
 		// Which aggregation a History call means would be undecidable.
@@ -509,7 +515,8 @@ func TestReportCodecEVMABIEncodeUnpackedExpr_Verify(t *testing.T) {
 			ReportFormat: llotypes.ReportFormatEVMABIEncodeUnpackedExpr,
 			Opts:         []byte(`{"baseUSDFee":"1","feedID":"0x1111111111111111111111111111111111111111111111111111111111111111","ABI":[{"type":"int192","expression":"Avg(History(s3, 10))","expressionStreamID":999}]}`),
 		}
-		err := c.Verify(cd)
+		require.NoError(t, c.Verify(cd))
+		err := c.VerifyForAdmission(cd)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "aggregators")
 	})

--- a/llo/reportcodec/evm/report_codec_evm_streamlined.go
+++ b/llo/reportcodec/evm/report_codec_evm_streamlined.go
@@ -22,6 +22,7 @@ import (
 
 var (
 	_ protocol.ReportCodec = ReportCodecEVMStreamlined{}
+	_ protocol.FeedIDer    = ReportCodecEVMStreamlined{}
 )
 
 func NewReportCodecStreamlined(lggr logger.Logger) ReportCodecEVMStreamlined {
@@ -187,4 +188,18 @@ func (r *ReportFormatEVMStreamlinedOpts) Decode(opts []byte) error {
 
 func (r *ReportFormatEVMStreamlinedOpts) Encode() ([]byte, error) {
 	return json.Marshal(r)
+}
+
+// FeedID implements protocol.FeedIDer. The feed ID is optional for this format:
+// a channel that omits it identifies its payload by channel ID instead, so it
+// has no feed ID to check for uniqueness.
+func (rc ReportCodecEVMStreamlined) FeedID(cd llotypes.ChannelDefinition) ([32]byte, bool, error) {
+	opts := new(ReportFormatEVMStreamlinedOpts)
+	if err := opts.Decode(cd.Opts); err != nil {
+		return [32]byte{}, false, fmt.Errorf("invalid Opts, got: %q; %w", cd.Opts, err)
+	}
+	if opts.FeedID == nil {
+		return [32]byte{}, false, nil
+	}
+	return *opts.FeedID, true, nil
 }

--- a/llo/reportcodec/evm/report_codec_premium_legacy.go
+++ b/llo/reportcodec/evm/report_codec_premium_legacy.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	_            protocol.ReportCodec = ReportCodecPremiumLegacy{}
+	_            protocol.FeedIDer    = ReportCodecPremiumLegacy{}
 	PayloadTypes                      = getPayloadTypes()
 )
 
@@ -273,4 +274,14 @@ func LegacyReportContext(cd ocr2types.ConfigDigest, seqNr uint64, donID uint32) 
 		},
 		ExtraHash: LLOExtraHash(donID), // ExtraHash is always zero for mercury, we use LLOExtraHash here to differentiate from the legacy plugin
 	}, nil
+}
+
+// FeedID implements protocol.FeedIDer: premium legacy reports always carry a
+// feed ID, and Verify has already rejected a zero one.
+func (r ReportCodecPremiumLegacy) FeedID(cd llotypes.ChannelDefinition) ([32]byte, bool, error) {
+	opts := ReportFormatEVMPremiumLegacyOpts{}
+	if err := (&opts).Decode(cd.Opts); err != nil {
+		return [32]byte{}, false, fmt.Errorf("invalid Opts, got: %q; %w", cd.Opts, err)
+	}
+	return opts.FeedID, true, nil
 }

--- a/llo/v30/codecs.go
+++ b/llo/v30/codecs.go
@@ -36,7 +36,7 @@ func GetOutcomeCodec(c protocol.OffchainConfig) OutcomeCodec {
 // SelectBackfillCandidate returns the next observation timestamp in nanoseconds, its raw key, and parsed opts, or an UnreportableChannelError.
 // outcome.ValidAfterNanoseconds[backfillCID] is the progress watermark (last emitted backfill observation time, in nanoseconds).
 // Min report interval and second-resolution overlap rules used for live channels do not apply to history_backfill.
-func SelectBackfillCandidate(out *Outcome, backfillCID llotypes.ChannelID) (tsNanos uint64, rawTS uint64, opts protocol.HistoryBackfillOpts, uerr *UnreportableChannelError) {
+func SelectBackfillCandidate(out *Outcome, backfillCID llotypes.ChannelID, optsCache *protocol.OptsCache) (tsNanos uint64, rawTS uint64, opts protocol.HistoryBackfillOpts, uerr *UnreportableChannelError) {
 	cd, exists := out.ChannelDefinitions[backfillCID]
 	if !exists {
 		return 0, 0, protocol.HistoryBackfillOpts{}, &UnreportableChannelError{Inner: nil, Reason: "IsReportable=false; no channel definition with this ID", ChannelID: backfillCID}
@@ -46,7 +46,7 @@ func SelectBackfillCandidate(out *Outcome, backfillCID llotypes.ChannelID) (tsNa
 	}
 
 	var err error
-	opts, err = protocol.ParseHistoryBackfillOpts(cd.Opts)
+	opts, err = protocol.GetHistoryBackfillOpts(optsCache, cd, backfillCID)
 	if err != nil {
 		return 0, 0, protocol.HistoryBackfillOpts{}, &UnreportableChannelError{Inner: fmt.Errorf("failed to backfill: %w", err), Reason: "failed to parse history_backfill opts", ChannelID: backfillCID}
 	}
@@ -69,7 +69,12 @@ func SelectBackfillCandidate(out *Outcome, backfillCID llotypes.ChannelID) (tsNa
 	var bestNanos uint64
 	found := false
 	for rawKey := range opts.Observations {
-		tsN := protocol.ObservationTimestampKeyToNanoseconds(rawKey, res)
+		tsN, ok := protocol.ObservationTimestampKeyToNanoseconds(rawKey, res)
+		if !ok {
+			// Not expressible in nanoseconds; scaling it would wrap into a
+			// timestamp that looks like a valid past one.
+			continue
+		}
 		if tsN >= obsTSNanos {
 			continue
 		}

--- a/llo/v30/history_backfill_test.go
+++ b/llo/v30/history_backfill_test.go
@@ -32,19 +32,19 @@ func TestSelectBackfillCandidate_picksSmallestEligible(t *testing.T) {
 		ValidAfterNanoseconds: map[llotypes.ChannelID]uint64{backfillID: 0},
 	}
 
-	ts, raw, _, uerr := SelectBackfillCandidate(&out, backfillID)
+	ts, raw, _, uerr := SelectBackfillCandidate(&out, backfillID, nil)
 	require.Nil(t, uerr)
 	require.Equal(t, uint64(100*time.Second), ts)
 	require.Equal(t, uint64(100), raw)
 
 	out.ValidAfterNanoseconds[backfillID] = uint64(100 * time.Second)
-	ts2, raw2, _, uerr2 := SelectBackfillCandidate(&out, backfillID)
+	ts2, raw2, _, uerr2 := SelectBackfillCandidate(&out, backfillID, nil)
 	require.Nil(t, uerr2)
 	require.Equal(t, uint64(150*time.Second), ts2)
 	require.Equal(t, uint64(150), raw2)
 
 	out.ValidAfterNanoseconds[backfillID] = uint64(200 * time.Second)
-	_, _, _, uerr3 := SelectBackfillCandidate(&out, backfillID)
+	_, _, _, uerr3 := SelectBackfillCandidate(&out, backfillID, nil)
 	require.NotNil(t, uerr3)
 	require.Contains(t, uerr3.Error(), "backfill complete, no remaining timestamps")
 }
@@ -64,7 +64,7 @@ func TestSelectBackfillCandidate_skipsFutureObservations(t *testing.T) {
 		},
 		ValidAfterNanoseconds: map[llotypes.ChannelID]uint64{10: 0},
 	}
-	_, _, _, uerr := SelectBackfillCandidate(&out, 10)
+	_, _, _, uerr := SelectBackfillCandidate(&out, 10, nil)
 	require.NotNil(t, uerr)
 	require.Contains(t, uerr.Error(), "backfill complete, no remaining timestamps")
 }

--- a/llo/v30/plugin.go
+++ b/llo/v30/plugin.go
@@ -288,6 +288,12 @@ func (p *Plugin) ValidateObservation(ctx context.Context, outctx ocr3types.Outco
 		return fmt.Errorf("RemoveChannelIDs is too long: %v vs %v", len(observation.RemoveChannelIDs), protocol.MaxObservationRemoveChannelIDsLength)
 	}
 
+	// Only the baseline checks run here. A definition is installed on more than
+	// f votes for its exact hash, so at least one honest oracle must have voted
+	// for it, and an honest oracle only votes for what its own admission-time
+	// verification accepted (see voteOnChannels). Repeating the admission-only
+	// checks here would add nothing, and would make oracles running different
+	// versions of those checks disagree on whether an observation is valid.
 	defsForVerify := observation.UpdateChannelDefinitions
 	if len(observation.UpdateChannelDefinitions) > 0 && outctx.SeqNr > 1 {
 		prevOutcome, prevErr := p.OutcomeCodec.Decode(outctx.PreviousOutcome)

--- a/llo/v30/plugin_observation.go
+++ b/llo/v30/plugin_observation.go
@@ -79,7 +79,11 @@ func (p *Plugin) observation(ctx context.Context, outctx ocr3types.OutcomeContex
 			//
 			// ChannelIDs should always be sorted the same way (channel ID ascending).
 			expectedChannelDefs := p.ChannelDefinitionCache.Definitions(previousOutcome.ChannelDefinitions)
-			if err = protocol.VerifyChannelDefinitions(p.ReportCodecs, expectedChannelDefs); err != nil {
+			// Only the channels this node would vote to add or change are held
+			// to the admission-only checks; the ones already committed are not,
+			// or a grandfathered channel would freeze channel voting entirely.
+			admitting := protocol.ChangedChannelIDs(previousOutcome.ChannelDefinitions, expectedChannelDefs)
+			if err = protocol.VerifyChannelDefinitionsForAdmission(p.ReportCodecs, expectedChannelDefs, admitting); err != nil {
 				// If channel definitions is invalid, do not error out but instead
 				// don't vote on any new channels.
 				//

--- a/llo/v30/plugin_outcome.go
+++ b/llo/v30/plugin_outcome.go
@@ -175,7 +175,7 @@ func (p *Plugin) outcome(outctx ocr3types.OutcomeContext, query types.Query, aos
 		for channelID, previousValidAfterNanoseconds := range previousOutcome.ValidAfterNanoseconds {
 			cd, ok := previousOutcome.ChannelDefinitions[channelID]
 			if ok && cd.ReportFormat == llotypes.ReportFormatHistoryBackfill {
-				tsNanos, _, _, uerr := SelectBackfillCandidate(&previousOutcome, channelID)
+				tsNanos, _, _, uerr := SelectBackfillCandidate(&previousOutcome, channelID, p.OptsCache)
 				if uerr != nil {
 					if p.Config.VerboseLogging {
 						p.Logger.Debugw("Channel is not reportable", "channelID", channelID, "err", uerr, "stage", "Outcome", "seqNr", outctx.SeqNr)
@@ -464,7 +464,7 @@ func (out *Outcome) IsReportable(channelID llotypes.ChannelID, protocolVersion u
 	}
 
 	if cd.ReportFormat == llotypes.ReportFormatHistoryBackfill {
-		_, _, _, uerr := SelectBackfillCandidate(out, channelID)
+		_, _, _, uerr := SelectBackfillCandidate(out, channelID, optsCache)
 		if uerr != nil {
 			return uerr
 		}

--- a/llo/v30/plugin_reports.go
+++ b/llo/v30/plugin_reports.go
@@ -57,7 +57,7 @@ func (p *Plugin) reports(ctx context.Context, seqNr uint64, rawOutcome ocr3types
 		cd := outcome.ChannelDefinitions[cid]
 
 		if cd.ReportFormat == llotypes.ReportFormatHistoryBackfill {
-			tsNanos, rawTS, opts, uerr := SelectBackfillCandidate(&outcome, cid)
+			tsNanos, rawTS, opts, uerr := SelectBackfillCandidate(&outcome, cid, p.OptsCache)
 			if uerr != nil {
 				p.Logger.Warnw("backfill channel was reportable but selection failed", "channelID", cid, "err", uerr, "stage", "Report", "seqNr", seqNr)
 				continue

--- a/llo/v30/stream_calculated.go
+++ b/llo/v30/stream_calculated.go
@@ -13,7 +13,10 @@ import (
 // to their channel definitions and writing the evaluated values into the
 // outcome's StreamAggregates.
 func (p *Plugin) ProcessCalculatedStreams(outcome *Outcome) {
-	calculated.ProcessCalculatedStreams(p.Logger, outcome.ChannelDefinitions, outcome.StreamAggregates, outcome.ObservationTimestampNanoseconds, p.OptsCache)
+	// nil HistoryReader: v30 has no replicated key-value state, so there is
+	// nowhere for stream history to live. Expressions using History fail closed
+	// rather than evaluating against an empty window.
+	calculated.ProcessCalculatedStreams(p.Logger, outcome.ChannelDefinitions, outcome.StreamAggregates, outcome.ObservationTimestampNanoseconds, p.OptsCache, nil)
 }
 
 // ProcessCalculatedStreamsDryRun validates an expression against synthetic inputs.

--- a/llo/v30/stream_calculated.go
+++ b/llo/v30/stream_calculated.go
@@ -12,11 +12,15 @@ import (
 // outcome's EVMABIEncodeUnpackedExpr channels, appending the calculated streams
 // to their channel definitions and writing the evaluated values into the
 // outcome's StreamAggregates.
+//
+// v3.0 commits ChannelDefinitions as part of its outcome, so it keeps the
+// deprecated appending variant. v3.1 derives the streams it reports instead,
+// via protocol.EffectiveStreams.
 func (p *Plugin) ProcessCalculatedStreams(outcome *Outcome) {
 	// nil HistoryReader: v30 has no replicated key-value state, so there is
 	// nowhere for stream history to live. Expressions using History fail closed
 	// rather than evaluating against an empty window.
-	calculated.ProcessCalculatedStreams(p.Logger, outcome.ChannelDefinitions, outcome.StreamAggregates, outcome.ObservationTimestampNanoseconds, p.OptsCache, nil)
+	calculated.ProcessCalculatedStreamsWithDefinitionAppend(p.Logger, outcome.ChannelDefinitions, outcome.StreamAggregates, outcome.ObservationTimestampNanoseconds, p.OptsCache, nil)
 }
 
 // ProcessCalculatedStreamsDryRun validates an expression against synthetic inputs.


### PR DESCRIPTION
Calculated streams can now read a window of a stream's past agreed values. This adds the persistence layer for that history, the window functions that consume it, static validation so an unusable expression cannot reach consensus, and concurrency work on the evaluation hot path.

Commits can be reviewed independently

1. [`0f5e6e6`](https://github.com/smartcontractkit/chainlink-data-streams/commit/0f5e6e6f208fe52fa817a582e0534877d0c2f4e9) — llo/protocol: chunked ring storage for stream history
2. [`de09a51`](https://github.com/smartcontractkit/chainlink-data-streams/commit/de09a51a79d1362bf8fbf6fd9e24c825fb284ca8) — llo/protocol/calculated: History() AST support
3. [`9e034e1`](https://github.com/smartcontractkit/chainlink-data-streams/commit/9e034e182fb77e9710ed2c83a5a9f938572842d4) — llo/protocol/calculated: evaluate expressions over history windows
4. [`5ba7997`](https://github.com/smartcontractkit/chainlink-data-streams/commit/5ba799704b45ad0eeefebf947cdd8b818d841164) — llo/dev/v31: stream history persistence and loading
5. [`5d2280a`](https://github.com/smartcontractkit/chainlink-data-streams/commit/5d2280a8d7ec596f94bbc9a3c08bd0964a216706) — llo/protocol/calculated: reject invalid expressions at the channel boundary
6. [`f096c3a`](https://github.com/smartcontractkit/chainlink-data-streams/commit/f096c3aabb768e4761295f1443e36bfc9eb88325) — llo/protocol/calculated: extend existing functions for series, guard decimal math
7. [`aa99b3c`](https://github.com/smartcontractkit/chainlink-data-streams/commit/aa99b3c8d78c48d7a9c9aa22130796f34018195f) — llo/protocol/calculated: series functions over history windows
8. [`04ba48f`](https://github.com/smartcontractkit/chainlink-data-streams/commit/04ba48f99d1a800efe12d81730b4d0865dbfd769) — llo/protocol/calculated: add SMA
9. [`8495b61`](https://github.com/smartcontractkit/chainlink-data-streams/commit/8495b616d45925a221dbd926e4420ed3381420b2) — llo/protocol/calculated: add WMA
10. [`afcf9a1`](https://github.com/smartcontractkit/chainlink-data-streams/commit/afcf9a16392f2fbda3dbe4945fef70d3b66b2b4f) — llo/protocol/calculated: add EMA
11. [`d91441d`](https://github.com/smartcontractkit/chainlink-data-streams/commit/d91441d527f0bdfd5ef1970c6f47c0f9f00524e3) — llo/protocol/calculated: add TWAP
12. [`9af6854`](https://github.com/smartcontractkit/chainlink-data-streams/commit/9af6854f7edfd45b86c9b11731ea1d81c6b9bfb9) — llo/protocol/calculated: document the expression package, fuzz evaluation
13. [`5b9019a`](https://github.com/smartcontractkit/chainlink-data-streams/commit/5b9019a7f7af7f61baf780ac0aa9c44bf73c34a7) — llo/protocol/calculated: evaluate channels concurrently
14. [`213407c`](https://github.com/smartcontractkit/chainlink-data-streams/commit/213407cde1aad2232f0e73b81998387a010813ef) — llo/protocol/calculated: fuzz a whole round, not one expression
15. [`2005b4e`](https://github.com/smartcontractkit/chainlink-data-streams/commit/2005b4efcf2afc20b678e1d62e95ca3b8c49fa04) — llo/protocol: reject colliding calculated stream IDs and feed IDs
16. [`52905c7`](https://github.com/smartcontractkit/chainlink-data-streams/commit/52905c7ca4fbcb46d3cbdbb3c492afeceaca8f8d) — llo: derive calculated streams instead of storing them on channel definitions
