### PR TITLE
feat(llo/v31): skip observation/aggregation for recently-reported channels

### DIFF
--- a/llo/dev/v31/blobpump_test.go
+++ b/llo/dev/v31/blobpump_test.go
@@ -222,8 +222,8 @@ func Test_observableStreams(t *testing.T) {
 		2: {ReportFormat: llotypes.ReportFormatJSON, Streams: []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}}},
 		3: {ReportFormat: llotypes.ReportFormatJSON, Tombstone: true, Streams: []llotypes.Stream{{StreamID: 102, Aggregator: llotypes.AggregatorMedian}}},
 	}}
-	require.ElementsMatch(t, []llotypes.StreamID{100}, observableStreams(state))
-	require.Empty(t, observableStreams(&kvState{}))
+	require.ElementsMatch(t, []llotypes.StreamID{100}, observableStreams(state, 0, 0))
+	require.Empty(t, observableStreams(&kvState{}, 0, 0))
 }
 
 // Test_blobPump_DisabledIsInert covers hosts that run the plugin without blob

--- a/llo/dev/v31/factory.go
+++ b/llo/dev/v31/factory.go
@@ -109,8 +109,9 @@ func (f *PluginFactory) NewReportingPlugin(ctx context.Context, cfg ocr3types.Re
 		DonID:                               f.DonID,
 		OutcomeTelemetryCh:                  f.OutcomeTelemetryCh,
 		ReportTelemetryCh:                   f.ReportTelemetryCh,
-		ProtocolVersion:                     offchainConfig.ProtocolVersion,
-		DefaultMinReportIntervalNanoseconds: offchainConfig.DefaultMinReportIntervalNanoseconds,
+		ProtocolVersion:                          offchainConfig.ProtocolVersion,
+		DefaultMinReportIntervalNanoseconds:      offchainConfig.DefaultMinReportIntervalNanoseconds,
+		DefaultMinObservationIntervalNanoseconds: offchainConfig.DefaultMinObservationIntervalNanoseconds,
 	}
 
 	// Definitions and the opts decoded from them are cached together, as one

--- a/llo/dev/v31/kv.go
+++ b/llo/dev/v31/kv.go
@@ -242,6 +242,34 @@ func readHotState(r ocr3_1types.KeyValueStateReader, s *kvState) error {
 	return nil
 }
 
+// readValidAfterOnly reads the r/agg record and extracts just the validAfter
+// watermarks, the previous observation timestamp, and the reportability flags,
+// skipping the (potentially large) carry-forward stream aggregates. It is a
+// lightweight alternative to readHotState for the Observation phase, which
+// needs the watermarks to decide whether a channel is due for observation but
+// does not need the aggregates.
+func readValidAfterOnly(r ocr3_1types.KeyValueStateReader, s *kvState) error {
+	b, err := r.Read(keyHotState)
+	if err != nil {
+		return fmt.Errorf("read hot state: %w", err)
+	}
+	if len(b) == 0 {
+		return nil
+	}
+	pb := &protocol.LLOHotStateProto{}
+	if err := proto.Unmarshal(b, pb); err != nil {
+		return fmt.Errorf("unmarshal hot state: %w", err)
+	}
+	s.observationTimestampNs = pb.ObservationTimestampNanoseconds
+	for _, va := range pb.ValidAfterNanoseconds {
+		s.validAfterNanoseconds[va.ChannelID] = va.ValidAfterNanoseconds
+	}
+	for _, cid := range pb.ReportableChannelIDs {
+		s.reportedLastRound[cid] = true
+	}
+	return nil
+}
+
 // writeLifecycle persists the lifecycle stage.
 func writeLifecycle(w ocr3_1types.KeyValueStateReadWriter, stage llotypes.LifeCycleStage) error {
 	return w.Write(keyLifecycle, []byte(stage))

--- a/llo/dev/v31/plugin.go
+++ b/llo/dev/v31/plugin.go
@@ -59,8 +59,9 @@ type Plugin struct {
 	pump *blobPump
 
 	// From offchain config
-	ProtocolVersion                     uint32
-	DefaultMinReportIntervalNanoseconds uint64
+	ProtocolVersion                          uint32
+	DefaultMinReportIntervalNanoseconds      uint64
+	DefaultMinObservationIntervalNanoseconds uint64
 }
 
 // Query is empty: LLO oracles do not coordinate on what to observe.
@@ -84,6 +85,11 @@ func (p *Plugin) Observation(_ context.Context, seqNr uint64, _ ocrtypes.Attribu
 	state, err := loadColdKVState(kvReader, p.ChannelCache)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load KV state: %w", err)
+	}
+
+	obsTSNanos := time.Now().UnixNano()
+	if obsTSNanos < 0 {
+		return nil, fmt.Errorf("negative observation timestamps are not supported, got: %d", obsTSNanos)
 	}
 
 	var obs Observation
@@ -110,7 +116,21 @@ func (p *Plugin) Observation(_ context.Context, seqNr uint64, _ ocrtypes.Attribu
 
 		p.voteOnChannels(&obs, state, seqNr)
 
-		streams = observableStreams(state)
+		if p.DefaultMinObservationIntervalNanoseconds > 0 {
+			if err := readValidAfterOnly(kvReader, state); err != nil {
+				return nil, fmt.Errorf("failed to load validAfter for observation skip: %w", err)
+			}
+			// Advance validAfter for channels that reported last round,
+			// matching what StateTransition computes as out.ValidAfterNanoseconds.
+			// The hot state's watermark lags one round behind the true last-report
+			// timestamp; without this advancement the skip would use a stale value.
+			for cid, reported := range state.reportedLastRound {
+				if reported {
+					state.validAfterNanoseconds[cid] = state.observationTimestampNs
+				}
+			}
+		}
+		streams = observableStreams(state, p.DefaultMinObservationIntervalNanoseconds, uint64(obsTSNanos))
 	}
 
 	// Stream values are gathered asynchronously by the blob pump and are always
@@ -133,26 +153,69 @@ func (p *Plugin) Observation(_ context.Context, seqNr uint64, _ ocrtypes.Attribu
 		}
 	}
 
-	obsTSNanos := time.Now().UnixNano()
-	if obsTSNanos < 0 {
-		return nil, fmt.Errorf("negative observation timestamps are not supported, got: %d", obsTSNanos)
-	}
 	obs.UnixTimestampNanoseconds = uint64(obsTSNanos)
 
 	return encodeObservation(obs, handles)
 }
 
+// isObservationDue reports whether enough time has elapsed since the channel's
+// last report (its validAfter watermark) for the channel to be
+// observed/aggregated. A channel with no validAfter yet (newly effective) is
+// always due so it can build its initial aggregates. When
+// minObservationInterval is 0 the feature is disabled and every channel is due.
+func isObservationDue(validAfterNanoseconds map[llotypes.ChannelID]uint64, channelID llotypes.ChannelID, minObservationInterval, now uint64) bool {
+	if minObservationInterval == 0 {
+		return true
+	}
+	validAfter, ok := validAfterNanoseconds[channelID]
+	if !ok {
+		return true
+	}
+	return now >= validAfter+minObservationInterval && now > validAfter
+}
+
+// observableDefinitions returns the subset of defs that are due for
+// observation/aggregation, excluding tombstoned and backfill channels. When
+// minObservationInterval is 0, defs is returned unchanged.
+func observableDefinitions(defs llotypes.ChannelDefinitions, validAfterNanoseconds map[llotypes.ChannelID]uint64, minObservationInterval, now uint64) llotypes.ChannelDefinitions {
+	if minObservationInterval == 0 {
+		return defs
+	}
+	filtered := make(llotypes.ChannelDefinitions, len(defs))
+	for channelID, cd := range defs {
+		if cd.Tombstone || cd.ReportFormat == llotypes.ReportFormatHistoryBackfill {
+			continue
+		}
+		if isObservationDue(validAfterNanoseconds, channelID, minObservationInterval, now) {
+			filtered[channelID] = cd
+		}
+	}
+	return filtered
+}
+
 // observableStreams lists the streams a round should observe: every stream of
 // every live channel, minus calculated streams (which are derived in
 // StateTransition rather than observed).
-func observableStreams(state *kvState) []llotypes.StreamID {
+//
+// When minObservationInterval is non-zero, channels whose last report (validAfter
+// watermark) is too recent are skipped: their streams are not observed unless
+// another due channel (or a backfill channel, which is always observed) shares
+// them. A channel with no validAfter yet (newly effective) is always considered
+// due so it can build its initial aggregates.
+func observableStreams(state *kvState, minObservationInterval uint64, now uint64) []llotypes.StreamID {
 	if len(state.channelDefinitions) == 0 {
 		return nil
 	}
 	seen := make(map[llotypes.StreamID]struct{})
 	streams := make([]llotypes.StreamID, 0, len(state.channelDefinitions))
-	for _, cd := range state.channelDefinitions {
+	for channelID, cd := range state.channelDefinitions {
 		if cd.Tombstone {
+			continue
+		}
+		if cd.ReportFormat == llotypes.ReportFormatHistoryBackfill {
+			continue
+		}
+		if !isObservationDue(state.validAfterNanoseconds, channelID, minObservationInterval, now) {
 			continue
 		}
 		for _, strm := range cd.Streams {

--- a/llo/dev/v31/plugin_test.go
+++ b/llo/dev/v31/plugin_test.go
@@ -111,8 +111,9 @@ func testPlugin(t *testing.T) *Plugin {
 		F:                                   1,
 		ReportCodecs:                        map[llotypes.ReportFormat]protocol.ReportCodec{llotypes.ReportFormatJSON: reportcodec.JSONReportCodec{}},
 		ChannelCache:                        protocol.NewChannelCache(),
-		ProtocolVersion:                     0,
-		DefaultMinReportIntervalNanoseconds: 0,
+		ProtocolVersion:                          0,
+		DefaultMinReportIntervalNanoseconds:      0,
+		DefaultMinObservationIntervalNanoseconds: 0,
 	}
 }
 
@@ -583,7 +584,7 @@ func Test_TimestampedAggregate_CarryForward(t *testing.T) {
 		obs := map[llotypes.StreamID][]protocol.StreamValue{100: {tsv(ts, v), tsv(ts, v), tsv(ts, v)}}
 		next := map[llotypes.StreamID]map[llotypes.Aggregator]*protocol.TimestampedStreamValue{}
 		// No history requirements: this test is about carry-forward aggregation.
-		require.NoError(t, p.aggregate(carry, next, defs, obs, out, nil, historyRequirements{}, ts))
+		require.NoError(t, p.aggregate(carry, next, defs, nil, 0, obs, out, nil, historyRequirements{}, ts))
 		carry = next
 		res, ok := out[100][llotypes.AggregatorMedian].(*protocol.TimestampedStreamValue)
 		require.True(t, ok, "expected a TimestampedStreamValue aggregate")
@@ -948,4 +949,195 @@ func Test_Observation_RejectsInlineStreamValues(t *testing.T) {
 	// Deterministic across oracles, so it must not be a blob-fetch failure.
 	var bfErr *blobFetchError
 	require.NotErrorAs(t, err, &bfErr)
+}
+
+func Test_ObservationIntervalSkip_observableStreams(t *testing.T) {
+	state := &kvState{
+		channelDefinitions: llotypes.ChannelDefinitions{
+			1: {ReportFormat: llotypes.ReportFormatJSON, Streams: []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}}},
+			2: {ReportFormat: llotypes.ReportFormatJSON, Streams: []llotypes.Stream{{StreamID: 200, Aggregator: llotypes.AggregatorMedian}}},
+			3: {ReportFormat: llotypes.ReportFormatJSON, Streams: []llotypes.Stream{{StreamID: 300, Aggregator: llotypes.AggregatorMedian}}},
+		},
+		validAfterNanoseconds: map[llotypes.ChannelID]uint64{
+			1: 1000,
+			2: 5000,
+		},
+	}
+	const interval = 3000
+
+	// t=3500: ch1 not due (3500<4000), ch2 not due (3500<8000), ch3 due (no validAfter)
+	require.ElementsMatch(t, []llotypes.StreamID{300}, observableStreams(state, interval, 3500))
+
+	// t=4000: ch1 due (4000>=4000, 4000>1000), ch2 not, ch3 due
+	require.ElementsMatch(t, []llotypes.StreamID{100, 300}, observableStreams(state, interval, 4000))
+
+	// t=8500: all due
+	require.ElementsMatch(t, []llotypes.StreamID{100, 200, 300}, observableStreams(state, interval, 8500))
+
+	// interval=0: all due (disabled)
+	require.ElementsMatch(t, []llotypes.StreamID{100, 200, 300}, observableStreams(state, 0, 3500))
+
+	// Shared stream: not-due channel shares stream with due channel
+	state.channelDefinitions[4] = llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatJSON,
+		Streams:      []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}},
+	}
+	state.validAfterNanoseconds[4] = 5000
+	require.ElementsMatch(t, []llotypes.StreamID{100, 300}, observableStreams(state, interval, 4000))
+
+	// Unique stream of not-due channel is NOT observed
+	state.channelDefinitions[5] = llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatJSON,
+		Streams:      []llotypes.Stream{{StreamID: 500, Aggregator: llotypes.AggregatorMedian}},
+	}
+	state.validAfterNanoseconds[5] = 5000
+	require.ElementsMatch(t, []llotypes.StreamID{100, 300}, observableStreams(state, interval, 4000))
+
+	// Reported-last-round advancement: validAfter lags one round; the
+	// Observation method advances it to the previous obsTs before calling
+	// observableStreams. Simulate that here.
+	state2 := &kvState{
+		channelDefinitions: llotypes.ChannelDefinitions{
+			1: {ReportFormat: llotypes.ReportFormatJSON, Streams: []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}}},
+		},
+		validAfterNanoseconds:  map[llotypes.ChannelID]uint64{1: 3000},
+		reportedLastRound:      map[llotypes.ChannelID]bool{1: true},
+		observationTimestampNs: 8000,
+	}
+	// Before advancement: validAfter=3000, due at t=8000 (8000>=8000)
+	require.ElementsMatch(t, []llotypes.StreamID{100}, observableStreams(state2, 5000, 8000))
+	// After advancement: validAfter=8000, NOT due at t=10000 (10000<13000)
+	for cid, reported := range state2.reportedLastRound {
+		if reported {
+			state2.validAfterNanoseconds[cid] = state2.observationTimestampNs
+		}
+	}
+	require.Empty(t, observableStreams(state2, 5000, 10000))
+	require.ElementsMatch(t, []llotypes.StreamID{100}, observableStreams(state2, 5000, 14000))
+}
+
+func Test_ObservationIntervalSkip_aggregate(t *testing.T) {
+	p := testPlugin(t)
+	p.DefaultMinObservationIntervalNanoseconds = 5000
+
+	defs := llotypes.ChannelDefinitions{
+		1: {ReportFormat: llotypes.ReportFormatJSON, Streams: []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}}},
+		2: {ReportFormat: llotypes.ReportFormatJSON, Streams: []llotypes.Stream{{StreamID: 200, Aggregator: llotypes.AggregatorMedian}}},
+	}
+	validAfter := map[llotypes.ChannelID]uint64{1: 1000, 2: 10000}
+
+	mkObs := func(sid llotypes.StreamID, v int64) []protocol.StreamValue {
+		return []protocol.StreamValue{
+			protocol.ToDecimal(decimal.NewFromInt(v)),
+			protocol.ToDecimal(decimal.NewFromInt(v)),
+			protocol.ToDecimal(decimal.NewFromInt(v)),
+		}
+	}
+	obs := map[llotypes.StreamID][]protocol.StreamValue{
+		100: mkObs(100, 42),
+		200: mkObs(200, 99),
+	}
+
+	out := protocol.StreamAggregates{}
+	next := map[llotypes.StreamID]map[llotypes.Aggregator]*protocol.TimestampedStreamValue{}
+
+	// t=6000: ch1 due (6000>=1000+5000=6000, 6000>1000), ch2 not (6000<10000+5000=15000)
+	err := p.aggregate(nil, next, defs, validAfter, 5000, obs, out, nil, historyRequirements{}, 6000)
+	require.NoError(t, err)
+
+	require.NotNil(t, out[100][llotypes.AggregatorMedian], "due channel's stream must be aggregated")
+	require.Nil(t, out[200][llotypes.AggregatorMedian], "not-due channel's stream must be skipped")
+
+	// interval=0: all channels aggregated (disabled)
+	out2 := protocol.StreamAggregates{}
+	next2 := map[llotypes.StreamID]map[llotypes.Aggregator]*protocol.TimestampedStreamValue{}
+	err = p.aggregate(nil, next2, defs, validAfter, 0, obs, out2, nil, historyRequirements{}, 6000)
+	require.NoError(t, err)
+	require.NotNil(t, out2[100][llotypes.AggregatorMedian])
+	require.NotNil(t, out2[200][llotypes.AggregatorMedian])
+}
+
+func Test_ObservationIntervalSkip_FullRound(t *testing.T) {
+	ctx := tests.Context(t)
+	p := testPlugin(t)
+	p.DefaultMinReportIntervalNanoseconds = 5000
+	p.DefaultMinObservationIntervalNanoseconds = 5000
+	kv := newMemKV()
+
+	channelDef := llotypes.ChannelDefinition{
+		ReportFormat: llotypes.ReportFormatJSON,
+		Streams:      []llotypes.Stream{{StreamID: 100, Aggregator: llotypes.AggregatorMedian}},
+	}
+
+	obsWithVal := func(ts uint64, v int64) []ocrtypes.AttributedObservation {
+		obs := Observation{
+			UnixTimestampNanoseconds: ts,
+			StreamValues:             protocol.StreamValues{100: protocol.ToDecimal(decimal.NewFromInt(v))},
+		}
+		aos := make([]ocrtypes.AttributedObservation, 0, 4)
+		for i := 0; i < 4; i++ {
+			aos = append(aos, ao(i, mustEncodeObs(t, obs)))
+		}
+		return aos
+	}
+
+	// Round 1: bootstrap
+	_, err := p.StateTransition(ctx, 1, ocrtypes.AttributedQuery{}, []ocrtypes.AttributedObservation{ao(0, nil), ao(1, nil), ao(2, nil)}, kv, testBlobs)
+	require.NoError(t, err)
+
+	// Round 2: add channel 1
+	_, err = p.StateTransition(ctx, 2, ocrtypes.AttributedQuery{}, addChannelRound(t, 1_000, 1, channelDef), kv, testBlobs)
+	require.NoError(t, err)
+	require.Contains(t, kvChannelDefs(t, kv), llotypes.ChannelID(1))
+
+	// Round 3: channel effective, first watermark. Not due (3000 < 3000+5000).
+	prec3, err := p.StateTransition(ctx, 3, ocrtypes.AttributedQuery{}, obsWithVal(3_000, 10), kv, testBlobs)
+	require.NoError(t, err)
+	p3, err := decodePrecursor(prec3)
+	require.NoError(t, err)
+	require.Nil(t, p3.StreamAggregates[100][llotypes.AggregatorMedian],
+		"round 3: channel not due, stream must not be aggregated")
+	reports3, err := p.Reports(ctx, 3, prec3)
+	require.NoError(t, err)
+	require.Empty(t, reports3, "round 3: no reports")
+	assert.Equal(t, uint64(3000), storedValidAfter(t, kv, 1))
+	require.False(t, reportedFlag(t, kv, 1))
+
+	// Round 4: due (8000 >= 3000+5000). Aggregated and reported.
+	prec4, err := p.StateTransition(ctx, 4, ocrtypes.AttributedQuery{}, obsWithVal(8_000, 20), kv, testBlobs)
+	require.NoError(t, err)
+	p4, err := decodePrecursor(prec4)
+	require.NoError(t, err)
+	require.NotNil(t, p4.StreamAggregates[100][llotypes.AggregatorMedian],
+		"round 4: channel due, stream must be aggregated")
+	reports4, err := p.Reports(ctx, 4, prec4)
+	require.NoError(t, err)
+	require.Len(t, reports4, 1, "round 4: one report")
+	assert.Equal(t, uint64(3000), storedValidAfter(t, kv, 1), "validAfter not yet advanced (advances next round)")
+	require.True(t, reportedFlag(t, kv, 1))
+
+	// Round 5: not due. validAfter advanced to 8000 (prev reported), 10000 < 8000+5000.
+	prec5, err := p.StateTransition(ctx, 5, ocrtypes.AttributedQuery{}, obsWithVal(10_000, 30), kv, testBlobs)
+	require.NoError(t, err)
+	p5, err := decodePrecursor(prec5)
+	require.NoError(t, err)
+	require.Nil(t, p5.StreamAggregates[100][llotypes.AggregatorMedian],
+		"round 5: channel not due, stream must not be aggregated")
+	reports5, err := p.Reports(ctx, 5, prec5)
+	require.NoError(t, err)
+	require.Empty(t, reports5, "round 5: no reports")
+	assert.Equal(t, uint64(8000), storedValidAfter(t, kv, 1), "validAfter advanced because prev round reported")
+	require.False(t, reportedFlag(t, kv, 1))
+
+	// Round 6: due again (14000 >= 8000+5000). Aggregated and reported.
+	prec6, err := p.StateTransition(ctx, 6, ocrtypes.AttributedQuery{}, obsWithVal(14_000, 40), kv, testBlobs)
+	require.NoError(t, err)
+	p6, err := decodePrecursor(prec6)
+	require.NoError(t, err)
+	require.NotNil(t, p6.StreamAggregates[100][llotypes.AggregatorMedian],
+		"round 6: channel due, stream must be aggregated")
+	reports6, err := p.Reports(ctx, 6, prec6)
+	require.NoError(t, err)
+	require.Len(t, reports6, 1, "round 6: one report")
+	require.True(t, reportedFlag(t, kv, 1))
 }

--- a/llo/dev/v31/statetransition.go
+++ b/llo/dev/v31/statetransition.go
@@ -188,9 +188,13 @@ func (p *Plugin) StateTransition(ctx context.Context, seqNr uint64, _ ocrtypes.A
 	// the r/agg record). carryForward accumulates the values to persist for the
 	// next round. Runs over the effective set, which is what was observed. The
 	// agreed value of every pair history requires is recorded as it is computed.
+	//
+	// When DefaultMinObservationIntervalNanoseconds is configured, only channels
+	// whose last report is old enough are aggregated; the rest are skipped to
+	// save work on channels that will not report this round.
 	carryForward := map[llotypes.StreamID]map[llotypes.Aggregator]*protocol.TimestampedStreamValue{}
-	if err := p.aggregate(prev.carryForward, carryForward, effective, streamObservations, out.StreamAggregates,
-		history, requirements, out.ObservationTimestampNanoseconds); err != nil {
+	if err := p.aggregate(prev.carryForward, carryForward, effective, out.ValidAfterNanoseconds, p.DefaultMinObservationIntervalNanoseconds,
+		streamObservations, out.StreamAggregates, history, requirements, out.ObservationTimestampNanoseconds); err != nil {
 		return nil, err
 	}
 
@@ -204,7 +208,11 @@ func (p *Plugin) StateTransition(ctx context.Context, seqNr uint64, _ ocrtypes.A
 	// channel reports is derived from its opts by protocol.EffectiveStreams, so
 	// nothing about evaluation reaches replicated state and a persisted
 	// definition stays exactly what was voted on.
-	calculated.ProcessCalculatedStreams(p.Logger, effective, out.StreamAggregates, out.ObservationTimestampNanoseconds, prev.opts, history)
+	//
+	// Only due channels are passed, matching the aggregation filter: calculated
+	// streams for not-due channels are not needed (the channel will not report).
+	aggregationDefs := observableDefinitions(effective, out.ValidAfterNanoseconds, p.DefaultMinObservationIntervalNanoseconds, out.ObservationTimestampNanoseconds)
+	calculated.ProcessCalculatedStreams(p.Logger, aggregationDefs, out.StreamAggregates, out.ObservationTimestampNanoseconds, prev.opts, history)
 
 	// Flush KV mutations.
 	if err := p.flushKV(kvRW, seqNr, prev, out, pending, carryForward, history); err != nil {
@@ -366,6 +374,8 @@ func applyChannelVotes(
 func (p *Plugin) aggregate(
 	prevCarry, nextCarry map[llotypes.StreamID]map[llotypes.Aggregator]*protocol.TimestampedStreamValue,
 	defs llotypes.ChannelDefinitions,
+	validAfterNanoseconds map[llotypes.ChannelID]uint64,
+	minObservationInterval uint64,
 	streamObservations map[llotypes.StreamID][]protocol.StreamValue,
 	out protocol.StreamAggregates,
 	history *historyStore,
@@ -379,11 +389,19 @@ func (p *Plugin) aggregate(
 		nextCarry[sid][agg] = tsv
 	}
 
-	for _, cd := range defs {
+	for channelID, cd := range defs {
 		if cd.Tombstone || cd.ReportFormat == llotypes.ReportFormatHistoryBackfill {
 			// Not aggregated, so nothing is carried forward on their behalf. A
 			// pair that some other live channel still aggregates is preserved by
 			// that channel.
+			continue
+		}
+		if !isObservationDue(validAfterNanoseconds, channelID, minObservationInterval, observationTimestampNanoseconds) {
+			// Channel is not due for observation; skip aggregation. Streams
+			// shared with due channels are still aggregated via those channels.
+			// Pairs exclusive to not-due channels are not carried forward, so
+			// their carry-forward value is dropped. When the channel becomes due
+			// again, fresh aggregation resumes.
 			continue
 		}
 		for _, strm := range cd.Streams {

--- a/llo/protocol/llo_offchain_config.pb.go
+++ b/llo/protocol/llo_offchain_config.pb.go
@@ -22,12 +22,13 @@ const (
 )
 
 type LLOOffchainConfigProto struct {
-	state                               protoimpl.MessageState `protogen:"open.v1"`
-	ProtocolVersion                     uint32                 `protobuf:"varint,1,opt,name=protocolVersion,proto3" json:"protocolVersion,omitempty"`
-	DefaultMinReportIntervalNanoseconds uint64                 `protobuf:"varint,2,opt,name=defaultMinReportIntervalNanoseconds,proto3" json:"defaultMinReportIntervalNanoseconds,omitempty"`
-	EnableObservationCompression        bool                   `protobuf:"varint,3,opt,name=enableObservationCompression,proto3" json:"enableObservationCompression,omitempty"`
-	unknownFields                       protoimpl.UnknownFields
-	sizeCache                           protoimpl.SizeCache
+	state                                    protoimpl.MessageState `protogen:"open.v1"`
+	ProtocolVersion                          uint32                 `protobuf:"varint,1,opt,name=protocolVersion,proto3" json:"protocolVersion,omitempty"`
+	DefaultMinReportIntervalNanoseconds      uint64                 `protobuf:"varint,2,opt,name=defaultMinReportIntervalNanoseconds,proto3" json:"defaultMinReportIntervalNanoseconds,omitempty"`
+	EnableObservationCompression             bool                   `protobuf:"varint,3,opt,name=enableObservationCompression,proto3" json:"enableObservationCompression,omitempty"`
+	DefaultMinObservationIntervalNanoseconds uint64                 `protobuf:"varint,4,opt,name=defaultMinObservationIntervalNanoseconds,proto3" json:"defaultMinObservationIntervalNanoseconds,omitempty"`
+	unknownFields                            protoimpl.UnknownFields
+	sizeCache                                protoimpl.SizeCache
 }
 
 func (x *LLOOffchainConfigProto) Reset() {
@@ -81,15 +82,23 @@ func (x *LLOOffchainConfigProto) GetEnableObservationCompression() bool {
 	return false
 }
 
+func (x *LLOOffchainConfigProto) GetDefaultMinObservationIntervalNanoseconds() uint64 {
+	if x != nil {
+		return x.DefaultMinObservationIntervalNanoseconds
+	}
+	return 0
+}
+
 var File_llo_offchain_config_proto protoreflect.FileDescriptor
 
 const file_llo_offchain_config_proto_rawDesc = "" +
 	"\n" +
-	"\x19llo_offchain_config.proto\x12\x02v1\"\xd8\x01\n" +
+	"\x19llo_offchain_config.proto\x12\x02v1\"\xb4\x02\n" +
 	"\x16LLOOffchainConfigProto\x12(\n" +
 	"\x0fprotocolVersion\x18\x01 \x01(\rR\x0fprotocolVersion\x12P\n" +
 	"#defaultMinReportIntervalNanoseconds\x18\x02 \x01(\x04R#defaultMinReportIntervalNanoseconds\x12B\n" +
-	"\x1cenableObservationCompression\x18\x03 \x01(\bR\x1cenableObservationCompressionB\fZ\n" +
+	"\x1cenableObservationCompression\x18\x03 \x01(\bR\x1cenableObservationCompression\x12Z\n" +
+	"(defaultMinObservationIntervalNanoseconds\x18\x04 \x01(\x04R(defaultMinObservationIntervalNanosecondsB\fZ\n" +
 	".;protocolb\x06proto3"
 
 var (

--- a/llo/protocol/llo_offchain_config.proto
+++ b/llo/protocol/llo_offchain_config.proto
@@ -7,4 +7,5 @@ message LLOOffchainConfigProto {
     uint32 protocolVersion = 1;
     uint64 defaultMinReportIntervalNanoseconds = 2;
     bool enableObservationCompression = 3;
+    uint64 defaultMinObservationIntervalNanoseconds = 4;
 }

--- a/llo/protocol/offchain_config.go
+++ b/llo/protocol/offchain_config.go
@@ -18,6 +18,18 @@ type OffchainConfig struct {
 	// produced quickly, you are still limited by OCR3's DeltaRound and
 	// DeltaGrace params, as well as networking latency.
 	DefaultMinReportIntervalNanoseconds uint64
+	// DefaultMinObservationIntervalNanoseconds is the default minimum interval
+	// in nanoseconds between the last report of a channel and the next time its
+	// streams are observed/aggregated. When the elapsed time since a channel's
+	// last report (its validAfter watermark) is less than this threshold, the
+	// channel's observation and aggregation are skipped entirely for the round.
+	//
+	// It must be set to 0 for protocol version 0.
+	// For protocol version 1+, 0 means disabled (all channels are always
+	// observed); a non-zero value enables the skip. It should not exceed
+	// DefaultMinReportIntervalNanoseconds, or a channel could be reportable
+	// but lack the observations needed to produce a report.
+	DefaultMinObservationIntervalNanoseconds uint64
 	// EnableObservationCompression enables observation compression.
 	EnableObservationCompression bool
 }
@@ -42,15 +54,17 @@ func DecodeOffchainConfig(b []byte) (o OffchainConfig, err error) {
 	}
 	o.ProtocolVersion = pbuf.ProtocolVersion
 	o.DefaultMinReportIntervalNanoseconds = pbuf.DefaultMinReportIntervalNanoseconds
+	o.DefaultMinObservationIntervalNanoseconds = pbuf.DefaultMinObservationIntervalNanoseconds
 	o.EnableObservationCompression = pbuf.EnableObservationCompression
 	return
 }
 
 func (c OffchainConfig) Encode() ([]byte, error) {
 	pbuf := &LLOOffchainConfigProto{
-		ProtocolVersion:                     c.ProtocolVersion,
-		DefaultMinReportIntervalNanoseconds: c.DefaultMinReportIntervalNanoseconds,
-		EnableObservationCompression:        c.EnableObservationCompression,
+		ProtocolVersion:                          c.ProtocolVersion,
+		DefaultMinReportIntervalNanoseconds:      c.DefaultMinReportIntervalNanoseconds,
+		DefaultMinObservationIntervalNanoseconds: c.DefaultMinObservationIntervalNanoseconds,
+		EnableObservationCompression:             c.EnableObservationCompression,
 	}
 	return proto.Marshal(pbuf)
 }
@@ -61,9 +75,15 @@ func (c OffchainConfig) Validate() error {
 		if c.DefaultMinReportIntervalNanoseconds != 0 {
 			return errors.New("default report cadence must be 0 if protocol version is 0")
 		}
+		if c.DefaultMinObservationIntervalNanoseconds != 0 {
+			return errors.New("default observation cadence must be 0 if protocol version is 0")
+		}
 	case 1:
 		if c.DefaultMinReportIntervalNanoseconds == 0 {
 			return errors.New("default report cadence must be non-zero if protocol version is 1")
+		}
+		if c.DefaultMinObservationIntervalNanoseconds > c.DefaultMinReportIntervalNanoseconds {
+			return errors.New("default observation cadence must not exceed default report cadence")
 		}
 	default:
 		return fmt.Errorf("unknown protocol version: %d", c.ProtocolVersion)

--- a/llo/protocol/offchain_config_test.go
+++ b/llo/protocol/offchain_config_test.go
@@ -47,13 +47,24 @@ func Test_OffchainConfig(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "default report cadence must be 0 if protocol version is 0")
 		})
+		t.Run("setting DefaultMinObservationIntervalNanoseconds is invalid", func(t *testing.T) {
+			cfg := OffchainConfig{
+				ProtocolVersion:                          0,
+				DefaultMinObservationIntervalNanoseconds: 1,
+			}
+
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "default observation cadence must be 0 if protocol version is 0")
+		})
 	})
 	t.Run("version 1", func(t *testing.T) {
 		t.Run("encode/decode valid values", func(t *testing.T) {
 			cfg := OffchainConfig{
-				ProtocolVersion:                     1,
-				DefaultMinReportIntervalNanoseconds: 1000,
-				EnableObservationCompression:        true,
+				ProtocolVersion:                          1,
+				DefaultMinReportIntervalNanoseconds:      1000,
+				DefaultMinObservationIntervalNanoseconds: 500,
+				EnableObservationCompression:             true,
 			}
 
 			b, err := cfg.Encode()
@@ -62,6 +73,24 @@ func Test_OffchainConfig(t *testing.T) {
 			cfgDecoded, err := DecodeOffchainConfig(b)
 			require.NoError(t, err)
 			assert.Equal(t, cfg, cfgDecoded)
+		})
+		t.Run("DefaultMinObservationIntervalNanoseconds=0 is valid (disabled)", func(t *testing.T) {
+			cfg := OffchainConfig{
+				ProtocolVersion:                          1,
+				DefaultMinReportIntervalNanoseconds:      1000,
+				DefaultMinObservationIntervalNanoseconds: 0,
+			}
+			require.NoError(t, cfg.Validate())
+		})
+		t.Run("DefaultMinObservationIntervalNanoseconds > DefaultMinReportIntervalNanoseconds is invalid", func(t *testing.T) {
+			cfg := OffchainConfig{
+				ProtocolVersion:                          1,
+				DefaultMinReportIntervalNanoseconds:      1000,
+				DefaultMinObservationIntervalNanoseconds: 1001,
+			}
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "default observation cadence must not exceed default report cadence")
 		})
 	})
 	t.Run("DefaultMinReportIntervalNanoseconds=0 is invalid", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a new offchain config field **`DefaultMinObservationIntervalNanoseconds`** that skips observation and aggregation for channels whose last report is too recent — the same direction as the existing `DefaultMinReportIntervalNanoseconds` report-skip, but applied **earlier** in the pipeline to avoid unnecessary data fetching and aggregation work on channels that won't report this round anyway.

## Motivation

The existing `DefaultMinReportIntervalNanoseconds` feature (`reports.go:242`) skips *report generation* when a channel's last report was too recent. However, even when a report is skipped, the channel's streams are still **observed** (via the blob pump) and **aggregated** (in `StateTransition`). This wastes resources — particularly I/O from the data source and CPU from aggregation — on channels that are guaranteed not to report.

This PR adds a complementary threshold that gates the observation and aggregation stages themselves, so the entire round's work for a not-due channel is skipped.

## Changes

### Config (`llo/protocol/`)
- **`llo_offchain_config.proto`**: New field 4 `defaultMinObservationIntervalNanoseconds`
- **`llo_offchain_config.pb.go`**: Regenerated
- **`offchain_config.go`**: Added field to `OffchainConfig` struct; wired `Decode`/`Encode`; validation rules:
  - Protocol v0: must be 0
  - Protocol v1+: 0 = disabled (all channels always observed); non-zero enables skip
  - Must not exceed `DefaultMinReportIntervalNanoseconds` (prevents a channel being reportable but lacking observations)
- **`offchain_config_test.go`**: Tests for encode/decode round-trip + all validation rules

### Plugin (`llo/dev/v31/`)
- **`plugin.go`**:
  - Added `DefaultMinObservationIntervalNanoseconds` to `Plugin` struct
  - `Observation()`: when enabled, loads validAfter watermarks via new `readValidAfterOnly`, advances the watermark for channels that reported last round (matching the one-round lag in persisted hot state), then calls the updated `observableStreams`
  - `observableStreams()`: now takes `minObservationInterval` + `now` params; skips not-due channels
  - New shared helpers: `isObservationDue()` (the threshold check) and `observableDefinitions()` (filters a definitions map to due channels)
- **`kv.go`**: New `readValidAfterOnly()` — lightweight hot-state read that extracts validAfter watermarks + reportability flags without decoding the (potentially large) carry-forward stream aggregates
- **`factory.go`**: Wires config field to Plugin struct
- **`statetransition.go`**:
  - `aggregate()`: new `validAfterNanoseconds` + `minObservationInterval` params; skips not-due channels
  - `ProcessCalculatedStreams` receives only due channel definitions (via `observableDefinitions`)

### Tests (`llo/dev/v31/plugin_test.go`, `blobpump_test.go`)
- **`Test_ObservationIntervalSkip_observableStreams`**: Unit test for `observableStreams` — due/not-due filtering, shared streams, disabled mode, validAfter advancement
- **`Test_ObservationIntervalSkip_aggregate`**: Unit test for `aggregate()` — due channel aggregated, not-due channel skipped
- **`Test_ObservationIntervalSkip_FullRound`**: End-to-end test over 6 rounds showing the skip → report → skip → report cycle, verifying validAfter advancement and reportability flags
- Updated existing test call sites for new function signatures

## Design Decisions

| Decision | Rationale |
|---|---|
| **ValidAfter advancement** | The persisted hot state's `validAfter` lags one round behind the true last-report timestamp (it only advances in the *next* round's `StateTransition`). Both `Observation()` and `aggregate()` use the *advanced* validAfter so the skip is aligned with the report skip. |
| **Shared streams** | If a due channel and a not-due channel share a stream, the stream is still observed/aggregated via the due channel. This avoids starving shared streams. |
| **New channels** | Always considered due (no `validAfter` yet) so they can build initial aggregates. |
| **Backfill channels** | Always observed (not gated by the interval); they have their own selection logic. |
| **Carry-forward** | Streams exclusive to a not-due channel are not carried forward. Fresh aggregation resumes when the channel becomes due again. |
| **Validation constraint** | Observation interval ≤ report interval, preventing a channel from being reportable but lacking the observations needed to produce a report. |

## Test Results

All tests in `llo/protocol/` and `llo/dev/v31/` pass:
```
ok  github.com/smartcontractkit/chainlink-data-streams/llo/protocol         0.7s
ok  github.com/smartcontractkit/chainlink-data-streams/llo/protocol/calculated  0.4s
ok  github.com/smartcontractkit/chainlink-data-streams/llo/dev/v31          1.2s
ok  github.com/smartcontractkit/chainlink-data-streams/llo/dev/v31/llotest  0.7s
```

## Files Changed

```
 llo/dev/v31/blobpump_test.go           |   4 +-
 llo/dev/v31/factory.go                 |   5 +-
 llo/dev/v31/kv.go                      |  28 +++++
 llo/dev/v31/plugin.go                  |  81 ++++++++++++--
 llo/dev/v31/plugin_test.go             | 198 ++++++++++++++++++++++++++++++++-
 llo/dev/v31/statetransition.go         |  26 ++++-
 llo/protocol/llo_offchain_config.pb.go |  25 +++--
 llo/protocol/llo_offchain_config.proto |   1 +
 llo/protocol/offchain_config.go        |  26 ++++-
 llo/protocol/offchain_config_test.go   |  35 +++++-
 10 files changed, 395 insertions(+), 34 deletions(-)
```